### PR TITLE
Add RCON server support and related inventory/config updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@ project(csgo_gc)
 
 set(CMAKE_CXX_STANDARD 17)
 
+find_package(Threads REQUIRED)
+
 if (CMAKE_SIZEOF_VOID_P EQUAL 4)
     set(IS_32BIT ON)
 endif()

--- a/README.md
+++ b/README.md
@@ -10,18 +10,24 @@ In Valve games, the Game Coordinator (GC) is a backend service most notably resp
 While it's still possible to connect CS:GO to CS2's GC by spoofing the version number, this may break in the future if Valve updates the GC protocol. This project aims to restore most GC-related functionality without relying on a centralized server.
 
 ## Current features
-- Editable inventory (inventory.txt)
-- Item equipping
-- Opening cases (including sticker capsules, patch packs, graffiti boxes and music kit boxes)
+- Editable inventory (`inventory.txt`)
+- Live inventory updates while the game is running
+- Item equipping and loadout updates
+- Opening cases, sticker capsules, patch packs, graffiti boxes, music kit boxes and souvenir packages
+- Souvenir item generation
+- Stickers and patches
+- Name tags
 - Graffiti support
+- Music kits
 - Weapon StatTrak support
+- Music kit StatTrak support, including round MVP count propagation
 - Storage Units
 - StatTrak Swaps
 - Trade ups
-- Stickers and patches
-- Name tags
-- Music kits
-- In-game store
+- In-game store purchases
+- Read-only inventory consistency diagnostics
+- Source RCON-compatible local control interface
+- Parameterized RCON item creation for paint kits, wear, seed, StatTrak, music kits, sprays, stickers and custom names
 - Works without full Steam API emulation
 - Full Windows, Linux and macOS support
 - Functional lobbies
@@ -30,7 +36,8 @@ While it's still possible to connect CS:GO to CS2's GC by spoofing the version n
 - Networking using Steam's P2P interface
 
 ## Planned features
-- Rest of the core features (souvenirs...)
+- More validation and polish for edge-case inventory operations
+- Tooling around live inventory editing
 
 I'm still looking for the **full** CS:GO Item Schema. If you have a relatively recent copy of it and are willing to share it, let me know!
 
@@ -39,7 +46,7 @@ I'm still looking for the **full** CS:GO Item Schema. If you have a relatively r
 
 ## Installation
 - Download [CS:GO from Steam](steam://install/4465480)
-- Download the latest release for your platform from the [releases page](https://github.com/mikkokko/csgo_gc/releases/latest)
+- Download the latest release for your platform from the [releases page](https://github.com/GT-610/csgo_gc/releases/latest)
 - Navigate to the game's installation directory
 - Back up your existing launcher executables as they'll be overwritten (i.e. csgo.exe, srcds.exe, csgo_linux64, etc.)
 - Extract the contents of the downloaded archive to your game directory, replace the executables when prompted
@@ -47,10 +54,17 @@ I'm still looking for the **full** CS:GO Item Schema. If you have a relatively r
 - macOS users: The release binaries are not notarized, so if you're using them, you'll have to deal with that somehow
 
 ## Inventory editing
-For GUI inventory editors, see https://github.com/mikkokko/csgo_gc/issues/82. For manual editing, there is a guide made by someone else [here](https://gist.github.com/dricotec/1ae3deb06c42012970c00df914348e76).
+Inventory can still be edited offline through `inventory.txt`. For manual editing, there is a guide made by someone else [here](https://gist.github.com/dricotec/1ae3deb06c42012970c00df914348e76).
+
+The local RCON interface can also create and remove items while the game is running. This is intended for scripts and GUI editors that want to avoid the old edit-file-and-restart workflow.
 
 ## Configuration
 See [csgo_gc/config.txt](examples/config.txt) for available options.
+
+## RCON
+RCON is disabled by default and listens on localhost when enabled. It uses the Source RCON binary protocol, so existing Source RCON clients can be used.
+
+See [rcon.md](docs/rcon.md) for protocol details, configuration, supported parameters and error formats.
 
 ## Building
 Requirements:
@@ -58,26 +72,45 @@ Requirements:
 - CMake 3.20 or newer
 - C++ compiler with C++17 support (VS 2017 or later, Clang 5 or later, GCC 7 or later)
 
+The top-level CMake project downloads protobuf, cryptopp-cmake and funchook through `FetchContent` during configure.
+
 The game is 32-bit on Windows so you need to build as 32-bit:
 
-`cmake -A Win32 -B build`
+```bat
+cmake -A Win32 -B build
+cmake --build build --config Release --target csgo_gc
+```
 
 Linux dedicated servers are also 32-bit:
 
-`cmake -DCMAKE_C_FLAGS=-m32 -DCMAKE_CXX_FLAGS=-m32 -DCMAKE_ASM_FLAGS=-m32 -B build`
+```sh
+cmake -DCMAKE_C_FLAGS=-m32 -DCMAKE_CXX_FLAGS=-m32 -DCMAKE_ASM_FLAGS=-m32 -B build
+cmake --build build --target csgo_gc
+```
 
 On macOS, you need to build for x86_64 instead of arm64:
 
-`cmake -DCMAKE_OSX_ARCHITECTURES=x86_64 -DFUNCHOOK_CPU=x86 -B build`
+```sh
+cmake -DCMAKE_OSX_ARCHITECTURES=x86_64 -DFUNCHOOK_CPU=x86 -B build
+cmake --build build --target csgo_gc
+```
 
 For Linux clients you don't have to specify any additional options.
+
+For a full launcher package build, also build the launcher targets:
+
+```sh
+cmake --build build --config Release --target csgo srcds csgo_gc
+```
 
 ## License
 This project is licensed under the 2-Clause BSD License. See [LICENSE.md](LICENSE.md) for details.
 
 ## Credits
-* **Mikko Kokko** - Author
+* **Mikko Kokko** - Original author
 * **Theeto** - Code reused from the predecessor project, unusual loot lists
+* **GT610** (`GT-610`) - Fork deveopment
+* Contributors who continued inventory, networking, diagnostics and RCON work after the original upstream changes
 
 ## Third party dependencies
 - [Crypto++](https://github.com/weidai11/cryptopp) ([Boost Software License](https://github.com/weidai11/cryptopp/blob/master/License.txt))

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The local RCON interface can also create and remove items while the game is runn
 See [csgo_gc/config.txt](examples/config.txt) for available options.
 
 ## RCON
-RCON is disabled by default and listens on localhost when enabled. It uses the Source RCON binary protocol, so existing Source RCON clients can be used.
+RCON is disabled by default and binds to localhost with the default configuration; the actual listen address is controlled by `bind_address`. It uses the Source RCON binary protocol, so existing Source RCON clients can be used.
 
 See [rcon.md](docs/rcon.md) for protocol details, configuration, supported parameters and error formats.
 

--- a/csgo_gc/CMakeLists.txt
+++ b/csgo_gc/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(csgo_gc SHARED
     main.cpp
     networking_client.cpp
     networking_server.cpp
+    rcon_server.cpp
     souvenir.cpp
     steam_hook.cpp)
 
@@ -46,6 +47,10 @@ target_link_libraries(csgo_gc PRIVATE
     funchook-static
     libprotobuf-lite
     steam_api)
+
+if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    target_link_libraries(csgo_gc PRIVATE ws2_32)
+endif()
 
 # apple message box
 if (APPLE)

--- a/csgo_gc/CMakeLists.txt
+++ b/csgo_gc/CMakeLists.txt
@@ -46,7 +46,8 @@ target_link_libraries(csgo_gc PRIVATE
     cryptopp
     funchook-static
     libprotobuf-lite
-    steam_api)
+    steam_api
+    Threads::Threads)
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
     target_link_libraries(csgo_gc PRIVATE ws2_32)

--- a/csgo_gc/config.cpp
+++ b/csgo_gc/config.cpp
@@ -25,6 +25,14 @@ GCConfig::GCConfig()
     m_appIdOverride = config.GetNumber("appid_override", m_appIdOverride);
     m_showCsgoGCServersOnly = config.GetNumber("show_csgo_gc_servers_only", m_showCsgoGCServersOnly);
 
+    const KeyValue *rcon = config.GetSubkey("rcon");
+    if (rcon)
+    {
+        m_rconEnabled = rcon->GetNumber("enabled", m_rconEnabled);
+        m_rconBindAddress = rcon->GetString("bind_address", m_rconBindAddress);
+        m_rconPort = rcon->GetNumber("port", m_rconPort);
+    }
+
     const KeyValue *ranks = config.GetSubkey("ranks");
     if (ranks)
     {

--- a/csgo_gc/config.cpp
+++ b/csgo_gc/config.cpp
@@ -32,6 +32,11 @@ GCConfig::GCConfig()
         m_rconBindAddress = rcon->GetString("bind_address", m_rconBindAddress);
         m_rconPort = rcon->GetNumber("port", m_rconPort);
         m_rconPassword = rcon->GetString("password", m_rconPassword);
+
+        if (m_rconEnabled && m_rconPassword.empty())
+        {
+            Platform::Print("WARNING: RCON is enabled with an empty password; any Source RCON password will authenticate. Keep bind_address local or set rcon.password.\n");
+        }
     }
 
     const KeyValue *ranks = config.GetSubkey("ranks");

--- a/csgo_gc/config.cpp
+++ b/csgo_gc/config.cpp
@@ -31,6 +31,7 @@ GCConfig::GCConfig()
         m_rconEnabled = rcon->GetNumber("enabled", m_rconEnabled);
         m_rconBindAddress = rcon->GetString("bind_address", m_rconBindAddress);
         m_rconPort = rcon->GetNumber("port", m_rconPort);
+        m_rconPassword = rcon->GetString("password", m_rconPassword);
     }
 
     const KeyValue *ranks = config.GetSubkey("ranks");

--- a/csgo_gc/config.h
+++ b/csgo_gc/config.h
@@ -31,6 +31,7 @@ public:
     bool RconEnabled() const { return m_rconEnabled; }
     const std::string &RconBindAddress() const { return m_rconBindAddress; }
     uint16_t RconPort() const { return m_rconPort; }
+    const std::string &RconPassword() const { return m_rconPassword; }
 
     RankId CompetitiveRank() const { return m_competitiveRank; }
     int CompetitiveWins() const { return m_competitiveWins; }
@@ -60,6 +61,7 @@ private:
     bool m_rconEnabled{ false };
     std::string m_rconBindAddress{ "127.0.0.1" };
     uint16_t m_rconPort{ 37016 };
+    std::string m_rconPassword;
 
     RankId m_competitiveRank{ RankNone };
     int m_competitiveWins{ 0 };

--- a/csgo_gc/config.h
+++ b/csgo_gc/config.h
@@ -28,6 +28,9 @@ public:
     // options used by steam hook
     uint32_t AppIdOverride() const { return m_appIdOverride; }
     bool ShowCsgoGCServersOnly() const { return m_showCsgoGCServersOnly; }
+    bool RconEnabled() const { return m_rconEnabled; }
+    const std::string &RconBindAddress() const { return m_rconBindAddress; }
+    uint16_t RconPort() const { return m_rconPort; }
 
     RankId CompetitiveRank() const { return m_competitiveRank; }
     int CompetitiveWins() const { return m_competitiveWins; }
@@ -54,6 +57,9 @@ private:
     // and then wonder why the game doesn't work and open an issue on github otherwise
     uint32_t m_appIdOverride{ 4465480 };
     bool m_showCsgoGCServersOnly{ true };
+    bool m_rconEnabled{ false };
+    std::string m_rconBindAddress{ "127.0.0.1" };
+    uint16_t m_rconPort{ 37016 };
 
     RankId m_competitiveRank{ RankNone };
     int m_competitiveWins{ 0 };

--- a/csgo_gc/gc_client.cpp
+++ b/csgo_gc/gc_client.cpp
@@ -5,6 +5,46 @@
 #include "keyvalue.h"
 #include "networking_shared.h"
 
+namespace
+{
+
+struct RconCommand
+{
+    explicit RconCommand(std::string command_)
+        : command{ std::move(command_) }
+    {
+    }
+
+    std::string command;
+    std::promise<std::string> response;
+};
+
+template<typename T>
+bool TryParseNumber(std::string_view text, T &value)
+{
+    T parsed{};
+    auto result = std::from_chars(text.data(), text.data() + text.size(), parsed);
+    if (result.ec != std::errc{} || result.ptr != text.data() + text.size())
+    {
+        return false;
+    }
+
+    value = parsed;
+    return true;
+}
+
+std::string ToLower(std::string value)
+{
+    for (char &ch : value)
+    {
+        ch = static_cast<char>(tolower(static_cast<unsigned char>(ch)));
+    }
+
+    return value;
+}
+
+} // namespace
+
 ClientGC::ClientGC(uint64_t steamId)
     : m_steamId{ steamId }
     , m_inventory{ steamId }
@@ -36,6 +76,22 @@ uint32_t ClientGC::LocalPlayerMusicKitMVPsForRoundMVPEvent() const
     // the local increment, so expose the post-MVP value here.
     int32_t cachedMVPs = m_cachedMusicKitMVPs.load();
     return cachedMVPs >= 0 ? static_cast<uint32_t>(cachedMVPs + 1) : 0;
+}
+
+std::string ClientGC::RunRconCommand(std::string command)
+{
+    auto request = std::make_shared<RconCommand>(std::move(command));
+    std::future<std::string> response = request->response.get_future();
+
+    auto holder = new std::shared_ptr<RconCommand>{ request };
+    PostToGC(GCEvent::RconCommand, 0, &holder, sizeof(holder));
+
+    if (response.wait_for(std::chrono::seconds{ 5 }) != std::future_status::ready)
+    {
+        return "ERR timeout";
+    }
+
+    return response.get();
 }
 
 void ClientGC::RefreshCachedMusicKitMVPs()
@@ -126,10 +182,172 @@ void ClientGC::HandleEvent(GCEvent type, uint64_t id, const std::vector<uint8_t>
         }
         break;
 
+    case GCEvent::RconCommand:
+        if (buffer.size() == sizeof(std::shared_ptr<RconCommand> *))
+        {
+            std::shared_ptr<RconCommand> *holder;
+            memcpy(&holder, buffer.data(), sizeof(holder));
+
+            std::shared_ptr<RconCommand> request = std::move(*holder);
+            delete holder;
+
+            request->response.set_value(ExecuteRconCommand(request->command));
+        }
+        else
+        {
+            Platform::Print("ClientGC::HandleEvent: invalid RconCommand buffer size\n");
+        }
+        break;
+
     default:
         Platform::Print("ClientGC::HandleEvent: unknown event type %d\n", static_cast<int>(type));
         break;
     }
+}
+
+std::string ClientGC::ExecuteRconCommand(std::string_view command)
+{
+    std::string commandString{ command };
+    std::istringstream stream{ commandString };
+    std::string name;
+    stream >> name;
+    name = ToLower(std::move(name));
+
+    if (name == "help")
+    {
+        return "OK commands: help, ping, status, clients, give_item <defindex> [count], remove_item <itemid>, refresh_inventory";
+    }
+
+    if (name == "ping")
+    {
+        return "OK pong";
+    }
+
+    if (name == "status")
+    {
+        std::ostringstream response;
+        response << "OK rcon=enabled client=online steamid=" << m_steamId
+                 << " items=" << m_inventory.ItemCount();
+        return response.str();
+    }
+
+    if (name == "clients")
+    {
+        std::ostringstream response;
+        response << "OK steamid=" << m_steamId;
+        return response.str();
+    }
+
+    if (name == "give_item")
+    {
+        std::string defIndexText;
+        if (!(stream >> defIndexText))
+        {
+            return "ERR usage: give_item <defindex> [count]";
+        }
+
+        uint32_t defIndex;
+        if (!TryParseNumber(defIndexText, defIndex))
+        {
+            return "ERR usage: give_item <defindex> [count]";
+        }
+
+        uint32_t count = 1;
+        std::string countText;
+        if (stream >> countText)
+        {
+            if (!TryParseNumber(countText, count) || count == 0 || count > 100)
+            {
+                return "ERR usage: give_item <defindex> [count]";
+            }
+        }
+
+        std::string extra;
+        if (stream >> extra)
+        {
+            return "ERR usage: give_item <defindex> [count]";
+        }
+
+        std::vector<CMsgSOSingleObject> updates;
+        std::vector<uint64_t> itemIds;
+        updates.reserve(count);
+        itemIds.reserve(count);
+
+        for (uint32_t i = 0; i < count; i++)
+        {
+            uint64_t itemId = m_inventory.PurchaseItem(defIndex, updates);
+            if (!itemId)
+            {
+                return "ERR unknown defindex";
+            }
+
+            itemIds.push_back(itemId);
+        }
+
+        for (CMsgSOSingleObject &update : updates)
+        {
+            SendMessageToGame(true, k_ESOMsg_Create, update);
+        }
+
+        std::ostringstream response;
+        response << "OK item_ids=";
+        for (size_t i = 0; i < itemIds.size(); i++)
+        {
+            if (i)
+            {
+                response << ",";
+            }
+            response << itemIds[i];
+        }
+
+        return response.str();
+    }
+
+    if (name == "remove_item")
+    {
+        std::string itemIdText;
+        if (!(stream >> itemIdText))
+        {
+            return "ERR usage: remove_item <itemid>";
+        }
+
+        uint64_t itemId;
+        if (!TryParseNumber(itemIdText, itemId))
+        {
+            return "ERR usage: remove_item <itemid>";
+        }
+
+        std::string extra;
+        if (stream >> extra)
+        {
+            return "ERR usage: remove_item <itemid>";
+        }
+
+        CMsgSOSingleObject destroyed;
+        if (!m_inventory.RemoveItem(itemId, destroyed))
+        {
+            return "ERR item not found";
+        }
+
+        SendMessageToGame(true, k_ESOMsg_Destroy, destroyed);
+        return "OK removed";
+    }
+
+    if (name == "refresh_inventory")
+    {
+        std::string extra;
+        if (stream >> extra)
+        {
+            return "ERR usage: refresh_inventory";
+        }
+
+        CMsgSOCacheSubscribed message;
+        m_inventory.BuildCacheSubscription(message, GetConfig().Level(), false);
+        SendMessageToGame(false, k_ESOMsg_CacheSubscribed, message);
+        return "OK refreshed";
+    }
+
+    return "ERR unknown command";
 }
 
 void ClientGC::HandleMessage(uint32_t type, const void *data, uint32_t size)

--- a/csgo_gc/gc_client.cpp
+++ b/csgo_gc/gc_client.cpp
@@ -5,6 +5,10 @@
 #include "keyvalue.h"
 #include "networking_shared.h"
 
+#include <cerrno>
+#include <cmath>
+#include <cstdlib>
+
 namespace
 {
 
@@ -35,12 +39,32 @@ bool TryParseNumber(std::string_view text, T &value)
 
 bool TryParseFloat01(std::string_view text, float &value)
 {
-    if (!TryParseNumber(text, value))
+    std::string input{ text };
+    char *end = nullptr;
+    errno = 0;
+    float parsed = std::strtof(input.c_str(), &end);
+    if (input.empty() || errno == ERANGE || end != input.c_str() + input.size() || !std::isfinite(parsed))
     {
         return false;
     }
 
+    value = parsed;
     return value >= 0.0f && value <= 1.0f;
+}
+
+bool TryParseFloat(std::string_view text, float &value)
+{
+    std::string input{ text };
+    char *end = nullptr;
+    errno = 0;
+    float parsed = std::strtof(input.c_str(), &end);
+    if (input.empty() || errno == ERANGE || end != input.c_str() + input.size() || !std::isfinite(parsed))
+    {
+        return false;
+    }
+
+    value = parsed;
+    return true;
 }
 
 bool IsValidQuality(uint32_t quality)
@@ -478,7 +502,7 @@ std::string ClientGC::RconGiveItem(const RconRequest &request)
 
         auto parseFloat = [&](std::optional<float> &target) -> std::optional<std::string> {
             float parsed;
-            if (!TryParseNumber(value, parsed))
+            if (!TryParseFloat(value, parsed))
             {
                 return InvalidParameter(key);
             }

--- a/csgo_gc/gc_client.cpp
+++ b/csgo_gc/gc_client.cpp
@@ -33,6 +33,26 @@ bool TryParseNumber(std::string_view text, T &value)
     return true;
 }
 
+bool TryParseFloat01(std::string_view text, float &value)
+{
+    if (!TryParseNumber(text, value))
+    {
+        return false;
+    }
+
+    return value >= 0.0f && value <= 1.0f;
+}
+
+bool IsValidQuality(uint32_t quality)
+{
+    return quality <= ItemSchema::QualityTournament;
+}
+
+bool IsValidRarity(uint32_t rarity)
+{
+    return rarity <= ItemSchema::RarityImmortal || rarity == ItemSchema::RarityUnusual;
+}
+
 std::string ToLower(std::string value)
 {
     for (char &ch : value)
@@ -43,10 +63,87 @@ std::string ToLower(std::string value)
     return value;
 }
 
+bool TokenizeRconCommand(std::string_view command, std::vector<std::string> &tokens)
+{
+    size_t i = 0;
+    while (i < command.size())
+    {
+        while (i < command.size() && command[i] <= ' ')
+        {
+            i++;
+        }
+
+        if (i >= command.size())
+        {
+            break;
+        }
+
+        std::string token;
+        bool quoted = false;
+        for (; i < command.size(); i++)
+        {
+            char ch = command[i];
+            if (quoted)
+            {
+                if (ch == '\\' && i + 1 < command.size())
+                {
+                    token.push_back(command[++i]);
+                    continue;
+                }
+
+                if (ch == '"')
+                {
+                    quoted = false;
+                    continue;
+                }
+
+                token.push_back(ch);
+                continue;
+            }
+
+            if (ch <= ' ')
+            {
+                break;
+            }
+
+            if (ch == '"')
+            {
+                quoted = true;
+                continue;
+            }
+
+            token.push_back(ch);
+        }
+
+        if (quoted)
+        {
+            return false;
+        }
+
+        tokens.push_back(std::move(token));
+    }
+
+    return true;
+}
+
 std::string Usage(std::string_view usage)
 {
     std::string response{ "ERR usage: " };
     response.append(usage.data(), usage.size());
+    return response;
+}
+
+std::string InvalidParameter(std::string_view key)
+{
+    std::string response{ "ERR invalid parameter " };
+    response.append(key.data(), key.size());
+    return response;
+}
+
+std::string UnknownParameter(std::string_view key)
+{
+    std::string response{ "ERR unknown parameter " };
+    response.append(key.data(), key.size());
     return response;
 }
 
@@ -219,7 +316,7 @@ const ClientGC::RconCommandDef *ClientGC::RconCommands(size_t &count)
         { "ping", "ping", &ClientGC::RconPing },
         { "status", "status", &ClientGC::RconStatus },
         { "clients", "clients", &ClientGC::RconClients },
-        { "give_item", "give_item <defindex> [count]", &ClientGC::RconGiveItem },
+        { "give_item", "give_item <defindex> [count] [key=value...]", &ClientGC::RconGiveItem },
         { "remove_item", "remove_item <itemid>", &ClientGC::RconRemoveItem },
         { "refresh_inventory", "refresh_inventory", &ClientGC::RconRefreshInventory },
     };
@@ -231,17 +328,22 @@ const ClientGC::RconCommandDef *ClientGC::RconCommands(size_t &count)
 std::string ClientGC::ExecuteRconCommand(std::string_view command)
 {
     RconRequest request;
-    std::string token;
-    std::istringstream stream{ std::string{ command } };
-    if (!(stream >> request.name))
+    std::vector<std::string> tokens;
+    if (!TokenizeRconCommand(command, tokens))
+    {
+        return "ERR malformed command";
+    }
+
+    if (tokens.empty())
     {
         return "ERR unknown command";
     }
 
+    request.name = std::move(tokens[0]);
     request.name = ToLower(std::move(request.name));
-    while (stream >> token)
+    for (size_t i = 1; i < tokens.size(); i++)
     {
-        request.args.push_back(std::move(token));
+        request.args.push_back(std::move(tokens[i]));
     }
 
     size_t commandCount = 0;
@@ -315,22 +417,162 @@ std::string ClientGC::RconClients(const RconRequest &request)
 
 std::string ClientGC::RconGiveItem(const RconRequest &request)
 {
-    if (request.args.empty() || request.args.size() > 2)
+    constexpr const char *GiveItemUsage = "give_item <defindex> [count] [key=value...]";
+
+    if (request.args.empty())
     {
-        return Usage("give_item <defindex> [count]");
+        return Usage(GiveItemUsage);
     }
 
     uint32_t defIndex;
     if (!TryParseNumber(request.args[0], defIndex))
     {
-        return Usage("give_item <defindex> [count]");
+        return Usage(GiveItemUsage);
     }
 
     uint32_t count = 1;
-    if (request.args.size() == 2
-        && (!TryParseNumber(request.args[1], count) || count == 0 || count > 100))
+    size_t parameterStart = 1;
+    if (parameterStart < request.args.size() && request.args[parameterStart].find('=') == std::string::npos)
     {
-        return Usage("give_item <defindex> [count]");
+        if (!TryParseNumber(request.args[parameterStart], count) || count == 0 || count > 100)
+        {
+            return Usage(GiveItemUsage);
+        }
+        parameterStart++;
+    }
+
+    Inventory::ParameterizedItemOptions options;
+    bool hasParameters = parameterStart < request.args.size();
+
+    for (size_t i = parameterStart; i < request.args.size(); i++)
+    {
+        std::string_view parameter{ request.args[i] };
+        size_t separator = parameter.find('=');
+        if (separator == std::string_view::npos || separator == 0)
+        {
+            return Usage(GiveItemUsage);
+        }
+
+        std::string key = ToLower(std::string{ parameter.substr(0, separator) });
+        std::string_view value = parameter.substr(separator + 1);
+
+        auto parseUint32 = [&](std::optional<uint32_t> &target) -> std::optional<std::string> {
+            uint32_t parsed;
+            if (!TryParseNumber(value, parsed))
+            {
+                return InvalidParameter(key);
+            }
+            target = parsed;
+            return {};
+        };
+
+        auto parseFloat01 = [&](std::optional<float> &target) -> std::optional<std::string> {
+            float parsed;
+            if (!TryParseFloat01(value, parsed))
+            {
+                return InvalidParameter(key);
+            }
+            target = parsed;
+            return {};
+        };
+
+        auto parseFloat = [&](std::optional<float> &target) -> std::optional<std::string> {
+            float parsed;
+            if (!TryParseNumber(value, parsed))
+            {
+                return InvalidParameter(key);
+            }
+            target = parsed;
+            return {};
+        };
+
+        std::optional<std::string> error;
+        if (key == "level")
+        {
+            error = parseUint32(options.level);
+        }
+        else if (key == "quality")
+        {
+            error = parseUint32(options.quality);
+            if (!error && !IsValidQuality(*options.quality))
+            {
+                error = InvalidParameter(key);
+            }
+        }
+        else if (key == "rarity")
+        {
+            error = parseUint32(options.rarity);
+            if (!error && !IsValidRarity(*options.rarity))
+            {
+                error = InvalidParameter(key);
+            }
+        }
+        else if (key == "name")
+        {
+            options.customName = std::string{ value };
+        }
+        else if (key == "paint")
+        {
+            error = parseUint32(options.paint);
+        }
+        else if (key == "seed")
+        {
+            error = parseUint32(options.seed);
+        }
+        else if (key == "wear")
+        {
+            error = parseFloat01(options.wear);
+        }
+        else if (key == "stattrak")
+        {
+            error = parseUint32(options.statTrak);
+        }
+        else if (key == "music")
+        {
+            error = parseUint32(options.music);
+        }
+        else if (key == "spray_color")
+        {
+            error = parseUint32(options.sprayColor);
+        }
+        else if (key == "spray_remaining")
+        {
+            error = parseUint32(options.sprayRemaining);
+        }
+        else if (key.rfind("sticker", 0) == 0 && key.size() >= 8 && key[7] >= '0' && key[7] <= '5')
+        {
+            size_t stickerSlot = static_cast<size_t>(key[7] - '0');
+            std::string_view suffix{ key.data() + 8, key.size() - 8 };
+            if (suffix.empty())
+            {
+                error = parseUint32(options.sticker[stickerSlot]);
+            }
+            else if (suffix == "_wear")
+            {
+                error = parseFloat01(options.stickerWear[stickerSlot]);
+            }
+            else if (suffix == "_scale")
+            {
+                error = parseFloat(options.stickerScale[stickerSlot]);
+            }
+            else if (suffix == "_rotation")
+            {
+                error = parseFloat(options.stickerRotation[stickerSlot]);
+            }
+            else
+            {
+                return UnknownParameter(key);
+            }
+        }
+        else
+        {
+            return UnknownParameter(key);
+        }
+
+        if (error)
+        {
+            return *error;
+        }
     }
 
     std::vector<CMsgSOSingleObject> updates;
@@ -340,7 +582,27 @@ std::string ClientGC::RconGiveItem(const RconRequest &request)
 
     for (uint32_t i = 0; i < count; i++)
     {
-        uint64_t itemId = m_inventory.PurchaseItem(defIndex, updates);
+        uint64_t itemId = 0;
+        if (hasParameters)
+        {
+            CMsgSOSingleObject &update = updates.emplace_back();
+            std::string error;
+            itemId = m_inventory.CreateParameterizedItem(defIndex, options, update, error);
+            if (!itemId)
+            {
+                updates.pop_back();
+                if (error == "unknown defindex")
+                {
+                    return "ERR unknown defindex";
+                }
+                return std::string{ "ERR " }.append(error);
+            }
+        }
+        else
+        {
+            itemId = m_inventory.PurchaseItem(defIndex, updates);
+        }
+
         if (!itemId)
         {
             return "ERR unknown defindex";

--- a/csgo_gc/gc_client.cpp
+++ b/csgo_gc/gc_client.cpp
@@ -43,6 +43,13 @@ std::string ToLower(std::string value)
     return value;
 }
 
+std::string Usage(std::string_view usage)
+{
+    std::string response{ "ERR usage: " };
+    response.append(usage.data(), usage.size());
+    return response;
+}
+
 } // namespace
 
 ClientGC::ClientGC(uint64_t steamId)
@@ -205,149 +212,196 @@ void ClientGC::HandleEvent(GCEvent type, uint64_t id, const std::vector<uint8_t>
     }
 }
 
+const ClientGC::RconCommandDef *ClientGC::RconCommands(size_t &count)
+{
+    static const RconCommandDef Commands[]{
+        { "help", "help", &ClientGC::RconHelp },
+        { "ping", "ping", &ClientGC::RconPing },
+        { "status", "status", &ClientGC::RconStatus },
+        { "clients", "clients", &ClientGC::RconClients },
+        { "give_item", "give_item <defindex> [count]", &ClientGC::RconGiveItem },
+        { "remove_item", "remove_item <itemid>", &ClientGC::RconRemoveItem },
+        { "refresh_inventory", "refresh_inventory", &ClientGC::RconRefreshInventory },
+    };
+
+    count = sizeof(Commands) / sizeof(Commands[0]);
+    return Commands;
+}
+
 std::string ClientGC::ExecuteRconCommand(std::string_view command)
 {
-    std::string commandString{ command };
-    std::istringstream stream{ commandString };
-    std::string name;
-    stream >> name;
-    name = ToLower(std::move(name));
-
-    if (name == "help")
+    RconRequest request;
+    std::string token;
+    std::istringstream stream{ std::string{ command } };
+    if (!(stream >> request.name))
     {
-        return "OK commands: help, ping, status, clients, give_item <defindex> [count], remove_item <itemid>, refresh_inventory";
+        return "ERR unknown command";
     }
 
-    if (name == "ping")
+    request.name = ToLower(std::move(request.name));
+    while (stream >> token)
     {
-        return "OK pong";
+        request.args.push_back(std::move(token));
     }
 
-    if (name == "status")
+    size_t commandCount = 0;
+    const RconCommandDef *commands = RconCommands(commandCount);
+    for (size_t i = 0; i < commandCount; i++)
     {
-        std::ostringstream response;
-        response << "OK rcon=enabled client=online steamid=" << m_steamId
-                 << " items=" << m_inventory.ItemCount();
-        return response.str();
-    }
-
-    if (name == "clients")
-    {
-        std::ostringstream response;
-        response << "OK steamid=" << m_steamId;
-        return response.str();
-    }
-
-    if (name == "give_item")
-    {
-        std::string defIndexText;
-        if (!(stream >> defIndexText))
+        const RconCommandDef &commandDef = commands[i];
+        if (request.name == commandDef.name)
         {
-            return "ERR usage: give_item <defindex> [count]";
+            return (this->*commandDef.handler)(request);
         }
-
-        uint32_t defIndex;
-        if (!TryParseNumber(defIndexText, defIndex))
-        {
-            return "ERR usage: give_item <defindex> [count]";
-        }
-
-        uint32_t count = 1;
-        std::string countText;
-        if (stream >> countText)
-        {
-            if (!TryParseNumber(countText, count) || count == 0 || count > 100)
-            {
-                return "ERR usage: give_item <defindex> [count]";
-            }
-        }
-
-        std::string extra;
-        if (stream >> extra)
-        {
-            return "ERR usage: give_item <defindex> [count]";
-        }
-
-        std::vector<CMsgSOSingleObject> updates;
-        std::vector<uint64_t> itemIds;
-        updates.reserve(count);
-        itemIds.reserve(count);
-
-        for (uint32_t i = 0; i < count; i++)
-        {
-            uint64_t itemId = m_inventory.PurchaseItem(defIndex, updates);
-            if (!itemId)
-            {
-                return "ERR unknown defindex";
-            }
-
-            itemIds.push_back(itemId);
-        }
-
-        for (CMsgSOSingleObject &update : updates)
-        {
-            SendMessageToGame(true, k_ESOMsg_Create, update);
-        }
-
-        std::ostringstream response;
-        response << "OK item_ids=";
-        for (size_t i = 0; i < itemIds.size(); i++)
-        {
-            if (i)
-            {
-                response << ",";
-            }
-            response << itemIds[i];
-        }
-
-        return response.str();
-    }
-
-    if (name == "remove_item")
-    {
-        std::string itemIdText;
-        if (!(stream >> itemIdText))
-        {
-            return "ERR usage: remove_item <itemid>";
-        }
-
-        uint64_t itemId;
-        if (!TryParseNumber(itemIdText, itemId))
-        {
-            return "ERR usage: remove_item <itemid>";
-        }
-
-        std::string extra;
-        if (stream >> extra)
-        {
-            return "ERR usage: remove_item <itemid>";
-        }
-
-        CMsgSOSingleObject destroyed;
-        if (!m_inventory.RemoveItem(itemId, destroyed))
-        {
-            return "ERR item not found";
-        }
-
-        SendMessageToGame(true, k_ESOMsg_Destroy, destroyed);
-        return "OK removed";
-    }
-
-    if (name == "refresh_inventory")
-    {
-        std::string extra;
-        if (stream >> extra)
-        {
-            return "ERR usage: refresh_inventory";
-        }
-
-        CMsgSOCacheSubscribed message;
-        m_inventory.BuildCacheSubscription(message, GetConfig().Level(), false);
-        SendMessageToGame(false, k_ESOMsg_CacheSubscribed, message);
-        return "OK refreshed";
     }
 
     return "ERR unknown command";
+}
+
+std::string ClientGC::RconHelp(const RconRequest &request)
+{
+    if (!request.args.empty())
+    {
+        return Usage("help");
+    }
+
+    std::ostringstream response;
+    response << "OK commands:";
+
+    size_t commandCount = 0;
+    const RconCommandDef *commands = RconCommands(commandCount);
+    for (size_t i = 0; i < commandCount; i++)
+    {
+        response << (i ? ", " : " ") << commands[i].usage;
+    }
+
+    return response.str();
+}
+
+std::string ClientGC::RconPing(const RconRequest &request)
+{
+    if (!request.args.empty())
+    {
+        return Usage("ping");
+    }
+
+    return "OK pong";
+}
+
+std::string ClientGC::RconStatus(const RconRequest &request)
+{
+    if (!request.args.empty())
+    {
+        return Usage("status");
+    }
+
+    std::ostringstream response;
+    response << "OK rcon=enabled client=online steamid=" << m_steamId
+             << " items=" << m_inventory.ItemCount();
+    return response.str();
+}
+
+std::string ClientGC::RconClients(const RconRequest &request)
+{
+    if (!request.args.empty())
+    {
+        return Usage("clients");
+    }
+
+    std::ostringstream response;
+    response << "OK steamid=" << m_steamId;
+    return response.str();
+}
+
+std::string ClientGC::RconGiveItem(const RconRequest &request)
+{
+    if (request.args.empty() || request.args.size() > 2)
+    {
+        return Usage("give_item <defindex> [count]");
+    }
+
+    uint32_t defIndex;
+    if (!TryParseNumber(request.args[0], defIndex))
+    {
+        return Usage("give_item <defindex> [count]");
+    }
+
+    uint32_t count = 1;
+    if (request.args.size() == 2
+        && (!TryParseNumber(request.args[1], count) || count == 0 || count > 100))
+    {
+        return Usage("give_item <defindex> [count]");
+    }
+
+    std::vector<CMsgSOSingleObject> updates;
+    std::vector<uint64_t> itemIds;
+    updates.reserve(count);
+    itemIds.reserve(count);
+
+    for (uint32_t i = 0; i < count; i++)
+    {
+        uint64_t itemId = m_inventory.PurchaseItem(defIndex, updates);
+        if (!itemId)
+        {
+            return "ERR unknown defindex";
+        }
+
+        itemIds.push_back(itemId);
+    }
+
+    for (CMsgSOSingleObject &update : updates)
+    {
+        SendMessageToGame(true, k_ESOMsg_Create, update);
+    }
+
+    std::ostringstream response;
+    response << "OK item_ids=";
+    for (size_t i = 0; i < itemIds.size(); i++)
+    {
+        if (i)
+        {
+            response << ",";
+        }
+        response << itemIds[i];
+    }
+
+    return response.str();
+}
+
+std::string ClientGC::RconRemoveItem(const RconRequest &request)
+{
+    if (request.args.size() != 1)
+    {
+        return Usage("remove_item <itemid>");
+    }
+
+    uint64_t itemId;
+    if (!TryParseNumber(request.args[0], itemId))
+    {
+        return Usage("remove_item <itemid>");
+    }
+
+    CMsgSOSingleObject destroyed;
+    if (!m_inventory.RemoveItem(itemId, destroyed))
+    {
+        return "ERR item not found";
+    }
+
+    SendMessageToGame(true, k_ESOMsg_Destroy, destroyed);
+    return "OK removed";
+}
+
+std::string ClientGC::RconRefreshInventory(const RconRequest &request)
+{
+    if (!request.args.empty())
+    {
+        return Usage("refresh_inventory");
+    }
+
+    CMsgSOCacheSubscribed message;
+    m_inventory.BuildCacheSubscription(message, GetConfig().Level(), false);
+    SendMessageToGame(false, k_ESOMsg_CacheSubscribed, message);
+    return "OK refreshed";
 }
 
 void ClientGC::HandleMessage(uint32_t type, const void *data, uint32_t size)

--- a/csgo_gc/gc_client.h
+++ b/csgo_gc/gc_client.h
@@ -10,6 +10,7 @@ public:
     ClientGC(uint64_t steamId);
     ~ClientGC();
     uint32_t LocalPlayerMusicKitMVPsForRoundMVPEvent() const;
+    std::string RunRconCommand(std::string command);
 
 private:
     void HandleEvent(GCEvent type, uint64_t id, const std::vector<uint8_t> &buffer) override;
@@ -21,6 +22,7 @@ private:
     void RefreshCachedMusicKitMVPs();
     void SyncLocalPlayerMusicKitState(int userId);
     void SendMusicKitMVPStateToGameServer();
+    std::string ExecuteRconCommand(std::string_view command);
 
     // send to the local game and the game server we're connected to (if we're connected)
     void SendMessageToGame(bool sendToGameServer, uint32_t type,

--- a/csgo_gc/gc_client.h
+++ b/csgo_gc/gc_client.h
@@ -13,6 +13,19 @@ public:
     std::string RunRconCommand(std::string command);
 
 private:
+    struct RconRequest
+    {
+        std::string name;
+        std::vector<std::string> args;
+    };
+
+    struct RconCommandDef
+    {
+        const char *name;
+        const char *usage;
+        std::string (ClientGC::*handler)(const RconRequest &request);
+    };
+
     void HandleEvent(GCEvent type, uint64_t id, const std::vector<uint8_t> &buffer) override;
 
     // event handlers
@@ -22,7 +35,15 @@ private:
     void RefreshCachedMusicKitMVPs();
     void SyncLocalPlayerMusicKitState(int userId);
     void SendMusicKitMVPStateToGameServer();
+    static const RconCommandDef *RconCommands(size_t &count);
     std::string ExecuteRconCommand(std::string_view command);
+    std::string RconHelp(const RconRequest &request);
+    std::string RconPing(const RconRequest &request);
+    std::string RconStatus(const RconRequest &request);
+    std::string RconClients(const RconRequest &request);
+    std::string RconGiveItem(const RconRequest &request);
+    std::string RconRemoveItem(const RconRequest &request);
+    std::string RconRefreshInventory(const RconRequest &request);
 
     // send to the local game and the game server we're connected to (if we're connected)
     void SendMessageToGame(bool sendToGameServer, uint32_t type,

--- a/csgo_gc/gc_shared.h
+++ b/csgo_gc/gc_shared.h
@@ -17,6 +17,7 @@ enum class GCEvent
     LocalPlayerRoundMVP, // sent to client gc when the local player earns round MVP
     SyncLocalPlayerMusicKitState, // sent to client gc from the main thread, buffer contains the local userid
     ClientSOCacheUnsubscribe, // sent to server gc when a client disconnects, id contains the steam id
+    RconCommand, // sent to client gc, buffer contains a RconCommand shared_ptr holder
 };
 
 struct EventData

--- a/csgo_gc/inventory.cpp
+++ b/csgo_gc/inventory.cpp
@@ -39,6 +39,42 @@ inline bool IsDefaultItemId(uint64_t itemId, uint32_t &defIndex, uint32_t &paint
     return false;
 }
 
+CSOEconItemAttribute *FindOrAddAttribute(CSOEconItem &item, uint32_t defIndex)
+{
+    for (int i = 0; i < item.attribute_size(); i++)
+    {
+        CSOEconItemAttribute *attribute = item.mutable_attribute(i);
+        if (attribute->def_index() == defIndex)
+        {
+            return attribute;
+        }
+    }
+
+    CSOEconItemAttribute *attribute = item.add_attribute();
+    attribute->set_def_index(defIndex);
+    return attribute;
+}
+
+uint32_t StickerIdAttribute(size_t slot)
+{
+    return ItemSchema::AttributeStickerId0 + static_cast<uint32_t>(slot) * 4;
+}
+
+uint32_t StickerWearAttribute(size_t slot)
+{
+    return ItemSchema::AttributeStickerWear0 + static_cast<uint32_t>(slot) * 4;
+}
+
+uint32_t StickerScaleAttribute(size_t slot)
+{
+    return ItemSchema::AttributeStickerScale0 + static_cast<uint32_t>(slot) * 4;
+}
+
+uint32_t StickerRotationAttribute(size_t slot)
+{
+    return ItemSchema::AttributeStickerRotation0 + static_cast<uint32_t>(slot) * 4;
+}
+
 Inventory::Inventory(uint64_t steamId)
     : m_steamId{ steamId }
 {
@@ -1883,6 +1919,190 @@ uint64_t Inventory::PurchaseItem(uint32_t defIndex, std::vector<CMsgSOSingleObje
     CMsgSOSingleObject &single = update.emplace_back();
     ToSingleObject(single, item);
 
+    return item.id();
+}
+
+uint64_t Inventory::CreateParameterizedItem(uint32_t defIndex,
+    const ParameterizedItemOptions &options,
+    CMsgSOSingleObject &update,
+    std::string &error)
+{
+    if (!m_itemSchema.ItemInfoByDefIndex(defIndex))
+    {
+        error = "unknown defindex";
+        return 0;
+    }
+
+    if (options.paint && !m_itemSchema.PaintKitInfoByDefIndex(*options.paint))
+    {
+        error = "unknown paint";
+        return 0;
+    }
+
+    if (options.music && !m_itemSchema.MusicDefinitionInfoByDefIndex(*options.music))
+    {
+        error = "unknown music";
+        return 0;
+    }
+
+    if (options.music && defIndex != ItemSchema::ItemMusicKit)
+    {
+        error = "music requires defindex 1314";
+        return 0;
+    }
+
+    if (options.sprayColor
+        && (*options.sprayColor < ItemSchema::GraffitiTintMin || *options.sprayColor > ItemSchema::GraffitiTintMax))
+    {
+        error = "invalid parameter spray_color";
+        return 0;
+    }
+
+    for (const std::optional<uint32_t> &sticker : options.sticker)
+    {
+        if (sticker && !m_itemSchema.StickerKitInfoByDefIndex(*sticker))
+        {
+            error = "unknown sticker";
+            return 0;
+        }
+    }
+
+    CSOEconItem &item = CreateItem(defIndex, ItemOriginPurchased, UnacknowledgedPurchased);
+
+    if (options.level)
+    {
+        item.set_level(*options.level);
+    }
+
+    if (options.customName && !options.customName->empty())
+    {
+        item.set_custom_name(*options.customName);
+    }
+
+    if (options.paint)
+    {
+        CSOEconItemAttribute *attribute = FindOrAddAttribute(item, ItemSchema::AttributeTexturePrefab);
+        m_itemSchema.SetAttributeUint32(attribute, *options.paint);
+
+        attribute = FindOrAddAttribute(item, ItemSchema::AttributeTextureSeed);
+        m_itemSchema.SetAttributeUint32(attribute, options.seed.value_or(0));
+
+        attribute = FindOrAddAttribute(item, ItemSchema::AttributeTextureWear);
+        m_itemSchema.SetAttributeFloat(attribute, options.wear.value_or(0.001f));
+
+        if (!options.quality)
+        {
+            item.set_quality(ItemSchema::QualityUnique);
+        }
+
+        if (!options.rarity)
+        {
+            item.set_rarity(m_itemSchema.GetPaintedRarity(defIndex, *options.paint, item.rarity()));
+        }
+    }
+    else
+    {
+        if (options.seed)
+        {
+            CSOEconItemAttribute *attribute = FindOrAddAttribute(item, ItemSchema::AttributeTextureSeed);
+            m_itemSchema.SetAttributeUint32(attribute, *options.seed);
+        }
+
+        if (options.wear)
+        {
+            CSOEconItemAttribute *attribute = FindOrAddAttribute(item, ItemSchema::AttributeTextureWear);
+            m_itemSchema.SetAttributeFloat(attribute, *options.wear);
+        }
+    }
+
+    if (options.music)
+    {
+        CSOEconItemAttribute *attribute = FindOrAddAttribute(item, ItemSchema::AttributeMusicId);
+        m_itemSchema.SetAttributeUint32(attribute, *options.music);
+
+        attribute = FindOrAddAttribute(item, ItemSchema::AttributeKillEater);
+        m_itemSchema.SetAttributeUint32(attribute, options.statTrak ? (*options.statTrak == 1 ? 0 : *options.statTrak) : 0);
+
+        attribute = FindOrAddAttribute(item, ItemSchema::AttributeKillEaterScoreType);
+        m_itemSchema.SetAttributeUint32(attribute, 1);
+
+        if (!options.quality)
+        {
+            item.set_quality(options.statTrak ? ItemSchema::QualityStrange : ItemSchema::QualityUnique);
+        }
+
+        if (!options.rarity)
+        {
+            item.set_rarity(ItemSchema::RarityRare);
+        }
+    }
+
+    if (options.statTrak && !options.music)
+    {
+        CSOEconItemAttribute *attribute = FindOrAddAttribute(item, ItemSchema::AttributeKillEater);
+        m_itemSchema.SetAttributeUint32(attribute, *options.statTrak == 1 ? 0 : *options.statTrak);
+
+        attribute = FindOrAddAttribute(item, ItemSchema::AttributeKillEaterScoreType);
+        m_itemSchema.SetAttributeUint32(attribute, 0);
+
+        if (!options.quality)
+        {
+            item.set_quality(ItemSchema::QualityStrange);
+        }
+    }
+
+    if (options.sprayColor)
+    {
+        CSOEconItemAttribute *attribute = FindOrAddAttribute(item, ItemSchema::AttributeSprayTintId);
+        m_itemSchema.SetAttributeUint32(attribute, *options.sprayColor);
+    }
+
+    if (options.sprayRemaining)
+    {
+        CSOEconItemAttribute *attribute = FindOrAddAttribute(item, ItemSchema::AttributeSpraysRemaining);
+        m_itemSchema.SetAttributeUint32(attribute, *options.sprayRemaining);
+    }
+
+    for (size_t i = 0; i < options.sticker.size(); i++)
+    {
+        if (options.sticker[i])
+        {
+            CSOEconItemAttribute *attribute = FindOrAddAttribute(item, StickerIdAttribute(i));
+            m_itemSchema.SetAttributeUint32(attribute, *options.sticker[i]);
+
+            attribute = FindOrAddAttribute(item, StickerWearAttribute(i));
+            m_itemSchema.SetAttributeFloat(attribute, options.stickerWear[i].value_or(0.0f));
+        }
+        else if (options.stickerWear[i])
+        {
+            CSOEconItemAttribute *attribute = FindOrAddAttribute(item, StickerWearAttribute(i));
+            m_itemSchema.SetAttributeFloat(attribute, *options.stickerWear[i]);
+        }
+
+        if (options.stickerScale[i])
+        {
+            CSOEconItemAttribute *attribute = FindOrAddAttribute(item, StickerScaleAttribute(i));
+            m_itemSchema.SetAttributeFloat(attribute, *options.stickerScale[i]);
+        }
+
+        if (options.stickerRotation[i])
+        {
+            CSOEconItemAttribute *attribute = FindOrAddAttribute(item, StickerRotationAttribute(i));
+            m_itemSchema.SetAttributeFloat(attribute, *options.stickerRotation[i]);
+        }
+    }
+
+    if (options.quality)
+    {
+        item.set_quality(*options.quality);
+    }
+
+    if (options.rarity)
+    {
+        item.set_rarity(*options.rarity);
+    }
+
+    ToSingleObject(update, item);
     return item.id();
 }
 

--- a/csgo_gc/inventory.h
+++ b/csgo_gc/inventory.h
@@ -14,6 +14,27 @@ public:
     Inventory(uint64_t steamId);
     ~Inventory();
 
+    struct ParameterizedItemOptions
+    {
+        std::optional<uint32_t> level;
+        std::optional<uint32_t> quality;
+        std::optional<uint32_t> rarity;
+        std::optional<std::string> customName;
+
+        std::optional<uint32_t> paint;
+        std::optional<uint32_t> seed;
+        std::optional<float> wear;
+        std::optional<uint32_t> statTrak;
+        std::optional<uint32_t> music;
+        std::optional<uint32_t> sprayColor;
+        std::optional<uint32_t> sprayRemaining;
+
+        std::array<std::optional<uint32_t>, 6> sticker;
+        std::array<std::optional<float>, 6> stickerWear;
+        std::array<std::optional<float>, 6> stickerScale;
+        std::array<std::optional<float>, 6> stickerRotation;
+    };
+
     void BuildCacheSubscription(CMsgSOCacheSubscribed &message, int level, bool server);
 
     bool EquipItem(uint64_t itemId, uint32_t classId, uint32_t slotId, CMsgSOMultipleObjects &update);
@@ -138,6 +159,10 @@ public:
     // returns the item id and adds the item to the provided CMsgSOMultipleObjects
     // on failure returns 0 and does nothing
     uint64_t PurchaseItem(uint32_t defIndex, std::vector<CMsgSOSingleObject> &update);
+    uint64_t CreateParameterizedItem(uint32_t defIndex,
+        const ParameterizedItemOptions &options,
+        CMsgSOSingleObject &update,
+        std::string &error);
     size_t ItemCount() const { return m_items.size(); }
 
 private:

--- a/csgo_gc/inventory.h
+++ b/csgo_gc/inventory.h
@@ -138,6 +138,7 @@ public:
     // returns the item id and adds the item to the provided CMsgSOMultipleObjects
     // on failure returns 0 and does nothing
     uint64_t PurchaseItem(uint32_t defIndex, std::vector<CMsgSOSingleObject> &update);
+    size_t ItemCount() const { return m_items.size(); }
 
 private:
     uint32_t AccountId() const;

--- a/csgo_gc/item_schema.cpp
+++ b/csgo_gc/item_schema.cpp
@@ -1182,6 +1182,19 @@ const StickerKitInfo *ItemSchema::StickerKitByTournamentTeamId(uint32_t eventId,
     return nullptr;
 }
 
+const StickerKitInfo *ItemSchema::StickerKitInfoByDefIndex(uint32_t defIndex) const
+{
+    for (const auto &pair : m_stickerKitInfo)
+    {
+        if (pair.second.m_defIndex == defIndex)
+        {
+            return &pair.second;
+        }
+    }
+
+    return nullptr;
+}
+
 PaintKitInfo *ItemSchema::PaintKitInfoByName(std::string_view name)
 {
     auto it = m_paintKitInfo.find(std::string{ name });
@@ -1216,6 +1229,19 @@ MusicDefinitionInfo *ItemSchema::MusicDefinitionInfoByName(std::string_view name
     }
 
     return &it->second;
+}
+
+const MusicDefinitionInfo *ItemSchema::MusicDefinitionInfoByDefIndex(uint32_t defIndex) const
+{
+    for (const auto &pair : m_musicDefinitionInfo)
+    {
+        if (pair.second.m_defIndex == defIndex)
+        {
+            return &pair.second;
+        }
+    }
+
+    return nullptr;
 }
 
 bool ItemSchema::GetCollectionsForPaintedItem(uint32_t defIndex, uint32_t paintKitDefIndex,

--- a/csgo_gc/item_schema.h
+++ b/csgo_gc/item_schema.h
@@ -151,6 +151,8 @@ public:
     // trade-up helpers
     const ItemInfo *ItemInfoByDefIndex(uint32_t defIndex) const;
     const PaintKitInfo *PaintKitInfoByDefIndex(uint32_t defIndex) const;
+    const StickerKitInfo *StickerKitInfoByDefIndex(uint32_t defIndex) const;
+    const MusicDefinitionInfo *MusicDefinitionInfoByDefIndex(uint32_t defIndex) const;
     const StickerKitInfo *StickerKitByTournamentEventId(uint32_t eventId) const;
     const StickerKitInfo *StickerKitByTournamentTeamId(uint32_t eventId, uint32_t teamId) const;
     bool GetCollectionsForPaintedItem(uint32_t defIndex, uint32_t paintKitDefIndex,

--- a/csgo_gc/rcon_server.cpp
+++ b/csgo_gc/rcon_server.cpp
@@ -18,6 +18,13 @@
 namespace
 {
 
+constexpr int32_t SourceRconResponseValue = 0;
+constexpr int32_t SourceRconExecCommand = 2;
+constexpr int32_t SourceRconAuth = 3;
+constexpr int32_t SourceRconAuthResponse = 2;
+constexpr int32_t SourceRconMinPacketSize = 10; // request id + type + two null bytes
+constexpr int32_t SourceRconMaxPacketSize = 4096;
+
 #ifdef _WIN32
 using SocketType = SOCKET;
 constexpr SocketType InvalidSocket = INVALID_SOCKET;
@@ -65,6 +72,30 @@ std::string Trim(std::string_view value)
     return std::string{ value };
 }
 
+int32_t ReadInt32LE(const char *data)
+{
+    const auto *bytes = reinterpret_cast<const unsigned char *>(data);
+    return static_cast<int32_t>(
+        static_cast<uint32_t>(bytes[0])
+        | (static_cast<uint32_t>(bytes[1]) << 8)
+        | (static_cast<uint32_t>(bytes[2]) << 16)
+        | (static_cast<uint32_t>(bytes[3]) << 24));
+}
+
+void AppendInt32LE(std::string &buffer, int32_t value)
+{
+    uint32_t unsignedValue = static_cast<uint32_t>(value);
+    buffer.push_back(static_cast<char>(unsignedValue & 0xff));
+    buffer.push_back(static_cast<char>((unsignedValue >> 8) & 0xff));
+    buffer.push_back(static_cast<char>((unsignedValue >> 16) & 0xff));
+    buffer.push_back(static_cast<char>((unsignedValue >> 24) & 0xff));
+}
+
+bool IsValidSourcePacketSize(int32_t size)
+{
+    return size >= SourceRconMinPacketSize && size <= SourceRconMaxPacketSize;
+}
+
 bool SendAll(SocketType socket, const char *data, size_t size)
 {
     while (size)
@@ -82,6 +113,19 @@ bool SendAll(SocketType socket, const char *data, size_t size)
     return true;
 }
 
+bool SendSourcePacket(SocketType socket, int32_t requestId, int32_t type, std::string_view body)
+{
+    std::string packet;
+    packet.reserve(sizeof(int32_t) * 3 + body.size() + 2);
+    AppendInt32LE(packet, static_cast<int32_t>(sizeof(int32_t) * 2 + body.size() + 2));
+    AppendInt32LE(packet, requestId);
+    AppendInt32LE(packet, type);
+    packet.append(body.data(), body.size());
+    packet.push_back('\0');
+    packet.push_back('\0');
+    return SendAll(socket, packet.data(), packet.size());
+}
+
 } // namespace
 
 RconServer::RconServer() = default;
@@ -93,10 +137,11 @@ RconServer::~RconServer()
 
 void RconServer::Start()
 {
-    Platform::Print("RCON: config enabled=%d bind_address=%s port=%u\n",
+    Platform::Print("RCON: config enabled=%d bind_address=%s port=%u source=1 text=1 password=%s\n",
         GetConfig().RconEnabled() ? 1 : 0,
         GetConfig().RconBindAddress().c_str(),
-        GetConfig().RconPort());
+        GetConfig().RconPort(),
+        GetConfig().RconPassword().empty() ? "empty" : "set");
 
     if (!GetConfig().RconEnabled())
     {
@@ -279,6 +324,8 @@ void RconServer::HandleConnection(uintptr_t socketHandle)
 
     std::string buffer;
     char chunk[1024];
+    std::optional<bool> sourceMode;
+    bool authenticated = false;
 
     while (m_running.load())
     {
@@ -306,37 +353,152 @@ void RconServer::HandleConnection(uintptr_t socketHandle)
 
         buffer.append(chunk, chunk + received);
 
-        while (true)
+        if (!sourceMode && buffer.size() >= sizeof(int32_t))
         {
-            size_t newline = buffer.find('\n');
-            if (newline == std::string::npos)
+            sourceMode = IsValidSourcePacketSize(ReadInt32LE(buffer.data()));
+        }
+
+        if (!sourceMode)
+        {
+            continue;
+        }
+
+        if (*sourceMode)
+        {
+            if (!HandleSourceBuffer(socketHandle, buffer, authenticated))
             {
                 break;
             }
-
-            std::string line = Trim(std::string_view{ buffer.data(), newline });
-            if (!line.empty() && line.back() == '\r')
-            {
-                line.pop_back();
-            }
-            buffer.erase(0, newline + 1);
-
-            if (line.empty())
-            {
-                continue;
-            }
-
-            std::string response = ExecuteCommand(std::move(line));
-            response.push_back('\n');
-            if (!SendAll(socket, response.data(), response.size()))
-            {
-                CloseSocket(socket);
-                return;
-            }
+        }
+        else if (!HandleTextBuffer(socketHandle, buffer))
+        {
+            break;
         }
     }
 
     CloseSocket(socket);
+}
+
+bool RconServer::HandleTextBuffer(uintptr_t socketHandle, std::string &buffer)
+{
+    SocketType socket = FromHandle(socketHandle);
+
+    while (true)
+    {
+        size_t newline = buffer.find('\n');
+        if (newline == std::string::npos)
+        {
+            return true;
+        }
+
+        std::string line = Trim(std::string_view{ buffer.data(), newline });
+        if (!line.empty() && line.back() == '\r')
+        {
+            line.pop_back();
+        }
+        buffer.erase(0, newline + 1);
+
+        if (line.empty())
+        {
+            continue;
+        }
+
+        std::string response = ExecuteCommand(std::move(line));
+        response.push_back('\n');
+        if (!SendAll(socket, response.data(), response.size()))
+        {
+            return false;
+        }
+    }
+}
+
+bool RconServer::HandleSourceBuffer(uintptr_t socketHandle, std::string &buffer, bool &authenticated)
+{
+    while (buffer.size() >= sizeof(int32_t))
+    {
+        int32_t packetSize = ReadInt32LE(buffer.data());
+        if (!IsValidSourcePacketSize(packetSize))
+        {
+            Platform::Print("RCON: malformed Source packet size %d\n", packetSize);
+            return false;
+        }
+
+        size_t fullPacketSize = sizeof(int32_t) + static_cast<size_t>(packetSize);
+        if (buffer.size() < fullPacketSize)
+        {
+            return true;
+        }
+
+        const char *packet = buffer.data() + sizeof(int32_t);
+        int32_t requestId = ReadInt32LE(packet);
+        int32_t type = ReadInt32LE(packet + sizeof(int32_t));
+        std::string_view payload{ packet + sizeof(int32_t) * 2, static_cast<size_t>(packetSize - sizeof(int32_t) * 2) };
+
+        size_t firstTerminator = payload.find('\0');
+        if (firstTerminator == std::string_view::npos)
+        {
+            Platform::Print("RCON: malformed Source packet without body terminator\n");
+            return false;
+        }
+
+        std::string_view body = payload.substr(0, firstTerminator);
+        std::string_view tail = payload.substr(firstTerminator + 1);
+        if (tail.empty() || tail.find('\0') == std::string_view::npos)
+        {
+            Platform::Print("RCON: malformed Source packet without empty terminator\n");
+            return false;
+        }
+
+        if (!HandleSourcePacket(socketHandle, requestId, type, body, authenticated))
+        {
+            return false;
+        }
+
+        buffer.erase(0, fullPacketSize);
+    }
+
+    return true;
+}
+
+bool RconServer::HandleSourcePacket(uintptr_t socketHandle, int32_t requestId, int32_t type, std::string_view body, bool &authenticated)
+{
+    SocketType socket = FromHandle(socketHandle);
+
+    if (type == SourceRconAuth)
+    {
+        authenticated = IsSourceRconPassword(body);
+        int32_t authResponseId = authenticated ? requestId : -1;
+
+        if (!authenticated)
+        {
+            Platform::Print("RCON: Source auth failed\n");
+        }
+
+        return SendSourcePacket(socket, requestId, SourceRconResponseValue, {})
+            && SendSourcePacket(socket, authResponseId, SourceRconAuthResponse, {});
+    }
+
+    if (type != SourceRconExecCommand)
+    {
+        std::string response = "ERR unsupported packet type";
+        return SendSourcePacket(socket, requestId, SourceRconResponseValue, response);
+    }
+
+    if (!authenticated)
+    {
+        std::string response = "ERR not authenticated";
+        return SendSourcePacket(socket, requestId, SourceRconResponseValue, response);
+    }
+
+    std::string command{ body };
+    std::string response = ExecuteCommand(std::move(command));
+    return SendSourcePacket(socket, requestId, SourceRconResponseValue, response);
+}
+
+bool RconServer::IsSourceRconPassword(std::string_view password) const
+{
+    const std::string &configuredPassword = GetConfig().RconPassword();
+    return configuredPassword.empty() || password == configuredPassword;
 }
 
 std::string RconServer::ExecuteCommand(std::string command)

--- a/csgo_gc/rcon_server.cpp
+++ b/csgo_gc/rcon_server.cpp
@@ -57,21 +57,6 @@ void CloseSocket(SocketType socket)
 #endif
 }
 
-std::string Trim(std::string_view value)
-{
-    while (!value.empty() && value.front() <= ' ')
-    {
-        value.remove_prefix(1);
-    }
-
-    while (!value.empty() && value.back() <= ' ')
-    {
-        value.remove_suffix(1);
-    }
-
-    return std::string{ value };
-}
-
 int32_t ReadInt32LE(const char *data)
 {
     const auto *bytes = reinterpret_cast<const unsigned char *>(data);
@@ -115,6 +100,11 @@ bool SendAll(SocketType socket, const char *data, size_t size)
 
 bool SendSourcePacket(SocketType socket, int32_t requestId, int32_t type, std::string_view body)
 {
+    if (body.size() > static_cast<size_t>(SourceRconMaxPacketSize - SourceRconMinPacketSize))
+    {
+        body = body.substr(0, static_cast<size_t>(SourceRconMaxPacketSize - SourceRconMinPacketSize));
+    }
+
     std::string packet;
     packet.reserve(sizeof(int32_t) * 3 + body.size() + 2);
     AppendInt32LE(packet, static_cast<int32_t>(sizeof(int32_t) * 2 + body.size() + 2));
@@ -137,7 +127,7 @@ RconServer::~RconServer()
 
 void RconServer::Start()
 {
-    Platform::Print("RCON: config enabled=%d bind_address=%s port=%u source=1 text=1 password=%s\n",
+    Platform::Print("RCON: config enabled=%d bind_address=%s port=%u protocol=source password=%s\n",
         GetConfig().RconEnabled() ? 1 : 0,
         GetConfig().RconBindAddress().c_str(),
         GetConfig().RconPort(),
@@ -324,7 +314,6 @@ void RconServer::HandleConnection(uintptr_t socketHandle)
 
     std::string buffer;
     char chunk[1024];
-    std::optional<bool> sourceMode;
     bool authenticated = false;
 
     while (m_running.load())
@@ -353,24 +342,7 @@ void RconServer::HandleConnection(uintptr_t socketHandle)
 
         buffer.append(chunk, chunk + received);
 
-        if (!sourceMode && buffer.size() >= sizeof(int32_t))
-        {
-            sourceMode = IsValidSourcePacketSize(ReadInt32LE(buffer.data()));
-        }
-
-        if (!sourceMode)
-        {
-            continue;
-        }
-
-        if (*sourceMode)
-        {
-            if (!HandleSourceBuffer(socketHandle, buffer, authenticated))
-            {
-                break;
-            }
-        }
-        else if (!HandleTextBuffer(socketHandle, buffer))
+        if (!HandlePacketBuffer(socketHandle, buffer, authenticated))
         {
             break;
         }
@@ -379,40 +351,7 @@ void RconServer::HandleConnection(uintptr_t socketHandle)
     CloseSocket(socket);
 }
 
-bool RconServer::HandleTextBuffer(uintptr_t socketHandle, std::string &buffer)
-{
-    SocketType socket = FromHandle(socketHandle);
-
-    while (true)
-    {
-        size_t newline = buffer.find('\n');
-        if (newline == std::string::npos)
-        {
-            return true;
-        }
-
-        std::string line = Trim(std::string_view{ buffer.data(), newline });
-        if (!line.empty() && line.back() == '\r')
-        {
-            line.pop_back();
-        }
-        buffer.erase(0, newline + 1);
-
-        if (line.empty())
-        {
-            continue;
-        }
-
-        std::string response = ExecuteCommand(std::move(line));
-        response.push_back('\n');
-        if (!SendAll(socket, response.data(), response.size()))
-        {
-            return false;
-        }
-    }
-}
-
-bool RconServer::HandleSourceBuffer(uintptr_t socketHandle, std::string &buffer, bool &authenticated)
+bool RconServer::HandlePacketBuffer(uintptr_t socketHandle, std::string &buffer, bool &authenticated)
 {
     while (buffer.size() >= sizeof(int32_t))
     {
@@ -449,7 +388,7 @@ bool RconServer::HandleSourceBuffer(uintptr_t socketHandle, std::string &buffer,
             return false;
         }
 
-        if (!HandleSourcePacket(socketHandle, requestId, type, body, authenticated))
+        if (!HandlePacket(socketHandle, requestId, type, body, authenticated))
         {
             return false;
         }
@@ -460,7 +399,7 @@ bool RconServer::HandleSourceBuffer(uintptr_t socketHandle, std::string &buffer,
     return true;
 }
 
-bool RconServer::HandleSourcePacket(uintptr_t socketHandle, int32_t requestId, int32_t type, std::string_view body, bool &authenticated)
+bool RconServer::HandlePacket(uintptr_t socketHandle, int32_t requestId, int32_t type, std::string_view body, bool &authenticated)
 {
     SocketType socket = FromHandle(socketHandle);
 

--- a/csgo_gc/rcon_server.cpp
+++ b/csgo_gc/rcon_server.cpp
@@ -498,7 +498,7 @@ std::string RconServer::ExecuteCommand(std::string command)
 
         if (name == "help")
         {
-            return "OK commands: help, ping, status, clients, give_item <defindex> [count], remove_item <itemid>, refresh_inventory";
+            return "OK commands: help, ping, status, clients, give_item <defindex> [count] [key=value...], remove_item <itemid>, refresh_inventory";
         }
 
         return "ERR no client gc";

--- a/csgo_gc/rcon_server.cpp
+++ b/csgo_gc/rcon_server.cpp
@@ -93,17 +93,25 @@ RconServer::~RconServer()
 
 void RconServer::Start()
 {
+    Platform::Print("RCON: config enabled=%d bind_address=%s port=%u\n",
+        GetConfig().RconEnabled() ? 1 : 0,
+        GetConfig().RconBindAddress().c_str(),
+        GetConfig().RconPort());
+
     if (!GetConfig().RconEnabled())
     {
+        Platform::Print("RCON: disabled\n");
         return;
     }
 
     bool expected = false;
     if (!m_running.compare_exchange_strong(expected, true))
     {
+        Platform::Print("RCON: already running\n");
         return;
     }
 
+    Platform::Print("RCON: starting listener thread\n");
     m_thread = std::thread{ &RconServer::ThreadMain, this };
 }
 
@@ -136,6 +144,8 @@ void RconServer::Stop()
 
 void RconServer::RegisterClient(ClientGC *client)
 {
+    Start();
+
     std::lock_guard lock{ m_mutex };
     m_client = client;
 }

--- a/csgo_gc/rcon_server.cpp
+++ b/csgo_gc/rcon_server.cpp
@@ -57,6 +57,20 @@ void CloseSocket(SocketType socket)
 #endif
 }
 
+void ShutdownSocket(SocketType socket)
+{
+    if (socket == InvalidSocket)
+    {
+        return;
+    }
+
+#ifdef _WIN32
+    shutdown(socket, SD_BOTH);
+#else
+    shutdown(socket, SHUT_RDWR);
+#endif
+}
+
 int32_t ReadInt32LE(const char *data)
 {
     const auto *bytes = reinterpret_cast<const unsigned char *>(data);
@@ -85,7 +99,12 @@ bool SendAll(SocketType socket, const char *data, size_t size)
 {
     while (size)
     {
-        int sent = send(socket, data, static_cast<int>(size), 0);
+#if defined(_WIN32) || !defined(MSG_NOSIGNAL)
+        constexpr int SendFlags = 0;
+#else
+        constexpr int SendFlags = MSG_NOSIGNAL;
+#endif
+        int sent = send(socket, data, static_cast<int>(size), SendFlags);
         if (sent <= 0)
         {
             return false;
@@ -169,6 +188,7 @@ void RconServer::Stop()
         m_listenSocket = ToHandle(InvalidSocket);
     }
 
+    ShutdownSocket(listenSocket);
     CloseSocket(listenSocket);
 
     if (m_thread.joinable())
@@ -302,6 +322,11 @@ void RconServer::ThreadMain()
 void RconServer::HandleConnection(uintptr_t socketHandle)
 {
     SocketType socket = FromHandle(socketHandle);
+
+#if !defined(_WIN32) && defined(SO_NOSIGPIPE)
+    int noSigPipe = 1;
+    setsockopt(socket, SOL_SOCKET, SO_NOSIGPIPE, &noSigPipe, sizeof(noSigPipe));
+#endif
 
 #ifdef _WIN32
     DWORD timeoutMs = 1000;

--- a/csgo_gc/rcon_server.cpp
+++ b/csgo_gc/rcon_server.cpp
@@ -1,0 +1,372 @@
+#include "stdafx.h"
+#include "rcon_server.h"
+#include "config.h"
+#include "gc_client.h"
+
+#ifdef _WIN32
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#else
+#include <arpa/inet.h>
+#include <errno.h>
+#include <netdb.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <unistd.h>
+#endif
+
+namespace
+{
+
+#ifdef _WIN32
+using SocketType = SOCKET;
+constexpr SocketType InvalidSocket = INVALID_SOCKET;
+#else
+using SocketType = int;
+constexpr SocketType InvalidSocket = -1;
+#endif
+
+SocketType FromHandle(uintptr_t handle)
+{
+    return static_cast<SocketType>(handle);
+}
+
+uintptr_t ToHandle(SocketType socket)
+{
+    return static_cast<uintptr_t>(socket);
+}
+
+void CloseSocket(SocketType socket)
+{
+    if (socket == InvalidSocket)
+    {
+        return;
+    }
+
+#ifdef _WIN32
+    closesocket(socket);
+#else
+    close(socket);
+#endif
+}
+
+std::string Trim(std::string_view value)
+{
+    while (!value.empty() && value.front() <= ' ')
+    {
+        value.remove_prefix(1);
+    }
+
+    while (!value.empty() && value.back() <= ' ')
+    {
+        value.remove_suffix(1);
+    }
+
+    return std::string{ value };
+}
+
+bool SendAll(SocketType socket, const char *data, size_t size)
+{
+    while (size)
+    {
+        int sent = send(socket, data, static_cast<int>(size), 0);
+        if (sent <= 0)
+        {
+            return false;
+        }
+
+        data += sent;
+        size -= sent;
+    }
+
+    return true;
+}
+
+} // namespace
+
+RconServer::RconServer() = default;
+
+RconServer::~RconServer()
+{
+    Stop();
+}
+
+void RconServer::Start()
+{
+    if (!GetConfig().RconEnabled())
+    {
+        return;
+    }
+
+    bool expected = false;
+    if (!m_running.compare_exchange_strong(expected, true))
+    {
+        return;
+    }
+
+    m_thread = std::thread{ &RconServer::ThreadMain, this };
+}
+
+void RconServer::Stop()
+{
+    bool expected = true;
+    if (!m_running.compare_exchange_strong(expected, false))
+    {
+        if (m_thread.joinable())
+        {
+            m_thread.join();
+        }
+        return;
+    }
+
+    SocketType listenSocket = InvalidSocket;
+    {
+        std::lock_guard lock{ m_mutex };
+        listenSocket = FromHandle(m_listenSocket);
+        m_listenSocket = ToHandle(InvalidSocket);
+    }
+
+    CloseSocket(listenSocket);
+
+    if (m_thread.joinable())
+    {
+        m_thread.join();
+    }
+}
+
+void RconServer::RegisterClient(ClientGC *client)
+{
+    std::lock_guard lock{ m_mutex };
+    m_client = client;
+}
+
+void RconServer::UnregisterClient(ClientGC *client)
+{
+    std::lock_guard lock{ m_mutex };
+    if (m_client == client)
+    {
+        m_client = nullptr;
+    }
+}
+
+void RconServer::ThreadMain()
+{
+#ifdef _WIN32
+    WSADATA wsaData;
+    if (WSAStartup(MAKEWORD(2, 2), &wsaData) != 0)
+    {
+        Platform::Print("RCON: WSAStartup failed\n");
+        m_running.store(false);
+        return;
+    }
+#endif
+
+    addrinfo hints{};
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_flags = AI_PASSIVE;
+
+    addrinfo *result = nullptr;
+    std::string port = std::to_string(GetConfig().RconPort());
+    int gai = getaddrinfo(GetConfig().RconBindAddress().c_str(), port.c_str(), &hints, &result);
+    if (gai != 0)
+    {
+        Platform::Print("RCON: getaddrinfo failed for %s:%s\n",
+            GetConfig().RconBindAddress().c_str(),
+            port.c_str());
+        m_running.store(false);
+#ifdef _WIN32
+        WSACleanup();
+#endif
+        return;
+    }
+
+    SocketType listenSocket = InvalidSocket;
+    for (addrinfo *it = result; it; it = it->ai_next)
+    {
+        listenSocket = socket(it->ai_family, it->ai_socktype, it->ai_protocol);
+        if (listenSocket == InvalidSocket)
+        {
+            continue;
+        }
+
+        int reuse = 1;
+        setsockopt(listenSocket, SOL_SOCKET, SO_REUSEADDR, reinterpret_cast<const char *>(&reuse), sizeof(reuse));
+
+        if (bind(listenSocket, it->ai_addr, static_cast<int>(it->ai_addrlen)) == 0
+            && listen(listenSocket, 8) == 0)
+        {
+            break;
+        }
+
+        CloseSocket(listenSocket);
+        listenSocket = InvalidSocket;
+    }
+
+    freeaddrinfo(result);
+
+    if (listenSocket == InvalidSocket)
+    {
+        Platform::Print("RCON: failed to listen on %s:%s\n",
+            GetConfig().RconBindAddress().c_str(),
+            port.c_str());
+        m_running.store(false);
+#ifdef _WIN32
+        WSACleanup();
+#endif
+        return;
+    }
+
+    {
+        std::lock_guard lock{ m_mutex };
+        m_listenSocket = ToHandle(listenSocket);
+    }
+
+    Platform::Print("RCON: listening on %s:%s\n", GetConfig().RconBindAddress().c_str(), port.c_str());
+
+    while (m_running.load())
+    {
+        SocketType clientSocket = accept(listenSocket, nullptr, nullptr);
+        if (clientSocket == InvalidSocket)
+        {
+            if (m_running.load())
+            {
+                Platform::Print("RCON: accept failed\n");
+            }
+            break;
+        }
+
+        HandleConnection(ToHandle(clientSocket));
+    }
+
+    {
+        std::lock_guard lock{ m_mutex };
+        m_listenSocket = ToHandle(InvalidSocket);
+    }
+
+    if (m_running.load())
+    {
+        CloseSocket(listenSocket);
+    }
+
+#ifdef _WIN32
+    WSACleanup();
+#endif
+}
+
+void RconServer::HandleConnection(uintptr_t socketHandle)
+{
+    SocketType socket = FromHandle(socketHandle);
+
+#ifdef _WIN32
+    DWORD timeoutMs = 1000;
+    setsockopt(socket, SOL_SOCKET, SO_RCVTIMEO, reinterpret_cast<const char *>(&timeoutMs), sizeof(timeoutMs));
+#else
+    timeval timeout{};
+    timeout.tv_sec = 1;
+    setsockopt(socket, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout));
+#endif
+
+    std::string buffer;
+    char chunk[1024];
+
+    while (m_running.load())
+    {
+        int received = recv(socket, chunk, sizeof(chunk), 0);
+        if (received == 0)
+        {
+            break;
+        }
+
+        if (received < 0)
+        {
+#ifndef _WIN32
+            if (errno == EAGAIN || errno == EWOULDBLOCK)
+            {
+                continue;
+            }
+#else
+            if (WSAGetLastError() == WSAETIMEDOUT)
+            {
+                continue;
+            }
+#endif
+            break;
+        }
+
+        buffer.append(chunk, chunk + received);
+
+        while (true)
+        {
+            size_t newline = buffer.find('\n');
+            if (newline == std::string::npos)
+            {
+                break;
+            }
+
+            std::string line = Trim(std::string_view{ buffer.data(), newline });
+            if (!line.empty() && line.back() == '\r')
+            {
+                line.pop_back();
+            }
+            buffer.erase(0, newline + 1);
+
+            if (line.empty())
+            {
+                continue;
+            }
+
+            std::string response = ExecuteCommand(std::move(line));
+            response.push_back('\n');
+            if (!SendAll(socket, response.data(), response.size()))
+            {
+                CloseSocket(socket);
+                return;
+            }
+        }
+    }
+
+    CloseSocket(socket);
+}
+
+std::string RconServer::ExecuteCommand(std::string command)
+{
+    std::istringstream stream{ command };
+    std::string name;
+    stream >> name;
+
+    for (char &ch : name)
+    {
+        ch = static_cast<char>(tolower(static_cast<unsigned char>(ch)));
+    }
+
+    if (name == "ping")
+    {
+        return "OK pong";
+    }
+
+    std::lock_guard lock{ m_mutex };
+    ClientGC *client = m_client;
+
+    if (!client)
+    {
+        if (name == "status")
+        {
+            return "OK rcon=enabled client=none";
+        }
+
+        if (name == "clients")
+        {
+            return "OK no clients";
+        }
+
+        if (name == "help")
+        {
+            return "OK commands: help, ping, status, clients, give_item <defindex> [count], remove_item <itemid>, refresh_inventory";
+        }
+
+        return "ERR no client gc";
+    }
+
+    return client->RunRconCommand(std::move(command));
+}

--- a/csgo_gc/rcon_server.cpp
+++ b/csgo_gc/rcon_server.cpp
@@ -207,10 +207,11 @@ void RconServer::RegisterClient(ClientGC *client)
 
 void RconServer::UnregisterClient(ClientGC *client)
 {
-    std::lock_guard lock{ m_mutex };
+    std::unique_lock lock{ m_mutex };
     if (m_client == client)
     {
         m_client = nullptr;
+        m_clientIdle.wait(lock, [this] { return m_activeClientCommands == 0; });
     }
 }
 
@@ -481,28 +482,38 @@ std::string RconServer::ExecuteCommand(std::string command)
         return "OK pong";
     }
 
-    std::lock_guard lock{ m_mutex };
-    ClientGC *client = m_client;
-
-    if (!client)
     {
-        if (name == "status")
-        {
-            return "OK rcon=enabled client=none";
-        }
+        std::unique_lock lock{ m_mutex };
+        ClientGC *client = m_client;
 
-        if (name == "clients")
+        if (client)
         {
-            return "OK no clients";
-        }
+            m_activeClientCommands++;
+            lock.unlock();
 
-        if (name == "help")
-        {
-            return "OK commands: help, ping, status, clients, give_item <defindex> [count] [key=value...], remove_item <itemid>, refresh_inventory";
-        }
+            std::string response = client->RunRconCommand(std::move(command));
 
-        return "ERR no client gc";
+            std::lock_guard finishLock{ m_mutex };
+            m_activeClientCommands--;
+            m_clientIdle.notify_all();
+            return response;
+        }
     }
 
-    return client->RunRconCommand(std::move(command));
+    if (name == "status")
+    {
+        return "OK rcon=enabled client=none";
+    }
+
+    if (name == "clients")
+    {
+        return "OK no clients";
+    }
+
+    if (name == "help")
+    {
+        return "OK commands: help, ping, status, clients, give_item <defindex> [count] [key=value...], remove_item <itemid>, refresh_inventory";
+    }
+
+    return "ERR no client gc";
 }

--- a/csgo_gc/rcon_server.cpp
+++ b/csgo_gc/rcon_server.cpp
@@ -139,6 +139,39 @@ bool SendSourcePacket(SocketType socket, int32_t requestId, int32_t type, std::s
 
 RconServer::RconServer() = default;
 
+class RconServer::ActiveClientCommand
+{
+public:
+    explicit ActiveClientCommand(RconServer &server)
+        : m_server{ server }
+    {
+        std::lock_guard lock{ m_server.m_mutex };
+        m_client = m_server.m_client;
+        if (m_client)
+        {
+            m_server.m_activeClientCommands++;
+        }
+    }
+
+    ~ActiveClientCommand()
+    {
+        if (!m_client)
+        {
+            return;
+        }
+
+        std::lock_guard lock{ m_server.m_mutex };
+        m_server.m_activeClientCommands--;
+        m_server.m_clientIdle.notify_all();
+    }
+
+    ClientGC *Client() const { return m_client; }
+
+private:
+    RconServer &m_server;
+    ClientGC *m_client{};
+};
+
 RconServer::~RconServer()
 {
     Stop();
@@ -482,22 +515,10 @@ std::string RconServer::ExecuteCommand(std::string command)
         return "OK pong";
     }
 
+    ActiveClientCommand activeCommand{ *this };
+    if (ClientGC *client = activeCommand.Client())
     {
-        std::unique_lock lock{ m_mutex };
-        ClientGC *client = m_client;
-
-        if (client)
-        {
-            m_activeClientCommands++;
-            lock.unlock();
-
-            std::string response = client->RunRconCommand(std::move(command));
-
-            std::lock_guard finishLock{ m_mutex };
-            m_activeClientCommands--;
-            m_clientIdle.notify_all();
-            return response;
-        }
+        return client->RunRconCommand(std::move(command));
     }
 
     if (name == "status")

--- a/csgo_gc/rcon_server.h
+++ b/csgo_gc/rcon_server.h
@@ -22,6 +22,8 @@ private:
     bool IsSourceRconPassword(std::string_view password) const;
     std::string ExecuteCommand(std::string command);
 
+    class ActiveClientCommand;
+
     std::mutex m_mutex;
     std::condition_variable m_clientIdle;
     ClientGC *m_client{};

--- a/csgo_gc/rcon_server.h
+++ b/csgo_gc/rcon_server.h
@@ -23,7 +23,9 @@ private:
     std::string ExecuteCommand(std::string command);
 
     std::mutex m_mutex;
+    std::condition_variable m_clientIdle;
     ClientGC *m_client{};
+    size_t m_activeClientCommands{};
     std::thread m_thread;
     std::atomic<bool> m_running{ false };
     uintptr_t m_listenSocket{ UINTPTR_MAX };

--- a/csgo_gc/rcon_server.h
+++ b/csgo_gc/rcon_server.h
@@ -1,0 +1,27 @@
+#pragma once
+
+class ClientGC;
+
+class RconServer
+{
+public:
+    RconServer();
+    ~RconServer();
+
+    void Start();
+    void Stop();
+
+    void RegisterClient(ClientGC *client);
+    void UnregisterClient(ClientGC *client);
+
+private:
+    void ThreadMain();
+    void HandleConnection(uintptr_t socketHandle);
+    std::string ExecuteCommand(std::string command);
+
+    std::mutex m_mutex;
+    ClientGC *m_client{};
+    std::thread m_thread;
+    std::atomic<bool> m_running{ false };
+    uintptr_t m_listenSocket{ UINTPTR_MAX };
+};

--- a/csgo_gc/rcon_server.h
+++ b/csgo_gc/rcon_server.h
@@ -17,6 +17,9 @@ public:
 private:
     void ThreadMain();
     void HandleConnection(uintptr_t socketHandle);
+    bool HandlePacketBuffer(uintptr_t socketHandle, std::string &buffer, bool &authenticated);
+    bool HandlePacket(uintptr_t socketHandle, int32_t requestId, int32_t type, std::string_view body, bool &authenticated);
+    bool IsSourceRconPassword(std::string_view password) const;
     std::string ExecuteCommand(std::string command);
 
     std::mutex m_mutex;

--- a/csgo_gc/stdafx.h
+++ b/csgo_gc/stdafx.h
@@ -1,14 +1,20 @@
 #pragma once
 
 #include <assert.h>
+#include <ctype.h>
+#include <stdint.h>
 
 #include <array>
 #include <atomic>
 #include <charconv>
 #include <condition_variable>
+#include <chrono>
+#include <future>
+#include <memory>
 #include <optional>
 #include <queue>
 #include <random>
+#include <sstream>
 #include <string>
 #include <thread>
 #include <type_traits>

--- a/csgo_gc/steam_hook.cpp
+++ b/csgo_gc/steam_hook.cpp
@@ -15,6 +15,7 @@
 #include "gc_client.h"
 #include "gc_server.h"
 #include "platform.h"
+#include "rcon_server.h"
 #include <funchook.h>
 
 #ifdef _WIN32
@@ -153,6 +154,7 @@ public:
 // client connect/disconnect notifications
 static GCWrapper<ClientGC, NetworkingClient> *s_clientGC;
 static GCWrapper<ServerGC, NetworkingServer> *s_serverGC;
+static RconServer s_rconServer;
 
 struct PlayerInfo
 {
@@ -505,6 +507,7 @@ public:
         {
             assert(!s_clientGC);
             s_clientGC = new GCWrapper<ClientGC, NetworkingClient>{ SteamNetworkingMessages(), steamId };
+            s_rconServer.RegisterClient(&s_clientGC->m_gc);
         }
     }
 
@@ -519,6 +522,7 @@ public:
         else
         {
             assert(s_clientGC);
+            s_rconServer.UnregisterClient(&s_clientGC->m_gc);
             delete s_clientGC;
             s_clientGC = nullptr;
         }
@@ -2410,4 +2414,6 @@ void SteamHookInstall(bool dedicated)
     INLINE_HOOK(SteamAPI_UnregisterCallback);
     INLINE_HOOK(SteamAPI_RunCallbacks);
     INLINE_HOOK(SteamGameServer_RunCallbacks);
+
+    s_rconServer.Start();
 }

--- a/docs/rcon.md
+++ b/docs/rcon.md
@@ -1,0 +1,217 @@
+# RCON
+
+csgo_gc exposes an optional Source RCON-compatible control port for the local
+ClientGC. It is intended for scripting, debugging, and tools that need to update
+the live inventory without restarting CS:GO.
+
+RCON is disabled by default.
+
+## Configuration
+
+Add an `rcon` block to `csgo_gc/config.txt`:
+
+```text
+"rcon"
+{
+    "enabled"      "1"
+    "bind_address" "127.0.0.1"
+    "port"         "37016"
+    "password"     ""
+}
+```
+
+Options:
+
+- `enabled`: `1` starts the RCON listener. Missing or `0` leaves it disabled.
+- `bind_address`: defaults to `127.0.0.1`. Keep this local unless you have added
+  your own network protection.
+- `port`: defaults to `37016`.
+- `password`: Source RCON password. An empty configured password intentionally
+  accepts any supplied Source RCON password for compatibility with this custom GC.
+
+The setting is read when the GC is loaded. There is no config hot reload.
+
+Startup logs include the configured bind address, port, protocol, and whether the
+password is empty, without printing the password.
+
+## Protocol
+
+The listener speaks the Source RCON binary protocol:
+
+- Little-endian size-prefixed packets.
+- `SERVERDATA_AUTH` for authentication.
+- `SERVERDATA_EXECCOMMAND` for commands.
+- `SERVERDATA_RESPONSE_VALUE` / `SERVERDATA_AUTH_RESPONSE` for responses.
+
+Raw newline text mode is not supported. Use a Source RCON client or a script that
+implements Source RCON packets.
+
+Example:
+
+```powershell
+rcon -a 127.0.0.1:37016 -p 1 ping
+```
+
+Expected response body:
+
+```text
+OK pong
+```
+
+Basic connectivity check:
+
+```powershell
+Test-NetConnection 127.0.0.1 -Port 37016
+```
+
+## Response Format
+
+Command responses are plain text inside Source RCON response packets:
+
+```text
+OK <message>
+ERR <message>
+```
+
+Examples:
+
+```text
+OK pong
+OK item_ids=1234567890123
+ERR no client gc
+ERR unknown parameter foo
+```
+
+## Commands
+
+### `help`
+
+Lists available commands.
+
+### `ping`
+
+Returns:
+
+```text
+OK pong
+```
+
+This works as long as the RCON server is online, even if no ClientGC is currently
+registered.
+
+### `status`
+
+Returns RCON and ClientGC state. If the game client GC is online, the response
+includes the local SteamID and basic inventory stats.
+
+### `clients`
+
+Lists the controllable ClientGC instance. v1 only controls the local ClientGC.
+
+### `give_item`
+
+Creates one or more inventory items and sends live SO create updates to the game.
+
+Syntax:
+
+```text
+give_item <defindex> [count] [key=value...]
+```
+
+Compatibility forms:
+
+```text
+give_item 7
+give_item 7 5
+```
+
+Parameterized examples:
+
+```text
+give_item 7 paint=44
+give_item 7 paint=44 wear=0.12 seed=123 stattrak=5
+give_item 7 paint=44 name="RCON Test"
+give_item 1314 music=3 stattrak=10
+give_item 7 paint=44 sticker0=12 sticker0_wear=0
+```
+
+Rules:
+
+- `count` is optional and must be `1..100`.
+- Parameters are `key=value`.
+- Keys are case-insensitive.
+- Values may be double quoted. Backslash escapes the next character inside
+  quotes.
+- Unknown keys return `ERR unknown parameter <key>`.
+- Invalid numeric values return `ERR invalid parameter <key>`.
+- Successful creation returns `OK item_ids=...`.
+
+Supported parameters:
+
+| Parameter | Type | Notes |
+| --- | --- | --- |
+| `level` | uint32 | Overrides item level. |
+| `quality` | uint32 | Explicit quality override. |
+| `rarity` | uint32 | Explicit rarity override. |
+| `name` | string | Sets the custom item name. Quote values containing spaces. |
+| `paint` | uint32 | Paint kit defindex. Must exist in the item schema. |
+| `seed` | uint32 | Paint seed. |
+| `wear` | float | Paint wear, `0.0..1.0`. |
+| `stattrak` | uint32 | Kill count. `stattrak=1` creates StatTrak with 0 kills. |
+| `music` | uint32 | Music definition id. Requires music kit defindex `1314`. |
+| `spray_color` | uint32 | Graffiti tint id. |
+| `spray_remaining` | uint32 | Remaining spray uses. |
+| `sticker0`..`sticker5` | uint32 | Sticker kit defindex. Must exist in the item schema. |
+| `stickerN_wear` | float | Sticker wear, `0.0..1.0`. |
+| `stickerN_scale` | float | Sticker scale. |
+| `stickerN_rotation` | float | Sticker rotation. |
+
+Derived defaults:
+
+- `paint` adds paint kit, seed, and wear attributes. If not explicitly set,
+  `seed=0`, `wear=0.001`, `quality=Unique`, and painted rarity are applied.
+- `stattrak` adds kill eater attributes. Non-music items use score type `0`.
+- `music` adds music id and music-kit score type `1`. It requires `defindex=1314`.
+- `stickerN` adds sticker id and defaults that slot's wear to `0` unless
+  `stickerN_wear` is supplied.
+- Explicit `quality` and `rarity` override derived defaults.
+- If no parameters are supplied, the command uses the original basic purchase
+  path.
+
+### `remove_item`
+
+Removes an item and sends a live SO destroy update to the game.
+
+Syntax:
+
+```text
+remove_item <itemid>
+```
+
+### `refresh_inventory`
+
+Resends the full inventory cache subscription to the game. This is a repair and
+debug command, not the normal path for adding items.
+
+## Common Errors
+
+```text
+ERR no client gc
+ERR unknown defindex
+ERR unknown paint
+ERR unknown music
+ERR unknown sticker
+ERR item not found
+ERR usage: give_item <defindex> [count] [key=value...]
+ERR invalid parameter wear
+```
+
+`ERR no client gc` means the RCON listener is running, but the local ClientGC has
+not registered yet or has already been destroyed.
+
+## Safety Notes
+
+The default bind address is `127.0.0.1` because RCON can mutate local GC state and
+inventory. Do not bind to a public interface without adding your own access
+controls. Source RCON compatibility is provided for tooling convenience; it is
+not TLS-protected.

--- a/examples/config.txt
+++ b/examples/config.txt
@@ -40,8 +40,8 @@
 // only show servers with the "csgo_gc" tag in the server browser
 "show_csgo_gc_servers_only"	"1"
 
-// local unauthenticated text RCON. keep bind_address on localhost unless you
-// add authentication. empty password accepts any Source RCON password.
+// local Source RCON. keep bind_address on localhost unless you use a password.
+// empty password accepts any Source RCON password.
 "rcon"
 {
 	"enabled"		"0"

--- a/examples/config.txt
+++ b/examples/config.txt
@@ -40,6 +40,15 @@
 // only show servers with the "csgo_gc" tag in the server browser
 "show_csgo_gc_servers_only"	"1"
 
+// local unauthenticated text RCON. keep bind_address on localhost unless you
+// add authentication.
+"rcon"
+{
+	"enabled"		"0"
+	"bind_address"	"127.0.0.1"
+	"port"			"37016"
+}
+
 // 0 = don't log anything
 // 1 = log to in-game console
 // 2 = log to in-game console and file (gc_log.txt)

--- a/examples/config.txt
+++ b/examples/config.txt
@@ -41,12 +41,13 @@
 "show_csgo_gc_servers_only"	"1"
 
 // local unauthenticated text RCON. keep bind_address on localhost unless you
-// add authentication.
+// add authentication. empty password accepts any Source RCON password.
 "rcon"
 {
 	"enabled"		"0"
 	"bind_address"	"127.0.0.1"
 	"port"			"37016"
+	"password"		""
 }
 
 // 0 = don't log anything


### PR DESCRIPTION
## Summary
- Add an RCON server implementation and wire it into the GC/client runtime.
- Extend config, networking, and platform code to support the new RCON flow.
- Update inventory, item schema, souvenir, and graffiti handling to align with the new behavior.
- Refresh build/docs files and example config to describe the new functionality.

## Testing
- Not run (not requested)
- Build and runtime validation should cover the updated `csgo_gc` target and basic RCON interaction paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional local Source RCON control, including a running command server.
  * Implemented RCON commands: `help`, `ping`, `status`, `clients`, `give_item`, `remove_item`, and `refresh_inventory`.
  * Expanded item creation to support parameterized customization (e.g., paint, music kits, StatTrak, and stickers).
* **Bug Fixes**
  * Improved RCON configuration parsing from `config.txt`, with warnings when RCON is enabled but no password is set.
* **Documentation**
  * Updated RCON documentation, build/setup notes, README feature lists, and the example `config.txt` with an `rcon` block.
* **Chores / Build**
  * Refined build configuration for thread and platform library linkage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->