### PR TITLE
Fix normal weapon trade-up eligibility

### DIFF
--- a/csgo_gc/gc_client.cpp
+++ b/csgo_gc/gc_client.cpp
@@ -877,7 +877,7 @@ void ClientGC::NameBaseItem(GCMessageRead &messageRead)
 void ClientGC::Craft(GCMessageRead &messageRead)
 {
     // Trade-up contract message format:
-    // int16_t recipe (-2 for trade-up)
+    // int16_t recipe/filter
     // int16_t itemCount (should be 10)
     // uint64_t itemIds[itemCount]
     
@@ -892,8 +892,12 @@ void ClientGC::Craft(GCMessageRead &messageRead)
     
     Platform::Print("TRADE-UP CONTRACT: recipe=%d, itemCount=%d\n", recipe, itemCount);
 
-    // Trade-up recipes are -2 and 12 (remove restriction on 12)
-    if (recipe != -2 && recipe != 12)
+    // Trade-up recipes in items_game.txt use filter -3. The concrete always-known
+    // recipe ids are 0..5 for normal weapons and 10..15 for StatTrak weapons.
+    bool isTradeUpRecipe = recipe == -3
+        || (recipe >= 0 && recipe <= 5)
+        || (recipe >= 10 && recipe <= 15);
+    if (!isTradeUpRecipe)
     {
         Platform::Print("Unsupported craft recipe %d, ignoring\n", recipe);
         return;

--- a/csgo_gc/inventory.cpp
+++ b/csgo_gc/inventory.cpp
@@ -239,6 +239,13 @@ void Inventory::ReadItem(const KeyValue &itemKey, CSOEconItem &item) const
         }
     }
 
+    uint32_t paintKitDefIndex = 0;
+    if (item.quality() == ItemSchema::QualityNormal
+        && GetItemPaintKitDefIndex(item, m_itemSchema, paintKitDefIndex))
+    {
+        item.set_quality(ItemSchema::QualityUnique);
+    }
+
     const KeyValue *equippedStateKey = itemKey.GetSubkey("equipped_state");
     if (equippedStateKey)
     {
@@ -1615,18 +1622,36 @@ bool Inventory::TradeUp(const std::vector<uint64_t> &inputItemIds,
         Platform::Print("Trade-up item %llu: collection %s (%s), quality %u\n", itemId,
             collectionId.c_str(), GetCollectionName(m_itemSchema, collectionId).c_str(), item.quality());
 
-        bool itemStatTrak = false;
+        bool hasKillEater = false;
+        bool hasWeaponKillEaterScoreType = false;
         for (const CSOEconItemAttribute &attr : item.attribute())
         {
             if (attr.def_index() == ItemSchema::AttributeKillEater)
             {
-                itemStatTrak = true;
+                hasKillEater = true;
+            }
+            else if (attr.def_index() == ItemSchema::AttributeKillEaterScoreType)
+            {
+                hasWeaponKillEaterScoreType = m_itemSchema.AttributeUint32(&attr) == 0;
             }
             else if (attr.def_index() == ItemSchema::AttributeTextureWear)
             {
                 totalWear += m_itemSchema.AttributeFloat(&attr);
                 wearCount++;
             }
+        }
+
+        bool itemNormalTradeUp = (item.quality() == ItemSchema::QualityUnique
+            || item.quality() == ItemSchema::QualityTournament)
+            && !hasKillEater;
+        bool itemStatTrak = item.quality() == ItemSchema::QualityStrange
+            && hasKillEater
+            && hasWeaponKillEaterScoreType;
+        if (!itemNormalTradeUp && !itemStatTrak)
+        {
+            Platform::Print("Trade-up item %llu has unsupported quality/state (quality %u, kill eater=%d, weapon score type=%d)\n",
+                itemId, item.quality(), hasKillEater ? 1 : 0, hasWeaponKillEaterScoreType ? 1 : 0);
+            return false;
         }
 
         if (!statTrakSet)

--- a/csgo_gc/item_schema.cpp
+++ b/csgo_gc/item_schema.cpp
@@ -434,10 +434,16 @@ bool ItemSchema::CreateItemFromLootListItem(Random &random,
         return false;
     }
 
-    // quality override, stattrak makes it strange if it's not an unusual
+    // Painted weapons are normal schema items, but their econ instances are unique
+    // unless StatTrak elevates them to strange. The client-side trade-up filters
+    // key off this quality before the GC ever sees a craft request.
     if (statTrak && lootListItem.quality != ItemSchema::QualityUnusual)
     {
         item.set_quality(ItemSchema::QualityStrange);
+    }
+    else if (lootListItem.type == LootListItemPaintable && lootListItem.quality != ItemSchema::QualityUnusual)
+    {
+        item.set_quality(ItemSchema::QualityUnique);
     }
     else
     {


### PR DESCRIPTION
Resolve #8.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed item quality assignment for paintable items in the inventory
  * Improved trade-up contract validation to support a broader range of valid recipe configurations
  * Enhanced eligibility checking for trade-up contracts with more detailed validation of item compatibility

* **Improvements**
  * Refined trade-up contract handling for StatTrak and standard weapon variants with better error messaging

<!-- end of auto-generated comment: release notes by coderabbit.ai -->