### PR TITLE
Validate tool target compatibility

### DIFF
--- a/csgo_gc/inventory.cpp
+++ b/csgo_gc/inventory.cpp
@@ -524,6 +524,13 @@ bool Inventory::UnlockCrate(uint64_t crateId,
                 keyId, key->second.def_index(), crateId);
             return false;
         }
+
+        if (!m_itemSchema.IsKeyCompatibleWithCrate(key->second.def_index(), crate->second.def_index()))
+        {
+            Platform::Print("UnlockCrate: key item %llu def %u is not compatible with crate %llu def %u\n",
+                keyId, key->second.def_index(), crateId, crate->second.def_index());
+            return false;
+        }
     }
 
     // CASE OPENING
@@ -853,8 +860,40 @@ bool Inventory::ApplySticker(const CMsgApplySticker &message,
         return false;
     }
 
-    CSOEconItem *item = nullptr;
+    uint32_t targetDefIndex = 0;
+    if (message.baseitem_defidx())
+    {
+        targetDefIndex = message.baseitem_defidx();
+    }
+    else
+    {
+        auto it = m_items.find(message.item_item_id());
+        if (it == m_items.end())
+        {
+            assert(false);
+            return false;
+        }
 
+        targetDefIndex = it->second.def_index();
+    }
+
+    if (sticker->second.def_index() == ItemSchema::ItemPatch)
+    {
+        if (!m_itemSchema.CanApplyPatchToDefIndex(targetDefIndex))
+        {
+            Platform::Print("ApplySticker: patch item %llu cannot be applied to target def %u (target item %llu)\n",
+                message.sticker_item_id(), targetDefIndex, message.item_item_id());
+            return false;
+        }
+    }
+    else if (!m_itemSchema.CanApplyStickerToDefIndex(targetDefIndex))
+    {
+        Platform::Print("ApplySticker: sticker item %llu cannot be applied to target def %u (target item %llu)\n",
+            message.sticker_item_id(), targetDefIndex, message.item_item_id());
+        return false;
+    }
+
+    CSOEconItem *item = nullptr;
     if (message.baseitem_defidx())
     {
         item = &CreateItem(message.baseitem_defidx(), ItemOriginBaseItem, UnacknowledgedInvalid);
@@ -1174,6 +1213,13 @@ bool Inventory::NameItem(uint64_t nameTagId,
         return false;
     }
 
+    if (!m_itemSchema.CanNameDefIndex(it->second.def_index()))
+    {
+        Platform::Print("NameItem: target %llu def %u is not nameable by name tag %llu\n",
+            itemId, it->second.def_index(), nameTagId);
+        return false;
+    }
+
     it->second.mutable_custom_name()->assign(name);
 
     ToSingleObject(update, it->second);
@@ -1208,6 +1254,13 @@ bool Inventory::NameBaseItem(uint64_t nameTagId,
     {
         Platform::Print("NameBaseItem: item %llu def %u is not a name tag for base def %u\n",
             nameTagId, tag->second.def_index(), defIndex);
+        return false;
+    }
+
+    if (!m_itemSchema.CanNameDefIndex(defIndex))
+    {
+        Platform::Print("NameBaseItem: base def %u is not nameable by name tag %llu\n",
+            defIndex, nameTagId);
         return false;
     }
 

--- a/csgo_gc/inventory.cpp
+++ b/csgo_gc/inventory.cpp
@@ -861,6 +861,7 @@ bool Inventory::ApplySticker(const CMsgApplySticker &message,
     }
 
     uint32_t targetDefIndex = 0;
+    CSOEconItem *item = nullptr;
     if (message.baseitem_defidx())
     {
         targetDefIndex = message.baseitem_defidx();
@@ -875,6 +876,7 @@ bool Inventory::ApplySticker(const CMsgApplySticker &message,
         }
 
         targetDefIndex = it->second.def_index();
+        item = &it->second;
     }
 
     if (sticker->second.def_index() == ItemSchema::ItemPatch)
@@ -893,21 +895,9 @@ bool Inventory::ApplySticker(const CMsgApplySticker &message,
         return false;
     }
 
-    CSOEconItem *item = nullptr;
     if (message.baseitem_defidx())
     {
         item = &CreateItem(message.baseitem_defidx(), ItemOriginBaseItem, UnacknowledgedInvalid);
-    }
-    else
-    {
-        auto it = m_items.find(message.item_item_id());
-        if (it == m_items.end())
-        {
-            assert(false);
-            return false;
-        }
-
-        item = &it->second;
     }
 
     assert(item);

--- a/csgo_gc/item_schema.cpp
+++ b/csgo_gc/item_schema.cpp
@@ -68,6 +68,9 @@ ItemInfo::ItemInfo(uint32_t defIndex)
     , m_quality{ ItemSchema::QualityNormal }
     , m_level{ 1 }
     , m_supplyCrateSeries{ 0 }
+    , m_canSticker{ false }
+    , m_canPatch{ false }
+    , m_nameable{ false }
     , m_isCoupon{ false }
     , m_willProduceStatTrak{ false }
 {
@@ -735,6 +738,38 @@ void ItemSchema::ParseItemRecursive(ItemInfo &info, const KeyValue &itemKey, con
     }
 
     info.m_willProduceStatTrak = itemKey.GetNumber("will_produce_stattrak", false);
+
+    const KeyValue *capabilities = itemKey.GetSubkey("capabilities");
+    if (capabilities)
+    {
+        const KeyValue *canSticker = capabilities->GetSubkey("can_sticker");
+        if (canSticker)
+        {
+            info.m_canSticker = FromString<int>(canSticker->String()) != 0;
+        }
+
+        const KeyValue *canPatch = capabilities->GetSubkey("can_patch");
+        if (canPatch)
+        {
+            info.m_canPatch = FromString<int>(canPatch->String()) != 0;
+        }
+
+        const KeyValue *nameable = capabilities->GetSubkey("nameable");
+        if (nameable)
+        {
+            info.m_nameable = FromString<int>(nameable->String()) != 0;
+        }
+    }
+
+    const KeyValue *tool = itemKey.GetSubkey("tool");
+    if (tool)
+    {
+        std::string_view restriction = tool->GetString("restriction");
+        if (restriction.size())
+        {
+            info.m_toolRestriction = restriction;
+        }
+    }
 
     const KeyValue *attributes = itemKey.GetSubkey("attributes");
     if (attributes)
@@ -1429,4 +1464,39 @@ bool ItemSchema::IsStatTrakSwapToolDefIndex(uint32_t defIndex) const
 
     return ItemInfoContains(*info, "stattrak")
         && ItemInfoContains(*info, "swap");
+}
+
+bool ItemSchema::IsKeyCompatibleWithCrate(uint32_t keyDefIndex, uint32_t crateDefIndex) const
+{
+    const ItemInfo *keyInfo = ItemInfoByDefIndex(keyDefIndex);
+    const ItemInfo *crateInfo = ItemInfoByDefIndex(crateDefIndex);
+    if (!keyInfo || !crateInfo)
+    {
+        return false;
+    }
+
+    if (keyInfo->m_toolRestriction.empty() || crateInfo->m_toolRestriction.empty())
+    {
+        return true;
+    }
+
+    return keyInfo->m_toolRestriction == crateInfo->m_toolRestriction;
+}
+
+bool ItemSchema::CanApplyStickerToDefIndex(uint32_t defIndex) const
+{
+    const ItemInfo *info = ItemInfoByDefIndex(defIndex);
+    return info && info->m_canSticker;
+}
+
+bool ItemSchema::CanApplyPatchToDefIndex(uint32_t defIndex) const
+{
+    const ItemInfo *info = ItemInfoByDefIndex(defIndex);
+    return info && info->m_canPatch;
+}
+
+bool ItemSchema::CanNameDefIndex(uint32_t defIndex) const
+{
+    const ItemInfo *info = ItemInfoByDefIndex(defIndex);
+    return info && info->m_nameable;
 }

--- a/csgo_gc/item_schema.h
+++ b/csgo_gc/item_schema.h
@@ -33,6 +33,10 @@ public:
     uint32_t m_supplyCrateSeries; // cases only
     std::string m_itemType;
     std::vector<std::string> m_prefabs;
+    std::string m_toolRestriction;
+    bool m_canSticker;
+    bool m_canPatch;
+    bool m_nameable;
 
     // kludge for coupons so we can buy stuff from the store
     bool m_isCoupon;
@@ -159,6 +163,10 @@ public:
     bool IsKeyToolDefIndex(uint32_t defIndex) const;
     bool IsNameTagToolDefIndex(uint32_t defIndex) const;
     bool IsStatTrakSwapToolDefIndex(uint32_t defIndex) const;
+    bool IsKeyCompatibleWithCrate(uint32_t keyDefIndex, uint32_t crateDefIndex) const;
+    bool CanApplyStickerToDefIndex(uint32_t defIndex) const;
+    bool CanApplyPatchToDefIndex(uint32_t defIndex) const;
+    bool CanNameDefIndex(uint32_t defIndex) const;
 
 
 public:


### PR DESCRIPTION
## Summary
- Preserve schema metadata for tool restrictions and target capabilities.
- Validate key/crate restriction compatibility before opening crates.
- Validate sticker, patch, and name tag target capabilities before mutating inventory.

## Validation
- Ran git diff --check.
- Built csgo_gc successfully with cmake --build build --config Release --target csgo_gc.

## Manual test notes
- Correct keys should still open matching crates, while mismatched keys should fail without inventory changes.
- keyId == 0 container flows should remain compatible.
- Stickers should apply to sticker-capable weapons, patches to patch-capable agents, and invalid targets should fail.
- Name tags should apply only to nameable item definitions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added stricter validation for opening crates, applying stickers/patches, and naming items so only compatible items can be modified.
  * Improved error reporting when an item action is not allowed, making failures clearer to end-users.

* **New Features**
  * Added support for item capability checks, including whether an item can accept stickers, patches, or custom names.
  * Added compatibility checks between keys and crates to prevent invalid use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->