### PR TITLE
Harden inventory and trade-up transaction handling

### DIFF
--- a/csgo_gc/gc_client.cpp
+++ b/csgo_gc/gc_client.cpp
@@ -938,9 +938,19 @@ void ClientGC::Craft(GCMessageRead &messageRead)
         const CSOEconItem* item = m_inventory.GetItem(itemId);
         if (item)
         {
+            uint32_t paintKitDefIndex = 0;
+            uint32_t paintedRarity = item->rarity();
+            if (GetItemPaintKitDefIndex(*item, m_inventory.GetItemSchema(), paintKitDefIndex))
+            {
+                paintedRarity = m_inventory.GetItemSchema().GetPaintedRarity(
+                    item->def_index(),
+                    paintKitDefIndex,
+                    item->rarity());
+            }
+
             std::string collectionId = GetItemCollectionId(*item, m_inventory.GetItemSchema());
-            Platform::Print("  Item %llu: def_index %u, rarity %u, quality %u, collection %s (%s)\n",
-                itemId, item->def_index(), item->rarity(), item->quality(), collectionId.c_str(),
+            Platform::Print("  Item %llu: def_index %u, paint_kit %u, stored rarity %u, painted rarity %u, quality %u, collection %s (%s)\n",
+                itemId, item->def_index(), paintKitDefIndex, item->rarity(), paintedRarity, item->quality(), collectionId.c_str(),
                 GetCollectionName(m_inventory.GetItemSchema(), collectionId).c_str());
         }
         else

--- a/csgo_gc/gc_client.cpp
+++ b/csgo_gc/gc_client.cpp
@@ -677,6 +677,7 @@ void ClientGC::StorePurchaseInit(GCMessageRead &messageRead)
 
     assert(!m_transactionId);
     m_transactionId = transactionId;
+    m_transactionItemIds.clear();
     m_transactionItemIds.reserve(message.line_items_size()); // rough approx
 
     // inventory update response
@@ -737,6 +738,7 @@ void ClientGC::StorePurchaseFinalize(GCMessageRead &messageRead)
 
     // done with this one
     m_transactionId = 0;
+    m_transactionItemIds.clear();
 }
 
 void ClientGC::DeleteItem(GCMessageRead &messageRead)
@@ -790,7 +792,11 @@ void ClientGC::UnlockCrate(GCMessageRead &messageRead)
         // Returning GenerateSouvenir here causes a "could not retrieve items" error.
         notification.set_request(k_EGCItemCustomizationNotification_UnlockCrate);
 
-        SendMessageToGame(true, k_ESOMsg_Destroy, destroyCrate);
+        if (destroyCrate.has_type_id())
+        {
+            SendMessageToGame(true, k_ESOMsg_Destroy, destroyCrate);
+        }
+
         SendMessageToGame(true, k_ESOMsg_Create, newItem);
 
         SendMessageToGame(false, k_EMsgGCItemCustomizationNotification, notification);
@@ -805,9 +811,16 @@ void ClientGC::UnlockCrate(GCMessageRead &messageRead)
             newItem,
             notification))
     {
-        // mikkotodo what does the server want to know
-        SendMessageToGame(true, k_ESOMsg_Destroy, destroyCrate);
-        SendMessageToGame(true, k_ESOMsg_Destroy, destroyKey);
+        if (destroyCrate.has_type_id())
+        {
+            SendMessageToGame(true, k_ESOMsg_Destroy, destroyCrate);
+        }
+
+        if (destroyKey.has_type_id())
+        {
+            SendMessageToGame(true, k_ESOMsg_Destroy, destroyKey);
+        }
+
         SendMessageToGame(true, k_ESOMsg_Create, newItem);
 
         SendMessageToGame(false, k_EMsgGCItemCustomizationNotification, notification);
@@ -1027,8 +1040,8 @@ void ClientGC::DispatchStorageResult(const Inventory::StorageTransaction &tx)
             
             if (tx.Succeeded())
             {
-                SendMessageToGame(false, k_ESOMsg_Update, tx.itemData);
-                SendMessageToGame(false, k_ESOMsg_Update, tx.containerData);
+                SendMessageToGame(true, k_ESOMsg_Update, tx.itemData);
+                SendMessageToGame(true, k_ESOMsg_Update, tx.containerData);
             }
             SendMessageToGame(false, k_EMsgGCItemCustomizationNotification, notice);
         }

--- a/csgo_gc/inventory.cpp
+++ b/csgo_gc/inventory.cpp
@@ -1687,8 +1687,15 @@ bool Inventory::TradeUp(const std::vector<uint64_t> &inputItemIds,
         const std::string &collectionId = collections.front();
         collectionCounts[collectionId]++;
 
-        Platform::Print("Trade-up item %llu: collection %s (%s), quality %u\n", itemId,
-            collectionId.c_str(), GetCollectionName(m_itemSchema, collectionId).c_str(), item.quality());
+        Platform::Print("Trade-up item %llu: def %u, paint %u, stored rarity %u, painted rarity %u, collection %s (%s), quality %u\n",
+            itemId,
+            item.def_index(),
+            paintKitDefIndex,
+            item.rarity(),
+            rarity,
+            collectionId.c_str(),
+            GetCollectionName(m_itemSchema, collectionId).c_str(),
+            item.quality());
 
         bool hasKillEater = false;
         bool hasWeaponKillEaterScoreType = false;

--- a/csgo_gc/inventory.cpp
+++ b/csgo_gc/inventory.cpp
@@ -1630,6 +1630,31 @@ bool Inventory::TradeUp(const std::vector<uint64_t> &inputItemIds,
     std::unordered_set<uint64_t> uniqueInputItemIds;
     uniqueInputItemIds.reserve(inputItemIds.size());
 
+    struct TradeUpItemDebug
+    {
+        uint64_t itemId{};
+        uint32_t defIndex{};
+        uint32_t paintKitDefIndex{};
+        uint32_t storedRarity{};
+        uint32_t paintedRarity{};
+        uint32_t quality{};
+        std::string collectionId;
+    };
+
+    auto printItemDebug = [this](const char *prefix, const TradeUpItemDebug &debug)
+    {
+        Platform::Print("%s item %llu: def %u, paint %u, stored rarity %u, painted rarity %u, quality %u, collection %s (%s)\n",
+            prefix,
+            debug.itemId,
+            debug.defIndex,
+            debug.paintKitDefIndex,
+            debug.storedRarity,
+            debug.paintedRarity,
+            debug.quality,
+            debug.collectionId.c_str(),
+            GetCollectionName(m_itemSchema, debug.collectionId).c_str());
+    };
+
     for (uint64_t itemId : inputItemIds)
     {
         if (!uniqueInputItemIds.insert(itemId).second)
@@ -1648,17 +1673,26 @@ bool Inventory::TradeUp(const std::vector<uint64_t> &inputItemIds,
         const CSOEconItem &item = it->second;
         inputItems.push_back(it);
 
+        TradeUpItemDebug debug;
+        debug.itemId = itemId;
+        debug.defIndex = item.def_index();
+        debug.storedRarity = item.rarity();
+        debug.quality = item.quality();
+
         uint32_t paintKitDefIndex = 0;
         if (!GetItemPaintKitDefIndex(item, m_itemSchema, paintKitDefIndex))
         {
-            Platform::Print("Trade-up item %llu has no paint kit\n", itemId);
+            Platform::Print("Trade-up item %llu has no paint kit (def %u, stored rarity %u, quality %u)\n",
+                itemId, item.def_index(), item.rarity(), item.quality());
             return false;
         }
+        debug.paintKitDefIndex = paintKitDefIndex;
 
         uint32_t rarity = m_itemSchema.GetPaintedRarity(item.def_index(), paintKitDefIndex, item.rarity());
+        debug.paintedRarity = rarity;
         if (rarity < ItemSchema::RarityCommon || rarity > ItemSchema::RarityLegendary)
         {
-            Platform::Print("Trade-up item %llu has invalid rarity %u\n", itemId, rarity);
+            printItemDebug("Trade-up item has invalid rarity", debug);
             return false;
         }
 
@@ -1668,7 +1702,9 @@ bool Inventory::TradeUp(const std::vector<uint64_t> &inputItemIds,
         }
         else if (rarity != inputRarity)
         {
-            Platform::Print("Trade-up items must all be same rarity (expected %u, got %u)\n", inputRarity, rarity);
+            Platform::Print("Trade-up items must all be same painted rarity (expected %u, got %u)\n",
+                inputRarity, rarity);
+            printItemDebug("Mismatched trade-up rarity", debug);
             return false;
         }
 
@@ -1677,25 +1713,18 @@ bool Inventory::TradeUp(const std::vector<uint64_t> &inputItemIds,
         {
             if (!m_itemSchema.GetCollectionsForPaintKit(paintKitDefIndex, collections))
             {
-                Platform::Print("Trade-up item %llu has no collection mapping (def %u, paint %u)\n",
-                    itemId, item.def_index(), paintKitDefIndex);
+                Platform::Print("Trade-up item %llu has no collection mapping (def %u, paint %u, stored rarity %u, painted rarity %u, quality %u)\n",
+                    itemId, item.def_index(), paintKitDefIndex, item.rarity(), rarity, item.quality());
                 return false;
             }
         }
 
         std::sort(collections.begin(), collections.end());
         const std::string &collectionId = collections.front();
+        debug.collectionId = collectionId;
         collectionCounts[collectionId]++;
 
-        Platform::Print("Trade-up item %llu: def %u, paint %u, stored rarity %u, painted rarity %u, collection %s (%s), quality %u\n",
-            itemId,
-            item.def_index(),
-            paintKitDefIndex,
-            item.rarity(),
-            rarity,
-            collectionId.c_str(),
-            GetCollectionName(m_itemSchema, collectionId).c_str(),
-            item.quality());
+        printItemDebug("Trade-up input", debug);
 
         bool hasKillEater = false;
         bool hasWeaponKillEaterScoreType = false;
@@ -1724,8 +1753,9 @@ bool Inventory::TradeUp(const std::vector<uint64_t> &inputItemIds,
             && hasWeaponKillEaterScoreType;
         if (!itemNormalTradeUp && !itemStatTrak)
         {
-            Platform::Print("Trade-up item %llu has unsupported quality/state (quality %u, kill eater=%d, weapon score type=%d)\n",
-                itemId, item.quality(), hasKillEater ? 1 : 0, hasWeaponKillEaterScoreType ? 1 : 0);
+            Platform::Print("Trade-up item %llu has unsupported quality/state (kill eater=%d, weapon score type=%d)\n",
+                itemId, hasKillEater ? 1 : 0, hasWeaponKillEaterScoreType ? 1 : 0);
+            printItemDebug("Unsupported trade-up item", debug);
             return false;
         }
 
@@ -1736,7 +1766,9 @@ bool Inventory::TradeUp(const std::vector<uint64_t> &inputItemIds,
         }
         else if (itemStatTrak != hasStatTrak)
         {
-            Platform::Print("Trade-up items must all be StatTrak or all non-StatTrak\n");
+            Platform::Print("Trade-up items must all be StatTrak or all non-StatTrak (expected stattrak=%d, got stattrak=%d)\n",
+                hasStatTrak ? 1 : 0, itemStatTrak ? 1 : 0);
+            printItemDebug("Mismatched StatTrak state", debug);
             return false;
         }
     }
@@ -1763,6 +1795,8 @@ bool Inventory::TradeUp(const std::vector<uint64_t> &inputItemIds,
         std::vector<const LootListItem *> candidates;
         if (!m_itemSchema.GetTradeUpCandidates(collection, outputRarity, candidates))
         {
+            Platform::Print("%s Collection has no trade-up candidates at output rarity %u\n",
+                GetCollectionName(m_itemSchema, collection).c_str(), outputRarity);
             continue;
         }
 

--- a/csgo_gc/inventory.cpp
+++ b/csgo_gc/inventory.cpp
@@ -1226,6 +1226,8 @@ Inventory::StorageItemPair Inventory::ResolveStorageItems(uint64_t storageId, ui
 
 void Inventory::EmbedStorageReference(CSOEconItem &item, uint64_t storageId)
 {
+    StripStorageReference(item);
+
     auto *attrLow = item.add_attribute();
     auto *attrHigh = item.add_attribute();
     
@@ -1250,6 +1252,33 @@ void Inventory::StripStorageReference(CSOEconItem &item)
         if (isStorageAttr)
             attrs->DeleteSubrange(i, 1);
     }
+}
+
+static std::optional<uint64_t> StorageReference(const CSOEconItem &item, const ItemSchema &schema)
+{
+    std::optional<uint32_t> low;
+    std::optional<uint32_t> high;
+
+    for (const CSOEconItemAttribute &attribute : item.attribute())
+    {
+        switch (attribute.def_index())
+        {
+        case ItemSchema::AttributeCasketIdLow:
+            low = schema.AttributeUint32(&attribute);
+            break;
+
+        case ItemSchema::AttributeCasketIdHigh:
+            high = schema.AttributeUint32(&attribute);
+            break;
+        }
+    }
+
+    if (!low.has_value() || !high.has_value())
+    {
+        return std::nullopt;
+    }
+
+    return static_cast<uint64_t>(*low) | (static_cast<uint64_t>(*high) << 32);
 }
 
 bool Inventory::ModifyStorageCounter(CSOEconItem &storage, int delta)
@@ -1295,6 +1324,12 @@ Inventory::StorageTransaction Inventory::DepositItemToStorage(uint64_t storageId
     tx.affectedContainerId = storageId;
     
     auto [storage, target] = ResolveStorageItems(storageId, itemId);
+
+    if (storageId == itemId)
+    {
+        tx.outcome = StorageResult::InvalidContainerType;
+        return tx;
+    }
     
     if (!storage)
     {
@@ -1311,6 +1346,18 @@ Inventory::StorageTransaction Inventory::DepositItemToStorage(uint64_t storageId
     if (storage->def_index() != ItemSchema::ItemCasket)
     {
         tx.outcome = StorageResult::InvalidContainerType;
+        return tx;
+    }
+
+    if (target->def_index() == ItemSchema::ItemCasket)
+    {
+        tx.outcome = StorageResult::InvalidContainerType;
+        return tx;
+    }
+
+    if (StorageReference(*target, m_itemSchema).has_value())
+    {
+        tx.outcome = StorageResult::InternalError;
         return tx;
     }
     
@@ -1353,6 +1400,13 @@ Inventory::StorageTransaction Inventory::WithdrawItemFromStorage(uint64_t storag
     if (storage->def_index() != ItemSchema::ItemCasket)
     {
         tx.outcome = StorageResult::InvalidContainerType;
+        return tx;
+    }
+
+    std::optional<uint64_t> storedIn = StorageReference(*target, m_itemSchema);
+    if (!storedIn.has_value() || *storedIn != storageId)
+    {
+        tx.outcome = StorageResult::ItemNotFound;
         return tx;
     }
     
@@ -1448,6 +1502,12 @@ Inventory::CounterSwapResult Inventory::PerformCounterSwap(uint64_t toolId, uint
 
 uint64_t Inventory::PurchaseItem(uint32_t defIndex, std::vector<CMsgSOSingleObject> &update)
 {
+    if (!m_itemSchema.ItemInfoByDefIndex(defIndex))
+    {
+        Platform::Print("PurchaseItem: unknown def_index %u\n", defIndex);
+        return 0;
+    }
+
     CSOEconItem &item = CreateItem(defIndex, ItemOriginPurchased, UnacknowledgedPurchased);
 
     CMsgSOSingleObject &single = update.emplace_back();
@@ -1567,9 +1627,17 @@ bool Inventory::TradeUp(const std::vector<uint64_t> &inputItemIds,
     int wearCount = 0;
 
     std::map<std::string, int> collectionCounts;
+    std::unordered_set<uint64_t> uniqueInputItemIds;
+    uniqueInputItemIds.reserve(inputItemIds.size());
 
     for (uint64_t itemId : inputItemIds)
     {
+        if (!uniqueInputItemIds.insert(itemId).second)
+        {
+            Platform::Print("Trade-up item %llu was submitted more than once\n", itemId);
+            return false;
+        }
+
         auto it = m_items.find(itemId);
         if (it == m_items.end())
         {

--- a/csgo_gc/inventory.cpp
+++ b/csgo_gc/inventory.cpp
@@ -1726,6 +1726,7 @@ bool Inventory::TradeUp(const std::vector<uint64_t> &inputItemIds,
 
         printItemDebug("Trade-up input", debug);
 
+        bool hasWear = false;
         bool hasKillEater = false;
         bool hasWeaponKillEaterScoreType = false;
         for (const CSOEconItemAttribute &attr : item.attribute())
@@ -1740,9 +1741,18 @@ bool Inventory::TradeUp(const std::vector<uint64_t> &inputItemIds,
             }
             else if (attr.def_index() == ItemSchema::AttributeTextureWear)
             {
+                hasWear = true;
                 totalWear += m_itemSchema.AttributeFloat(&attr);
                 wearCount++;
             }
+        }
+
+        if (!hasWear)
+        {
+            Platform::Print("Trade-up item %llu has no wear attribute; cannot calculate contract output float\n",
+                itemId);
+            printItemDebug("Missing trade-up wear", debug);
+            return false;
         }
 
         bool itemNormalTradeUp = (item.quality() == ItemSchema::QualityUnique
@@ -1795,9 +1805,9 @@ bool Inventory::TradeUp(const std::vector<uint64_t> &inputItemIds,
         std::vector<const LootListItem *> candidates;
         if (!m_itemSchema.GetTradeUpCandidates(collection, outputRarity, candidates))
         {
-            Platform::Print("%s Collection has no trade-up candidates at output rarity %u\n",
-                GetCollectionName(m_itemSchema, collection).c_str(), outputRarity);
-            continue;
+            Platform::Print("%s Collection has no trade-up candidates at output rarity %u; rejecting contract with %d input item(s) from this collection\n",
+                GetCollectionName(m_itemSchema, collection).c_str(), outputRarity, pair.second);
+            return false;
         }
 
         int count = pair.second;

--- a/csgo_gc/stdafx.h
+++ b/csgo_gc/stdafx.h
@@ -13,6 +13,7 @@
 #include <thread>
 #include <type_traits>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 // might as well


### PR DESCRIPTION
## Summary
- reject duplicate trade-up inputs and improve trade-up failure diagnostics
- require valid output candidates for every input collection and require input wear for float calculation
- avoid empty destroy SO messages, clear store transaction item ids, and add basic storage validation/server sync

## Validation
- Built csgo_gc in Release with CMake/MSBuild

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved storage transactions by preventing invalid deposits and requiring matching storage references before withdrawals.
  * Fixed purchase handling so unknown item definitions are rejected instead of creating invalid items.
  * Made crate unlock and storage result updates behave more consistently for the game server.
  * Tightened trade-up validation to catch duplicate inputs, missing wear data, invalid mappings, and unsupported item combinations.
* **Style**
  * Expanded trade-up debug output with more detailed item information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->