### PR TITLE
Support legacy souvenir loot lists

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,6 +69,7 @@ jobs:
         cp $GITHUB_WORKSPACE/examples/config.txt $GITHUB_WORKSPACE/release/csgo_gc/
         cp $GITHUB_WORKSPACE/examples/inventory.txt $GITHUB_WORKSPACE/release/csgo_gc/
         cp $GITHUB_WORKSPACE/examples/price_sheet.txt $GITHUB_WORKSPACE/release/csgo_gc/
+        cp $GITHUB_WORKSPACE/examples/gc_loot_lists.txt $GITHUB_WORKSPACE/release/csgo_gc/
         cp $GITHUB_WORKSPACE/examples/unusual_loot_lists.txt $GITHUB_WORKSPACE/release/csgo_gc/
 
     - name: Zip artifacts (Windows)

--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ how package loot lists differ from souvenir sticker metadata.
 ## Configuration
 See [csgo_gc/config.txt](examples/config.txt) for available options.
 
-Server-only loot lists that are missing from the client item schema are stored
-in [csgo_gc/gc_loot_lists.txt](examples/gc_loot_lists.txt). An external loot
-list can include an `item_sets` block to reuse collections from
+Supplemental server-only loot lists that are missing from the client schema are
+stored in [csgo_gc/gc_loot_lists.txt](examples/gc_loot_lists.txt). An external
+loot list can include an `item_sets` block to reuse collections from
 `items_game.txt` without duplicating every item in the collection.
 
 ## RCON

--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ The local RCON interface can also create and remove items while the game is runn
 ## Configuration
 See [csgo_gc/config.txt](examples/config.txt) for available options.
 
+Server-only loot lists that are missing from the client item schema are stored
+in [csgo_gc/gc_loot_lists.txt](examples/gc_loot_lists.txt). An external loot
+list can include an `item_sets` block to reuse collections from
+`items_game.txt` without duplicating every item in the collection.
+
 ## RCON
 RCON is disabled by default and binds to localhost with the default configuration; the actual listen address is controlled by `bind_address`. It uses the Source RCON binary protocol, so existing Source RCON clients can be used.
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ Inventory can still be edited offline through `inventory.txt`. For manual editin
 
 The local RCON interface can also create and remove items while the game is running. This is intended for scripts and GUI editors that want to avoid the old edit-file-and-restart workflow.
 
+See [Souvenir Packages](docs/souvenirs.md) for tournament attributes, examples
+for different Major eras, manual `inventory.txt` editing, and an explanation of
+how package loot lists differ from souvenir sticker metadata.
+
 ## Configuration
 See [csgo_gc/config.txt](examples/config.txt) for available options.
 

--- a/csgo_gc/gc_client.cpp
+++ b/csgo_gc/gc_client.cpp
@@ -822,23 +822,23 @@ std::string ClientGC::RconGiveItem(const RconRequest &request)
         }
         else if (key == "tournament_event")
         {
-            error = parseUint32(options.tournamentEvent);
+            error = parseUint32(options.tournament.eventId);
         }
         else if (key == "tournament_stage")
         {
-            error = parseUint32(options.tournamentStage);
+            error = parseUint32(options.tournament.stageId);
         }
         else if (key == "tournament_team0")
         {
-            error = parseUint32(options.tournamentTeam0);
+            error = parseUint32(options.tournament.team0Id);
         }
         else if (key == "tournament_team1")
         {
-            error = parseUint32(options.tournamentTeam1);
+            error = parseUint32(options.tournament.team1Id);
         }
         else if (key == "tournament_mvp")
         {
-            error = parseUint32(options.tournamentMvp);
+            error = parseUint32(options.tournament.mvpAccountId);
         }
         else if (key.rfind("sticker", 0) == 0 && key.size() >= 8 && key[7] >= '0' && key[7] <= '5')
         {

--- a/csgo_gc/gc_client.cpp
+++ b/csgo_gc/gc_client.cpp
@@ -820,6 +820,22 @@ std::string ClientGC::RconGiveItem(const RconRequest &request)
         {
             error = parseUint32(options.sprayRemaining);
         }
+        else if (key == "tournament_event")
+        {
+            error = parseUint32(options.tournamentEvent);
+        }
+        else if (key == "tournament_stage")
+        {
+            error = parseUint32(options.tournamentStage);
+        }
+        else if (key == "tournament_team0")
+        {
+            error = parseUint32(options.tournamentTeam0);
+        }
+        else if (key == "tournament_team1")
+        {
+            error = parseUint32(options.tournamentTeam1);
+        }
         else if (key.rfind("sticker", 0) == 0 && key.size() >= 8 && key[7] >= '0' && key[7] <= '5')
         {
             size_t stickerSlot = static_cast<size_t>(key[7] - '0');

--- a/csgo_gc/gc_client.cpp
+++ b/csgo_gc/gc_client.cpp
@@ -836,6 +836,10 @@ std::string ClientGC::RconGiveItem(const RconRequest &request)
         {
             error = parseUint32(options.tournamentTeam1);
         }
+        else if (key == "tournament_mvp")
+        {
+            error = parseUint32(options.tournamentMvp);
+        }
         else if (key.rfind("sticker", 0) == 0 && key.size() >= 8 && key[7] >= '0' && key[7] <= '5')
         {
             size_t stickerSlot = static_cast<size_t>(key[7] - '0');

--- a/csgo_gc/inventory.cpp
+++ b/csgo_gc/inventory.cpp
@@ -2063,6 +2063,22 @@ uint64_t Inventory::CreateParameterizedItem(uint32_t defIndex,
         m_itemSchema.SetAttributeUint32(attribute, *options.sprayRemaining);
     }
 
+    auto setTournamentAttribute = [&](const std::optional<uint32_t> &value, uint32_t attributeDefIndex)
+    {
+        if (!value)
+        {
+            return;
+        }
+
+        CSOEconItemAttribute *attribute = FindOrAddAttribute(item, attributeDefIndex);
+        m_itemSchema.SetAttributeUint32(attribute, *value);
+    };
+
+    setTournamentAttribute(options.tournamentEvent, ItemSchema::AttributeTournamentEventId);
+    setTournamentAttribute(options.tournamentStage, ItemSchema::AttributeTournamentEventStageId);
+    setTournamentAttribute(options.tournamentTeam0, ItemSchema::AttributeTournamentTeam0Id);
+    setTournamentAttribute(options.tournamentTeam1, ItemSchema::AttributeTournamentTeam1Id);
+
     for (size_t i = 0; i < options.sticker.size(); i++)
     {
         if (options.sticker[i])

--- a/csgo_gc/inventory.cpp
+++ b/csgo_gc/inventory.cpp
@@ -2074,11 +2074,11 @@ uint64_t Inventory::CreateParameterizedItem(uint32_t defIndex,
         m_itemSchema.SetAttributeUint32(attribute, *value);
     };
 
-    setTournamentAttribute(options.tournamentEvent, ItemSchema::AttributeTournamentEventId);
-    setTournamentAttribute(options.tournamentStage, ItemSchema::AttributeTournamentEventStageId);
-    setTournamentAttribute(options.tournamentTeam0, ItemSchema::AttributeTournamentTeam0Id);
-    setTournamentAttribute(options.tournamentTeam1, ItemSchema::AttributeTournamentTeam1Id);
-    setTournamentAttribute(options.tournamentMvp, ItemSchema::AttributeTournamentMvpAccountId);
+    setTournamentAttribute(options.tournament.eventId, ItemSchema::AttributeTournamentEventId);
+    setTournamentAttribute(options.tournament.stageId, ItemSchema::AttributeTournamentEventStageId);
+    setTournamentAttribute(options.tournament.team0Id, ItemSchema::AttributeTournamentTeam0Id);
+    setTournamentAttribute(options.tournament.team1Id, ItemSchema::AttributeTournamentTeam1Id);
+    setTournamentAttribute(options.tournament.mvpAccountId, ItemSchema::AttributeTournamentMvpAccountId);
 
     for (size_t i = 0; i < options.sticker.size(); i++)
     {

--- a/csgo_gc/inventory.cpp
+++ b/csgo_gc/inventory.cpp
@@ -2078,6 +2078,7 @@ uint64_t Inventory::CreateParameterizedItem(uint32_t defIndex,
     setTournamentAttribute(options.tournamentStage, ItemSchema::AttributeTournamentEventStageId);
     setTournamentAttribute(options.tournamentTeam0, ItemSchema::AttributeTournamentTeam0Id);
     setTournamentAttribute(options.tournamentTeam1, ItemSchema::AttributeTournamentTeam1Id);
+    setTournamentAttribute(options.tournamentMvp, ItemSchema::AttributeTournamentMvpAccountId);
 
     for (size_t i = 0; i < options.sticker.size(); i++)
     {

--- a/csgo_gc/inventory.h
+++ b/csgo_gc/inventory.h
@@ -28,6 +28,10 @@ public:
         std::optional<uint32_t> music;
         std::optional<uint32_t> sprayColor;
         std::optional<uint32_t> sprayRemaining;
+        std::optional<uint32_t> tournamentEvent;
+        std::optional<uint32_t> tournamentStage;
+        std::optional<uint32_t> tournamentTeam0;
+        std::optional<uint32_t> tournamentTeam1;
 
         std::array<std::optional<uint32_t>, 6> sticker;
         std::array<std::optional<float>, 6> stickerWear;

--- a/csgo_gc/inventory.h
+++ b/csgo_gc/inventory.h
@@ -32,6 +32,7 @@ public:
         std::optional<uint32_t> tournamentStage;
         std::optional<uint32_t> tournamentTeam0;
         std::optional<uint32_t> tournamentTeam1;
+        std::optional<uint32_t> tournamentMvp;
 
         std::array<std::optional<uint32_t>, 6> sticker;
         std::array<std::optional<float>, 6> stickerWear;

--- a/csgo_gc/inventory.h
+++ b/csgo_gc/inventory.h
@@ -16,6 +16,15 @@ public:
 
     struct ParameterizedItemOptions
     {
+        struct TournamentOptions
+        {
+            std::optional<uint32_t> eventId;
+            std::optional<uint32_t> stageId;
+            std::optional<uint32_t> team0Id;
+            std::optional<uint32_t> team1Id;
+            std::optional<uint32_t> mvpAccountId;
+        };
+
         std::optional<uint32_t> level;
         std::optional<uint32_t> quality;
         std::optional<uint32_t> rarity;
@@ -28,11 +37,7 @@ public:
         std::optional<uint32_t> music;
         std::optional<uint32_t> sprayColor;
         std::optional<uint32_t> sprayRemaining;
-        std::optional<uint32_t> tournamentEvent;
-        std::optional<uint32_t> tournamentStage;
-        std::optional<uint32_t> tournamentTeam0;
-        std::optional<uint32_t> tournamentTeam1;
-        std::optional<uint32_t> tournamentMvp;
+        TournamentOptions tournament;
 
         std::array<std::optional<uint32_t>, 6> sticker;
         std::array<std::optional<float>, 6> stickerWear;

--- a/csgo_gc/item_schema.cpp
+++ b/csgo_gc/item_schema.cpp
@@ -92,6 +92,7 @@ PaintKitInfo::PaintKitInfo(const KeyValue &key)
 
 StickerKitInfo::StickerKitInfo(const KeyValue &key)
     : m_defIndex{ FromString<uint32_t>(key.Name()) }
+    , m_name{ key.GetString("name") }
     , m_rarity{ ItemSchema::RarityDefault }
     , m_tournamentEventId{ 0 }
     , m_tournamentTeamId{ 0 }
@@ -1217,32 +1218,51 @@ StickerKitInfo *ItemSchema::StickerKitInfoByName(std::string_view name)
     return &it->second;
 }
 
-const StickerKitInfo *ItemSchema::StickerKitByTournamentEventId(uint32_t eventId) const
+const StickerKitInfo *ItemSchema::StickerKitInfoByName(std::string_view name) const
+{
+    auto it = m_stickerKitInfo.find(std::string{ name });
+    if (it == m_stickerKitInfo.end())
+    {
+        return nullptr;
+    }
+
+    return &it->second;
+}
+
+void ItemSchema::GetStickerKitsByTournamentEventId(uint32_t eventId, std::vector<const StickerKitInfo *> &out) const
 {
     for (const auto &pair : m_stickerKitInfo)
     {
         const StickerKitInfo &info = pair.second;
         if (info.m_tournamentEventId == eventId && info.m_tournamentTeamId == 0 && info.m_tournamentPlayerId == 0)
         {
-            return &info;
+            out.push_back(&info);
         }
     }
-
-    return nullptr;
 }
 
-const StickerKitInfo *ItemSchema::StickerKitByTournamentTeamId(uint32_t eventId, uint32_t teamId) const
+void ItemSchema::GetStickerKitsByTournamentTeamId(uint32_t eventId, uint32_t teamId, std::vector<const StickerKitInfo *> &out) const
 {
     for (const auto &pair : m_stickerKitInfo)
     {
         const StickerKitInfo &info = pair.second;
         if (info.m_tournamentEventId == eventId && info.m_tournamentTeamId == teamId && info.m_tournamentPlayerId == 0)
         {
-            return &info;
+            out.push_back(&info);
         }
     }
+}
 
-    return nullptr;
+void ItemSchema::GetStickerKitsByTournamentPlayerId(uint32_t eventId, uint32_t playerId, std::vector<const StickerKitInfo *> &out) const
+{
+    for (const auto &pair : m_stickerKitInfo)
+    {
+        const StickerKitInfo &info = pair.second;
+        if (info.m_tournamentEventId == eventId && info.m_tournamentPlayerId == playerId)
+        {
+            out.push_back(&info);
+        }
+    }
 }
 
 const StickerKitInfo *ItemSchema::StickerKitInfoByDefIndex(uint32_t defIndex) const

--- a/csgo_gc/item_schema.cpp
+++ b/csgo_gc/item_schema.cpp
@@ -68,6 +68,10 @@ ItemInfo::ItemInfo(uint32_t defIndex)
     , m_quality{ ItemSchema::QualityNormal }
     , m_level{ 1 }
     , m_supplyCrateSeries{ 0 }
+    , m_tournamentEventId{ 0 }
+    , m_tournamentEventStageId{ 0 }
+    , m_tournamentTeam0Id{ 0 }
+    , m_tournamentTeam1Id{ 0 }
     , m_canSticker{ false }
     , m_canPatch{ false }
     , m_nameable{ false }
@@ -802,6 +806,20 @@ void ItemSchema::ParseItemRecursive(ItemInfo &info, const KeyValue &itemKey, con
         {
             info.m_supplyCrateSeries = supplyCrateSeries->GetNumber<uint32_t>("value");
         }
+
+        auto parseTournamentAttribute = [&](std::string_view name, uint32_t &value)
+        {
+            const KeyValue *attribute = attributes->GetSubkey(name);
+            if (attribute)
+            {
+                value = attribute->GetNumber<uint32_t>("value");
+            }
+        };
+
+        parseTournamentAttribute("tournament event id", info.m_tournamentEventId);
+        parseTournamentAttribute("tournament event stage id", info.m_tournamentEventStageId);
+        parseTournamentAttribute("tournament event team0 id", info.m_tournamentTeam0Id);
+        parseTournamentAttribute("tournament event team1 id", info.m_tournamentTeam1Id);
     }
 }
 

--- a/csgo_gc/item_schema.cpp
+++ b/csgo_gc/item_schema.cpp
@@ -68,10 +68,6 @@ ItemInfo::ItemInfo(uint32_t defIndex)
     , m_quality{ ItemSchema::QualityNormal }
     , m_level{ 1 }
     , m_supplyCrateSeries{ 0 }
-    , m_tournamentEventId{ 0 }
-    , m_tournamentEventStageId{ 0 }
-    , m_tournamentTeam0Id{ 0 }
-    , m_tournamentTeam1Id{ 0 }
     , m_canSticker{ false }
     , m_canPatch{ false }
     , m_nameable{ false }
@@ -206,8 +202,8 @@ ItemSchema::ItemSchema()
     }
 
     // Some loot lists are only present in Valve's GC schema and are not
-    // included in the client items_game.txt. Keep replacements in an external
-    // file so they can be updated without rebuilding the GC library.
+    // included in the client items_game.txt. Load supplemental definitions
+    // from a data file so they can be updated without rebuilding the library.
     {
         KeyValue gcLootLists{ "gc_loot_lists" };
 
@@ -817,10 +813,11 @@ void ItemSchema::ParseItemRecursive(ItemInfo &info, const KeyValue &itemKey, con
             }
         };
 
-        parseTournamentAttribute("tournament event id", info.m_tournamentEventId);
-        parseTournamentAttribute("tournament event stage id", info.m_tournamentEventStageId);
-        parseTournamentAttribute("tournament event team0 id", info.m_tournamentTeam0Id);
-        parseTournamentAttribute("tournament event team1 id", info.m_tournamentTeam1Id);
+        parseTournamentAttribute("tournament event id", info.m_tournament.eventId);
+        parseTournamentAttribute("tournament event stage id", info.m_tournament.stageId);
+        parseTournamentAttribute("tournament event team0 id", info.m_tournament.team0Id);
+        parseTournamentAttribute("tournament event team1 id", info.m_tournament.team1Id);
+        parseTournamentAttribute("tournament mvp account id", info.m_tournament.mvpAccountId);
     }
 }
 
@@ -972,13 +969,19 @@ static LootListItemType LootListItemTypeFromName(std::string_view name, std::str
 
 void ItemSchema::ParseLootLists(const KeyValue *lootListsKey, bool unusual)
 {
-    m_lootLists.reserve(lootListsKey->SubkeyCount());
+    m_lootLists.reserve(m_lootLists.size() + lootListsKey->SubkeyCount());
 
     for (const KeyValue &lootListKey : *lootListsKey)
     {
         auto emplace = m_lootLists.emplace(std::piecewise_construct,
             std::forward_as_tuple(lootListKey.Name()),
             std::forward_as_tuple());
+
+        if (!emplace.second)
+        {
+            Platform::Print("Duplicate loot list %s ignored\n", std::string{ lootListKey.Name() }.c_str());
+            continue;
+        }
 
         LootList &lootList = emplace.first->second;
         lootList.isUnusual = unusual;
@@ -987,7 +990,7 @@ void ItemSchema::ParseLootLists(const KeyValue *lootListsKey, bool unusual)
         {
             std::string_view entryName = entryKey.Name();
 
-            // External GC loot-list replacements can reuse collections from
+            // Supplemental GC loot lists can reuse collections from
             // items_game.txt instead of duplicating every painted item.
             if (entryName == "item_sets")
             {
@@ -1114,7 +1117,7 @@ bool ItemSchema::ParseLootListItem(LootListItem &item, std::string_view name)
     else if (item.type == LootListItemSticker || item.type == LootListItemSpray || item.type == LootListItemPatch)
     {
         // the attribute is the sticker name
-        item.stickerKitInfo = StickerKitInfoByName(attributeName);
+        item.stickerKitInfo = MutableStickerKitInfoByName(attributeName);
         if (!item.stickerKitInfo)
         {
             Platform::Print("WARNING: No such sticker kit %s\n", std::string{ attributeName }.c_str());
@@ -1206,7 +1209,7 @@ const ItemInfo *ItemSchema::ItemInfoByDefIndex(uint32_t defIndex) const
     return &it->second;
 }
 
-StickerKitInfo *ItemSchema::StickerKitInfoByName(std::string_view name)
+StickerKitInfo *ItemSchema::MutableStickerKitInfoByName(std::string_view name)
 {
     auto it = m_stickerKitInfo.find(std::string{ name });
     if (it == m_stickerKitInfo.end())
@@ -1218,7 +1221,7 @@ StickerKitInfo *ItemSchema::StickerKitInfoByName(std::string_view name)
     return &it->second;
 }
 
-const StickerKitInfo *ItemSchema::StickerKitInfoByName(std::string_view name) const
+const StickerKitInfo *ItemSchema::FindStickerKitInfoByName(std::string_view name) const
 {
     auto it = m_stickerKitInfo.find(std::string{ name });
     if (it == m_stickerKitInfo.end())
@@ -1229,40 +1232,41 @@ const StickerKitInfo *ItemSchema::StickerKitInfoByName(std::string_view name) co
     return &it->second;
 }
 
-void ItemSchema::GetStickerKitsByTournamentEventId(uint32_t eventId, std::vector<const StickerKitInfo *> &out) const
+std::vector<const StickerKitInfo *> ItemSchema::TournamentStickerKits(
+    TournamentStickerRole role, uint32_t eventId, uint32_t subjectId) const
 {
+    std::vector<const StickerKitInfo *> result;
     for (const auto &pair : m_stickerKitInfo)
     {
         const StickerKitInfo &info = pair.second;
-        if (info.m_tournamentEventId == eventId && info.m_tournamentTeamId == 0 && info.m_tournamentPlayerId == 0)
+        if (info.m_tournamentEventId != eventId)
         {
-            out.push_back(&info);
+            continue;
         }
-    }
-}
 
-void ItemSchema::GetStickerKitsByTournamentTeamId(uint32_t eventId, uint32_t teamId, std::vector<const StickerKitInfo *> &out) const
-{
-    for (const auto &pair : m_stickerKitInfo)
-    {
-        const StickerKitInfo &info = pair.second;
-        if (info.m_tournamentEventId == eventId && info.m_tournamentTeamId == teamId && info.m_tournamentPlayerId == 0)
+        bool matchesRole = false;
+        switch (role)
         {
-            out.push_back(&info);
-        }
-    }
-}
+        case TournamentStickerRole::Event:
+            matchesRole = info.m_tournamentTeamId == 0 && info.m_tournamentPlayerId == 0;
+            break;
 
-void ItemSchema::GetStickerKitsByTournamentPlayerId(uint32_t eventId, uint32_t playerId, std::vector<const StickerKitInfo *> &out) const
-{
-    for (const auto &pair : m_stickerKitInfo)
-    {
-        const StickerKitInfo &info = pair.second;
-        if (info.m_tournamentEventId == eventId && info.m_tournamentPlayerId == playerId)
+        case TournamentStickerRole::Team:
+            matchesRole = info.m_tournamentTeamId == subjectId && info.m_tournamentPlayerId == 0;
+            break;
+
+        case TournamentStickerRole::Player:
+            matchesRole = info.m_tournamentPlayerId == subjectId;
+            break;
+        }
+
+        if (matchesRole)
         {
-            out.push_back(&info);
+            result.push_back(&info);
         }
     }
+
+    return result;
 }
 
 const StickerKitInfo *ItemSchema::StickerKitInfoByDefIndex(uint32_t defIndex) const

--- a/csgo_gc/item_schema.cpp
+++ b/csgo_gc/item_schema.cpp
@@ -200,6 +200,22 @@ ItemSchema::ItemSchema()
         ParseLootLists(lootListsKey, false);
     }
 
+    // Some loot lists are only present in Valve's GC schema and are not
+    // included in the client items_game.txt. Keep replacements in an external
+    // file so they can be updated without rebuilding the GC library.
+    {
+        KeyValue gcLootLists{ "gc_loot_lists" };
+
+        if (gcLootLists.ParseFromFile("csgo_gc/gc_loot_lists.txt"))
+        {
+            ParseLootLists(&gcLootLists, false);
+        }
+        else
+        {
+            Platform::Print("csgo_gc/gc_loot_lists.txt not found, server-only loot lists will be unavailable\n");
+        }
+    }
+
     const KeyValue *revolvingLootListsKey = itemsGame->GetSubkey("revolving_loot_lists");
     if (revolvingLootListsKey)
     {
@@ -951,6 +967,35 @@ void ItemSchema::ParseLootLists(const KeyValue *lootListsKey, bool unusual)
         for (const KeyValue &entryKey : lootListKey)
         {
             std::string_view entryName = entryKey.Name();
+
+            // External GC loot-list replacements can reuse collections from
+            // items_game.txt instead of duplicating every painted item.
+            if (entryName == "item_sets")
+            {
+                for (const KeyValue &itemSetKey : entryKey)
+                {
+                    auto itemSetSearch = m_itemSets.find(std::string{ itemSetKey.Name() });
+                    if (itemSetSearch == m_itemSets.end())
+                    {
+                        Platform::Print("Loot list %s references missing item set %s\n",
+                            std::string{ lootListKey.Name() }.c_str(),
+                            std::string{ itemSetKey.Name() }.c_str());
+                        continue;
+                    }
+
+                    for (LootListItem item : itemSetSearch->second.items)
+                    {
+                        if (unusual)
+                        {
+                            item.quality = QualityUnusual;
+                        }
+
+                        lootList.items.push_back(item);
+                    }
+                }
+
+                continue;
+            }
 
             // check for options that we ignore
             if (entryName == "will_produce_stattrak")

--- a/csgo_gc/item_schema.h
+++ b/csgo_gc/item_schema.h
@@ -31,6 +31,10 @@ public:
     uint32_t m_quality;
     uint32_t m_level;
     uint32_t m_supplyCrateSeries; // cases only
+    uint32_t m_tournamentEventId;
+    uint32_t m_tournamentEventStageId;
+    uint32_t m_tournamentTeam0Id;
+    uint32_t m_tournamentTeam1Id;
     std::string m_itemType;
     std::vector<std::string> m_prefabs;
     std::string m_toolRestriction;
@@ -273,10 +277,10 @@ public:
         AttributeCasketIdLow = 272,
         AttributeCasketIdHigh = 273,
 
-        // these are on souvenir package items, mikkotodo parse from schema
-        AttributeTournamentEventId = 267,
-        AttributeTournamentTeamId1 = 268,
-        AttributeTournamentTeamId2 = 269,
+        AttributeTournamentEventId = 137,
+        AttributeTournamentEventStageId = 138,
+        AttributeTournamentTeam0Id = 139,
+        AttributeTournamentTeam1Id = 140,
     };
 
 private:

--- a/csgo_gc/item_schema.h
+++ b/csgo_gc/item_schema.h
@@ -20,6 +20,15 @@ public:
     AttributeType m_type;
 };
 
+struct TournamentMetadata
+{
+    uint32_t eventId{};
+    uint32_t stageId{};
+    uint32_t team0Id{};
+    uint32_t team1Id{};
+    uint32_t mvpAccountId{};
+};
+
 class ItemInfo
 {
 public:
@@ -31,10 +40,7 @@ public:
     uint32_t m_quality;
     uint32_t m_level;
     uint32_t m_supplyCrateSeries; // cases only
-    uint32_t m_tournamentEventId;
-    uint32_t m_tournamentEventStageId;
-    uint32_t m_tournamentTeam0Id;
-    uint32_t m_tournamentTeam1Id;
+    TournamentMetadata m_tournament;
     std::string m_itemType;
     std::vector<std::string> m_prefabs;
     std::string m_toolRestriction;
@@ -71,6 +77,13 @@ public:
     uint32_t m_tournamentEventId;
     uint32_t m_tournamentTeamId;
     uint32_t m_tournamentPlayerId;
+};
+
+enum class TournamentStickerRole
+{
+    Event,
+    Team,
+    Player,
 };
 
 class MusicDefinitionInfo
@@ -158,10 +171,9 @@ public:
     const PaintKitInfo *PaintKitInfoByDefIndex(uint32_t defIndex) const;
     const StickerKitInfo *StickerKitInfoByDefIndex(uint32_t defIndex) const;
     const MusicDefinitionInfo *MusicDefinitionInfoByDefIndex(uint32_t defIndex) const;
-    const StickerKitInfo *StickerKitInfoByName(std::string_view name) const;
-    void GetStickerKitsByTournamentEventId(uint32_t eventId, std::vector<const StickerKitInfo *> &out) const;
-    void GetStickerKitsByTournamentTeamId(uint32_t eventId, uint32_t teamId, std::vector<const StickerKitInfo *> &out) const;
-    void GetStickerKitsByTournamentPlayerId(uint32_t eventId, uint32_t playerId, std::vector<const StickerKitInfo *> &out) const;
+    const StickerKitInfo *FindStickerKitInfoByName(std::string_view name) const;
+    std::vector<const StickerKitInfo *> TournamentStickerKits(
+        TournamentStickerRole role, uint32_t eventId, uint32_t subjectId = 0) const;
     bool GetCollectionsForPaintedItem(uint32_t defIndex, uint32_t paintKitDefIndex,
         std::vector<std::string> &outCollections) const;
     bool GetCollectionsForPaintKit(uint32_t paintKitDefIndex,
@@ -303,7 +315,7 @@ private:
 
     // internal slop
     ItemInfo *ItemInfoByName(std::string_view name);
-    StickerKitInfo *StickerKitInfoByName(std::string_view name);
+    StickerKitInfo *MutableStickerKitInfoByName(std::string_view name);
     PaintKitInfo *PaintKitInfoByName(std::string_view name);
     MusicDefinitionInfo *MusicDefinitionInfoByName(std::string_view name);
 

--- a/csgo_gc/item_schema.h
+++ b/csgo_gc/item_schema.h
@@ -66,6 +66,7 @@ public:
     explicit StickerKitInfo(const KeyValue &key);
 
     uint32_t m_defIndex;
+    std::string m_name;
     uint32_t m_rarity;
     uint32_t m_tournamentEventId;
     uint32_t m_tournamentTeamId;
@@ -157,8 +158,10 @@ public:
     const PaintKitInfo *PaintKitInfoByDefIndex(uint32_t defIndex) const;
     const StickerKitInfo *StickerKitInfoByDefIndex(uint32_t defIndex) const;
     const MusicDefinitionInfo *MusicDefinitionInfoByDefIndex(uint32_t defIndex) const;
-    const StickerKitInfo *StickerKitByTournamentEventId(uint32_t eventId) const;
-    const StickerKitInfo *StickerKitByTournamentTeamId(uint32_t eventId, uint32_t teamId) const;
+    const StickerKitInfo *StickerKitInfoByName(std::string_view name) const;
+    void GetStickerKitsByTournamentEventId(uint32_t eventId, std::vector<const StickerKitInfo *> &out) const;
+    void GetStickerKitsByTournamentTeamId(uint32_t eventId, uint32_t teamId, std::vector<const StickerKitInfo *> &out) const;
+    void GetStickerKitsByTournamentPlayerId(uint32_t eventId, uint32_t playerId, std::vector<const StickerKitInfo *> &out) const;
     bool GetCollectionsForPaintedItem(uint32_t defIndex, uint32_t paintKitDefIndex,
         std::vector<std::string> &outCollections) const;
     bool GetCollectionsForPaintKit(uint32_t paintKitDefIndex,
@@ -281,6 +284,7 @@ public:
         AttributeTournamentEventStageId = 138,
         AttributeTournamentTeam0Id = 139,
         AttributeTournamentTeam1Id = 140,
+        AttributeTournamentMvpAccountId = 223,
     };
 
 private:

--- a/csgo_gc/souvenir.cpp
+++ b/csgo_gc/souvenir.cpp
@@ -27,6 +27,124 @@ static bool CompareRarity(const LootListItem *a, const LootListItem *b) { return
 static bool RarityLower(const LootListItem *a, uint32_t b) { return a->CaseRarity() < b; }
 static bool RarityUpper(uint32_t a, const LootListItem *b) { return a < b->CaseRarity(); }
 
+static bool EndsWith(std::string_view value, std::string_view suffix)
+{
+    return value.size() >= suffix.size() && value.compare(value.size() - suffix.size(), suffix.size(), suffix) == 0;
+}
+
+template<typename Predicate>
+static const StickerKitInfo *SelectStickerKit(const std::vector<const StickerKitInfo *> &candidates, Predicate predicate, Random &random)
+{
+    std::vector<const StickerKitInfo *> matches;
+    for (const StickerKitInfo *candidate : candidates)
+    {
+        if (predicate(*candidate))
+        {
+            matches.push_back(candidate);
+        }
+    }
+
+    if (matches.empty())
+    {
+        return nullptr;
+    }
+
+    std::sort(matches.begin(), matches.end(), [](const StickerKitInfo *a, const StickerKitInfo *b) {
+        return a->m_defIndex < b->m_defIndex;
+    });
+
+    return matches[random.Integer<size_t>(0, matches.size() - 1)];
+}
+
+static const StickerKitInfo *SelectHighestDefIndex(const std::vector<const StickerKitInfo *> &candidates)
+{
+    if (candidates.empty())
+    {
+        return nullptr;
+    }
+
+    return *std::max_element(candidates.begin(), candidates.end(), [](const StickerKitInfo *a, const StickerKitInfo *b) {
+        return a->m_defIndex < b->m_defIndex;
+    });
+}
+
+static const StickerKitInfo *SelectEventStickerKit(const ItemSchema &schema, uint32_t eventId, Random &random)
+{
+    std::vector<const StickerKitInfo *> candidates;
+    schema.GetStickerKitsByTournamentEventId(eventId, candidates);
+
+    // The first four Majors predate the later all-gold souvenir format.
+    // Their dedicated souvenir variants are still identifiable from the
+    // schema, but use different finishes.
+    if (eventId == 1)
+    {
+        return SelectStickerKit(candidates, [](const StickerKitInfo &) { return true; }, random);
+    }
+
+    if (eventId == 3)
+    {
+        return SelectStickerKit(candidates, [](const StickerKitInfo &kit) {
+            return kit.m_name.find("_gold_") != std::string::npos;
+        }, random);
+    }
+
+    if (eventId == 4)
+    {
+        // Cologne 2014 has one additional event-only sticker after the two
+        // capsule variants. Its definition index is the highest of the three.
+        return SelectHighestDefIndex(candidates);
+    }
+
+    if (eventId == 5)
+    {
+        return SelectStickerKit(candidates, [](const StickerKitInfo &kit) {
+            return !EndsWith(kit.m_name, "_foil");
+        }, random);
+    }
+
+    return SelectStickerKit(candidates, [](const StickerKitInfo &kit) {
+        return EndsWith(kit.m_name, "_gold");
+    }, random);
+}
+
+static const StickerKitInfo *SelectTeamStickerKit(const ItemSchema &schema, uint32_t eventId, uint32_t teamId, Random &random)
+{
+    std::vector<const StickerKitInfo *> candidates;
+    schema.GetStickerKitsByTournamentTeamId(eventId, teamId, candidates);
+
+    const char *suffix = eventId <= 4 ? "_foil" : "_gold";
+    return SelectStickerKit(candidates, [suffix](const StickerKitInfo &kit) {
+        return EndsWith(kit.m_name, suffix);
+    }, random);
+}
+
+static const StickerKitInfo *SelectPlayerStickerKit(const ItemSchema &schema, uint32_t eventId, uint32_t playerId, Random &random)
+{
+    std::vector<const StickerKitInfo *> candidates;
+    schema.GetStickerKitsByTournamentPlayerId(eventId, playerId, candidates);
+    return SelectStickerKit(candidates, [](const StickerKitInfo &kit) {
+        return EndsWith(kit.m_name, "_gold");
+    }, random);
+}
+
+static const StickerKitInfo *MapStickerKit(const ItemSchema &schema, const ItemInfo *packageInfo)
+{
+    if (!packageInfo)
+    {
+        return nullptr;
+    }
+
+    size_t mapPosition = packageInfo->m_name.rfind("_de_");
+    if (mapPosition == std::string::npos)
+    {
+        return nullptr;
+    }
+
+    std::string stickerName = packageInfo->m_name.substr(mapPosition + 1);
+    stickerName += "_gold";
+    return schema.StickerKitInfoByName(stickerName);
+}
+
 bool SouvenirOpening::OpenPackage(const CSOEconItem &package, CSOEconItem &item)
 {
     const LootList *lootList = m_itemSchema.GetCrateLootList(package.def_index());
@@ -74,6 +192,7 @@ bool SouvenirOpening::OpenPackage(const CSOEconItem &package, CSOEconItem &item)
     uint32_t stageId = packageInfo ? packageInfo->m_tournamentEventStageId : 0;
     uint32_t team0Id = packageInfo ? packageInfo->m_tournamentTeam0Id : 0;
     uint32_t team1Id = packageInfo ? packageInfo->m_tournamentTeam1Id : 0;
+    uint32_t mvpAccountId = 0;
 
     for (const CSOEconItemAttribute &attribute : package.attribute())
     {
@@ -96,6 +215,10 @@ bool SouvenirOpening::OpenPackage(const CSOEconItem &package, CSOEconItem &item)
         case ItemSchema::AttributeTournamentTeam1Id:
             team1Id = value;
             break;
+
+        case ItemSchema::AttributeTournamentMvpAccountId:
+            mvpAccountId = value;
+            break;
         }
     }
 
@@ -115,19 +238,32 @@ bool SouvenirOpening::OpenPackage(const CSOEconItem &package, CSOEconItem &item)
     addTournamentAttribute(ItemSchema::AttributeTournamentEventStageId, stageId);
     addTournamentAttribute(ItemSchema::AttributeTournamentTeam0Id, team0Id);
     addTournamentAttribute(ItemSchema::AttributeTournamentTeam1Id, team1Id);
+    addTournamentAttribute(ItemSchema::AttributeTournamentMvpAccountId, mvpAccountId);
 
-    const StickerKitInfo *eventKit = eventId ? m_itemSchema.StickerKitByTournamentEventId(eventId) : nullptr;
-    const StickerKitInfo *team0Kit = eventId && team0Id ? m_itemSchema.StickerKitByTournamentTeamId(eventId, team0Id) : nullptr;
-    const StickerKitInfo *team1Kit = eventId && team1Id ? m_itemSchema.StickerKitByTournamentTeamId(eventId, team1Id) : nullptr;
+    const StickerKitInfo *eventKit = eventId ? SelectEventStickerKit(m_itemSchema, eventId, m_random) : nullptr;
+    const StickerKitInfo *team0Kit = eventId && team0Id ? SelectTeamStickerKit(m_itemSchema, eventId, team0Id, m_random) : nullptr;
+    const StickerKitInfo *team1Kit = eventId && team1Id ? SelectTeamStickerKit(m_itemSchema, eventId, team1Id, m_random) : nullptr;
+    const StickerKitInfo *fourthKit = nullptr;
+
+    if (eventId >= 18)
+    {
+        fourthKit = MapStickerKit(m_itemSchema, packageInfo);
+    }
+    else if (eventId >= 7 && mvpAccountId)
+    {
+        fourthKit = SelectPlayerStickerKit(m_itemSchema, eventId, mvpAccountId, m_random);
+    }
 
     uint32_t eventStickerKit = eventKit ? eventKit->m_defIndex : 0;
     uint32_t team0StickerKit = team0Kit ? team0Kit->m_defIndex : 0;
     uint32_t team1StickerKit = team1Kit ? team1Kit->m_defIndex : 0;
+    uint32_t fourthStickerKit = fourthKit ? fourthKit->m_defIndex : 0;
 
-    Platform::Print("SouvenirOpening: event %u stage %u teams %u/%u stickers %u/%u/%u\n",
-        eventId, stageId, team0Id, team1Id, eventStickerKit, team0StickerKit, team1StickerKit);
+    Platform::Print("SouvenirOpening: event %u stage %u teams %u/%u mvp %u stickers %u/%u/%u/%u\n",
+        eventId, stageId, team0Id, team1Id, mvpAccountId,
+        eventStickerKit, team0StickerKit, team1StickerKit, fourthStickerKit);
 
-    ApplyTournamentAttributes(item, eventStickerKit, team0StickerKit, team1StickerKit, 0);
+    ApplyTournamentAttributes(item, eventStickerKit, team0StickerKit, team1StickerKit, fourthStickerKit);
 
     return true;
 }
@@ -189,9 +325,9 @@ const LootListItem *SouvenirOpening::SelectItem(const std::vector<const LootList
     return nullptr;
 }
 
-void SouvenirOpening::ApplyTournamentAttributes(CSOEconItem &item, uint32_t eventStickerKit, uint32_t team1StickerKit, uint32_t team2StickerKit, uint32_t mvpStickerKit)
+void SouvenirOpening::ApplyTournamentAttributes(CSOEconItem &item, uint32_t eventStickerKit, uint32_t team1StickerKit, uint32_t team2StickerKit, uint32_t fourthStickerKit)
 {
-    // souvenir stickers are always gold, mint condition, default scale, no rotation
+    // Souvenir stickers are mint condition with default scale and rotation.
     auto addSticker = [&](uint32_t stickerIdAttr, uint32_t wearAttr, uint32_t scaleAttr, uint32_t rotationAttr, uint32_t stickerKitDefIndex)
     {
         if (stickerKitDefIndex == 0)
@@ -228,10 +364,10 @@ void SouvenirOpening::ApplyTournamentAttributes(CSOEconItem &item, uint32_t even
     addSticker(ItemSchema::AttributeStickerId2, ItemSchema::AttributeStickerWear2,
         ItemSchema::AttributeStickerScale2, ItemSchema::AttributeStickerRotation2, team2StickerKit);
 
-    // MVP autograph sticker (slot 3) if available
-    if (mvpStickerKit != 0)
+    // MVP autograph (2015-2019) or map gold sticker (2021+) in slot 3.
+    if (fourthStickerKit != 0)
     {
         addSticker(ItemSchema::AttributeStickerId3, ItemSchema::AttributeStickerWear3,
-            ItemSchema::AttributeStickerScale3, ItemSchema::AttributeStickerRotation3, mvpStickerKit);
+            ItemSchema::AttributeStickerScale3, ItemSchema::AttributeStickerRotation3, fourthStickerKit);
     }
 }

--- a/csgo_gc/souvenir.cpp
+++ b/csgo_gc/souvenir.cpp
@@ -27,6 +27,58 @@ static bool CompareRarity(const LootListItem *a, const LootListItem *b) { return
 static bool RarityLower(const LootListItem *a, uint32_t b) { return a->CaseRarity() < b; }
 static bool RarityUpper(uint32_t a, const LootListItem *b) { return a < b->CaseRarity(); }
 
+namespace SouvenirTournament
+{
+    constexpr uint32_t DreamHack2013 = 1;
+    constexpr uint32_t Katowice2014 = 3;
+    constexpr uint32_t Cologne2014 = 4;
+    constexpr uint32_t DreamHack2014 = 5;
+    constexpr uint32_t Katowice2015 = 6;
+    constexpr uint32_t Cologne2015 = 7;
+    constexpr uint32_t Berlin2019 = 16;
+    constexpr uint32_t Stockholm2021 = 18;
+}
+
+enum class SouvenirFormat
+{
+    Unknown,
+    EventOnly,
+    FoilTeams,
+    GoldTeams,
+    GoldMvp,
+    GoldMap,
+};
+
+static SouvenirFormat SouvenirFormatForEvent(uint32_t eventId)
+{
+    if (eventId == SouvenirTournament::DreamHack2013)
+    {
+        return SouvenirFormat::EventOnly;
+    }
+
+    if (eventId >= SouvenirTournament::Katowice2014 && eventId <= SouvenirTournament::Cologne2014)
+    {
+        return SouvenirFormat::FoilTeams;
+    }
+
+    if (eventId >= SouvenirTournament::DreamHack2014 && eventId <= SouvenirTournament::Katowice2015)
+    {
+        return SouvenirFormat::GoldTeams;
+    }
+
+    if (eventId >= SouvenirTournament::Cologne2015 && eventId <= SouvenirTournament::Berlin2019)
+    {
+        return SouvenirFormat::GoldMvp;
+    }
+
+    if (eventId >= SouvenirTournament::Stockholm2021)
+    {
+        return SouvenirFormat::GoldMap;
+    }
+
+    return SouvenirFormat::Unknown;
+}
+
 static bool EndsWith(std::string_view value, std::string_view suffix)
 {
     return value.size() >= suffix.size() && value.compare(value.size() - suffix.size(), suffix.size(), suffix) == 0;
@@ -56,50 +108,31 @@ static const StickerKitInfo *SelectStickerKit(const std::vector<const StickerKit
     return matches[random.Integer<size_t>(0, matches.size() - 1)];
 }
 
-static const StickerKitInfo *SelectHighestDefIndex(const std::vector<const StickerKitInfo *> &candidates)
+static const StickerKitInfo *SelectEventStickerKit(
+    const ItemSchema &schema, uint32_t eventId, SouvenirFormat format, Random &random)
 {
-    if (candidates.empty())
-    {
-        return nullptr;
-    }
+    std::vector<const StickerKitInfo *> candidates = schema.TournamentStickerKits(TournamentStickerRole::Event, eventId);
 
-    return *std::max_element(candidates.begin(), candidates.end(), [](const StickerKitInfo *a, const StickerKitInfo *b) {
-        return a->m_defIndex < b->m_defIndex;
-    });
-}
-
-static const StickerKitInfo *SelectEventStickerKit(const ItemSchema &schema, uint32_t eventId, Random &random)
-{
-    std::vector<const StickerKitInfo *> candidates;
-    schema.GetStickerKitsByTournamentEventId(eventId, candidates);
-
-    // The first four Majors predate the later all-gold souvenir format.
-    // Their dedicated souvenir variants are still identifiable from the
-    // schema, but use different finishes.
-    if (eventId == 1)
+    if (format == SouvenirFormat::EventOnly)
     {
         return SelectStickerKit(candidates, [](const StickerKitInfo &) { return true; }, random);
     }
 
-    if (eventId == 3)
+    if (eventId == SouvenirTournament::Katowice2014)
     {
         return SelectStickerKit(candidates, [](const StickerKitInfo &kit) {
             return kit.m_name.find("_gold_") != std::string::npos;
         }, random);
     }
 
-    if (eventId == 4)
+    if (eventId == SouvenirTournament::Cologne2014)
     {
-        // Cologne 2014 has one additional event-only sticker after the two
-        // capsule variants. Its definition index is the highest of the three.
-        return SelectHighestDefIndex(candidates);
+        return schema.FindStickerKitInfoByName("cologne2014_esl_c");
     }
 
-    if (eventId == 5)
+    if (eventId == SouvenirTournament::DreamHack2014)
     {
-        return SelectStickerKit(candidates, [](const StickerKitInfo &kit) {
-            return !EndsWith(kit.m_name, "_foil");
-        }, random);
+        return schema.FindStickerKitInfoByName("dhw2014_dhw");
     }
 
     return SelectStickerKit(candidates, [](const StickerKitInfo &kit) {
@@ -107,12 +140,12 @@ static const StickerKitInfo *SelectEventStickerKit(const ItemSchema &schema, uin
     }, random);
 }
 
-static const StickerKitInfo *SelectTeamStickerKit(const ItemSchema &schema, uint32_t eventId, uint32_t teamId, Random &random)
+static const StickerKitInfo *SelectTeamStickerKit(
+    const ItemSchema &schema, uint32_t eventId, uint32_t teamId, SouvenirFormat format, Random &random)
 {
-    std::vector<const StickerKitInfo *> candidates;
-    schema.GetStickerKitsByTournamentTeamId(eventId, teamId, candidates);
+    std::vector<const StickerKitInfo *> candidates = schema.TournamentStickerKits(TournamentStickerRole::Team, eventId, teamId);
 
-    const char *suffix = eventId <= 4 ? "_foil" : "_gold";
+    const char *suffix = format == SouvenirFormat::FoilTeams ? "_foil" : "_gold";
     return SelectStickerKit(candidates, [suffix](const StickerKitInfo &kit) {
         return EndsWith(kit.m_name, suffix);
     }, random);
@@ -120,8 +153,7 @@ static const StickerKitInfo *SelectTeamStickerKit(const ItemSchema &schema, uint
 
 static const StickerKitInfo *SelectPlayerStickerKit(const ItemSchema &schema, uint32_t eventId, uint32_t playerId, Random &random)
 {
-    std::vector<const StickerKitInfo *> candidates;
-    schema.GetStickerKitsByTournamentPlayerId(eventId, playerId, candidates);
+    std::vector<const StickerKitInfo *> candidates = schema.TournamentStickerKits(TournamentStickerRole::Player, eventId, playerId);
     return SelectStickerKit(candidates, [](const StickerKitInfo &kit) {
         return EndsWith(kit.m_name, "_gold");
     }, random);
@@ -142,7 +174,7 @@ static const StickerKitInfo *MapStickerKit(const ItemSchema &schema, const ItemI
 
     std::string stickerName = packageInfo->m_name.substr(mapPosition + 1);
     stickerName += "_gold";
-    return schema.StickerKitInfoByName(stickerName);
+    return schema.FindStickerKitInfoByName(stickerName);
 }
 
 bool SouvenirOpening::OpenPackage(const CSOEconItem &package, CSOEconItem &item)
@@ -188,11 +220,7 @@ bool SouvenirOpening::OpenPackage(const CSOEconItem &package, CSOEconItem &item)
     // Static tournament metadata comes from the package definition. Instance
     // attributes identify the particular match and override those defaults.
     const ItemInfo *packageInfo = m_itemSchema.ItemInfoByDefIndex(package.def_index());
-    uint32_t eventId = packageInfo ? packageInfo->m_tournamentEventId : 0;
-    uint32_t stageId = packageInfo ? packageInfo->m_tournamentEventStageId : 0;
-    uint32_t team0Id = packageInfo ? packageInfo->m_tournamentTeam0Id : 0;
-    uint32_t team1Id = packageInfo ? packageInfo->m_tournamentTeam1Id : 0;
-    uint32_t mvpAccountId = 0;
+    TournamentMetadata tournament = packageInfo ? packageInfo->m_tournament : TournamentMetadata{};
 
     for (const CSOEconItemAttribute &attribute : package.attribute())
     {
@@ -201,23 +229,23 @@ bool SouvenirOpening::OpenPackage(const CSOEconItem &package, CSOEconItem &item)
         switch (attribute.def_index())
         {
         case ItemSchema::AttributeTournamentEventId:
-            eventId = value;
+            tournament.eventId = value;
             break;
 
         case ItemSchema::AttributeTournamentEventStageId:
-            stageId = value;
+            tournament.stageId = value;
             break;
 
         case ItemSchema::AttributeTournamentTeam0Id:
-            team0Id = value;
+            tournament.team0Id = value;
             break;
 
         case ItemSchema::AttributeTournamentTeam1Id:
-            team1Id = value;
+            tournament.team1Id = value;
             break;
 
         case ItemSchema::AttributeTournamentMvpAccountId:
-            mvpAccountId = value;
+            tournament.mvpAccountId = value;
             break;
         }
     }
@@ -234,24 +262,36 @@ bool SouvenirOpening::OpenPackage(const CSOEconItem &package, CSOEconItem &item)
         m_itemSchema.SetAttributeUint32(attribute, value);
     };
 
-    addTournamentAttribute(ItemSchema::AttributeTournamentEventId, eventId);
-    addTournamentAttribute(ItemSchema::AttributeTournamentEventStageId, stageId);
-    addTournamentAttribute(ItemSchema::AttributeTournamentTeam0Id, team0Id);
-    addTournamentAttribute(ItemSchema::AttributeTournamentTeam1Id, team1Id);
-    addTournamentAttribute(ItemSchema::AttributeTournamentMvpAccountId, mvpAccountId);
+    addTournamentAttribute(ItemSchema::AttributeTournamentEventId, tournament.eventId);
+    addTournamentAttribute(ItemSchema::AttributeTournamentEventStageId, tournament.stageId);
+    addTournamentAttribute(ItemSchema::AttributeTournamentTeam0Id, tournament.team0Id);
+    addTournamentAttribute(ItemSchema::AttributeTournamentTeam1Id, tournament.team1Id);
+    addTournamentAttribute(ItemSchema::AttributeTournamentMvpAccountId, tournament.mvpAccountId);
 
-    const StickerKitInfo *eventKit = eventId ? SelectEventStickerKit(m_itemSchema, eventId, m_random) : nullptr;
-    const StickerKitInfo *team0Kit = eventId && team0Id ? SelectTeamStickerKit(m_itemSchema, eventId, team0Id, m_random) : nullptr;
-    const StickerKitInfo *team1Kit = eventId && team1Id ? SelectTeamStickerKit(m_itemSchema, eventId, team1Id, m_random) : nullptr;
+    SouvenirFormat format = SouvenirFormatForEvent(tournament.eventId);
+    if (tournament.eventId && format == SouvenirFormat::Unknown)
+    {
+        Platform::Print("SouvenirOpening: unsupported tournament event %u\n", tournament.eventId);
+    }
+
+    const StickerKitInfo *eventKit = format != SouvenirFormat::Unknown
+        ? SelectEventStickerKit(m_itemSchema, tournament.eventId, format, m_random)
+        : nullptr;
+    const StickerKitInfo *team0Kit = format != SouvenirFormat::Unknown && tournament.team0Id
+        ? SelectTeamStickerKit(m_itemSchema, tournament.eventId, tournament.team0Id, format, m_random)
+        : nullptr;
+    const StickerKitInfo *team1Kit = format != SouvenirFormat::Unknown && tournament.team1Id
+        ? SelectTeamStickerKit(m_itemSchema, tournament.eventId, tournament.team1Id, format, m_random)
+        : nullptr;
     const StickerKitInfo *fourthKit = nullptr;
 
-    if (eventId >= 18)
+    if (format == SouvenirFormat::GoldMap)
     {
         fourthKit = MapStickerKit(m_itemSchema, packageInfo);
     }
-    else if (eventId >= 7 && mvpAccountId)
+    else if (format == SouvenirFormat::GoldMvp && tournament.mvpAccountId)
     {
-        fourthKit = SelectPlayerStickerKit(m_itemSchema, eventId, mvpAccountId, m_random);
+        fourthKit = SelectPlayerStickerKit(m_itemSchema, tournament.eventId, tournament.mvpAccountId, m_random);
     }
 
     uint32_t eventStickerKit = eventKit ? eventKit->m_defIndex : 0;
@@ -260,7 +300,7 @@ bool SouvenirOpening::OpenPackage(const CSOEconItem &package, CSOEconItem &item)
     uint32_t fourthStickerKit = fourthKit ? fourthKit->m_defIndex : 0;
 
     Platform::Print("SouvenirOpening: event %u stage %u teams %u/%u mvp %u stickers %u/%u/%u/%u\n",
-        eventId, stageId, team0Id, team1Id, mvpAccountId,
+        tournament.eventId, tournament.stageId, tournament.team0Id, tournament.team1Id, tournament.mvpAccountId,
         eventStickerKit, team0StickerKit, team1StickerKit, fourthStickerKit);
 
     ApplyTournamentAttributes(item, eventStickerKit, team0StickerKit, team1StickerKit, fourthStickerKit);

--- a/csgo_gc/souvenir.cpp
+++ b/csgo_gc/souvenir.cpp
@@ -67,10 +67,13 @@ bool SouvenirOpening::OpenPackage(const CSOEconItem &package, CSOEconItem &item)
     // override quality to tournament
     item.set_quality(ItemSchema::QualityTournament);
 
-    // read tournament attributes from the package and look up sticker kits
-    uint32_t eventId = 0;
-    uint32_t teamId1 = 0;
-    uint32_t teamId2 = 0;
+    // Static tournament metadata comes from the package definition. Instance
+    // attributes identify the particular match and override those defaults.
+    const ItemInfo *packageInfo = m_itemSchema.ItemInfoByDefIndex(package.def_index());
+    uint32_t eventId = packageInfo ? packageInfo->m_tournamentEventId : 0;
+    uint32_t stageId = packageInfo ? packageInfo->m_tournamentEventStageId : 0;
+    uint32_t team0Id = packageInfo ? packageInfo->m_tournamentTeam0Id : 0;
+    uint32_t team1Id = packageInfo ? packageInfo->m_tournamentTeam1Id : 0;
 
     for (const CSOEconItemAttribute &attribute : package.attribute())
     {
@@ -82,25 +85,49 @@ bool SouvenirOpening::OpenPackage(const CSOEconItem &package, CSOEconItem &item)
             eventId = value;
             break;
 
-        case ItemSchema::AttributeTournamentTeamId1:
-            teamId1 = value;
+        case ItemSchema::AttributeTournamentEventStageId:
+            stageId = value;
             break;
 
-        case ItemSchema::AttributeTournamentTeamId2:
-            teamId2 = value;
+        case ItemSchema::AttributeTournamentTeam0Id:
+            team0Id = value;
+            break;
+
+        case ItemSchema::AttributeTournamentTeam1Id:
+            team1Id = value;
             break;
         }
     }
 
+    auto addTournamentAttribute = [&](uint32_t attributeDefIndex, uint32_t value)
+    {
+        if (!value)
+        {
+            return;
+        }
+
+        CSOEconItemAttribute *attribute = item.add_attribute();
+        attribute->set_def_index(attributeDefIndex);
+        m_itemSchema.SetAttributeUint32(attribute, value);
+    };
+
+    addTournamentAttribute(ItemSchema::AttributeTournamentEventId, eventId);
+    addTournamentAttribute(ItemSchema::AttributeTournamentEventStageId, stageId);
+    addTournamentAttribute(ItemSchema::AttributeTournamentTeam0Id, team0Id);
+    addTournamentAttribute(ItemSchema::AttributeTournamentTeam1Id, team1Id);
+
     const StickerKitInfo *eventKit = eventId ? m_itemSchema.StickerKitByTournamentEventId(eventId) : nullptr;
-    const StickerKitInfo *team1Kit = eventId && teamId1 ? m_itemSchema.StickerKitByTournamentTeamId(eventId, teamId1) : nullptr;
-    const StickerKitInfo *team2Kit = eventId && teamId2 ? m_itemSchema.StickerKitByTournamentTeamId(eventId, teamId2) : nullptr;
+    const StickerKitInfo *team0Kit = eventId && team0Id ? m_itemSchema.StickerKitByTournamentTeamId(eventId, team0Id) : nullptr;
+    const StickerKitInfo *team1Kit = eventId && team1Id ? m_itemSchema.StickerKitByTournamentTeamId(eventId, team1Id) : nullptr;
 
     uint32_t eventStickerKit = eventKit ? eventKit->m_defIndex : 0;
+    uint32_t team0StickerKit = team0Kit ? team0Kit->m_defIndex : 0;
     uint32_t team1StickerKit = team1Kit ? team1Kit->m_defIndex : 0;
-    uint32_t team2StickerKit = team2Kit ? team2Kit->m_defIndex : 0;
 
-    ApplyTournamentAttributes(item, eventStickerKit, team1StickerKit, team2StickerKit, 0);
+    Platform::Print("SouvenirOpening: event %u stage %u teams %u/%u stickers %u/%u/%u\n",
+        eventId, stageId, team0Id, team1Id, eventStickerKit, team0StickerKit, team1StickerKit);
+
+    ApplyTournamentAttributes(item, eventStickerKit, team0StickerKit, team1StickerKit, 0);
 
     return true;
 }

--- a/csgo_gc/souvenir.cpp
+++ b/csgo_gc/souvenir.cpp
@@ -37,6 +37,7 @@ namespace SouvenirTournament
     constexpr uint32_t Cologne2015 = 7;
     constexpr uint32_t Berlin2019 = 16;
     constexpr uint32_t Stockholm2021 = 18;
+    constexpr uint32_t Paris2023 = 21;
 }
 
 enum class SouvenirFormat
@@ -71,7 +72,7 @@ static SouvenirFormat SouvenirFormatForEvent(uint32_t eventId)
         return SouvenirFormat::GoldMvp;
     }
 
-    if (eventId >= SouvenirTournament::Stockholm2021)
+    if (eventId >= SouvenirTournament::Stockholm2021 && eventId <= SouvenirTournament::Paris2023)
     {
         return SouvenirFormat::GoldMap;
     }

--- a/csgo_gc/souvenir.h
+++ b/csgo_gc/souvenir.h
@@ -15,7 +15,7 @@ public:
 
 private:
     const LootListItem *SelectItem(const std::vector<const LootListItem *> &items);
-    void ApplyTournamentAttributes(CSOEconItem &item, uint32_t eventStickerKit, uint32_t team1StickerKit, uint32_t team2StickerKit, uint32_t mvpStickerKit);
+    void ApplyTournamentAttributes(CSOEconItem &item, uint32_t eventStickerKit, uint32_t team1StickerKit, uint32_t team2StickerKit, uint32_t fourthStickerKit);
 
     const ItemSchema &m_itemSchema;
     Random &m_random;

--- a/docs/rcon.md
+++ b/docs/rcon.md
@@ -184,6 +184,7 @@ give_item 7 paint=44 wear=0.12 seed=123 stattrak=5
 give_item 7 paint=44 name="RCON Test"
 give_item 1314 music=3 stattrak=10
 give_item 7 paint=44 sticker0=12 sticker0_wear=0
+give_item 4013 tournament_team0=31 tournament_team1=1
 ```
 
 Rules:
@@ -212,6 +213,10 @@ Supported parameters:
 | `music` | uint32 | Music definition id. Requires music kit defindex `1314`. |
 | `spray_color` | uint32 | Graffiti tint id. |
 | `spray_remaining` | uint32 | Remaining spray uses. |
+| `tournament_event` | uint32 | Tournament event id. Souvenir package definitions normally provide this automatically. |
+| `tournament_stage` | uint32 | Tournament event stage id for a specific match. |
+| `tournament_team0` | uint32 | First tournament team id for a souvenir package. |
+| `tournament_team1` | uint32 | Second tournament team id for a souvenir package. |
 | `sticker0`..`sticker5` | uint32 | Sticker kit defindex. Must exist in the item schema. |
 | `stickerN_wear` | float | Sticker wear, `0.0..1.0`. |
 | `stickerN_scale` | float | Sticker scale. |

--- a/docs/rcon.md
+++ b/docs/rcon.md
@@ -185,6 +185,7 @@ give_item 7 paint=44 name="RCON Test"
 give_item 1314 music=3 stattrak=10
 give_item 7 paint=44 sticker0=12 sticker0_wear=0
 give_item 4013 tournament_team0=31 tournament_team1=1
+give_item 4132 tournament_team0=46 tournament_team1=1 tournament_mvp=64640068
 ```
 
 Rules:
@@ -217,6 +218,7 @@ Supported parameters:
 | `tournament_stage` | uint32 | Tournament event stage id for a specific match. |
 | `tournament_team0` | uint32 | First tournament team id for a souvenir package. |
 | `tournament_team1` | uint32 | Second tournament team id for a souvenir package. |
+| `tournament_mvp` | uint32 | MVP Steam account id for Cologne 2015 through Berlin 2019 souvenir packages. |
 | `sticker0`..`sticker5` | uint32 | Sticker kit defindex. Must exist in the item schema. |
 | `stickerN_wear` | float | Sticker wear, `0.0..1.0`. |
 | `stickerN_scale` | float | Sticker scale. |
@@ -233,6 +235,10 @@ Derived defaults:
 - Explicit `quality` and `rarity` override derived defaults.
 - If no parameters are supplied, the command uses the original basic purchase
   path.
+
+See [Souvenir Packages](souvenirs.md) for complete package examples, tournament
+attribute numbers, historical sticker formats, and manual `inventory.txt`
+editing.
 
 ### `remove_item`
 

--- a/docs/souvenirs.md
+++ b/docs/souvenirs.md
@@ -2,8 +2,8 @@
 
 csgo_gc can open legacy CS:GO souvenir packages and generate the tournament
 metadata and stickers expected for their Major era. The package definition
-selects the map collection and tournament, while attributes on that particular
-package describe the match.
+and its GC loot list select the available collection or collections, while
+attributes on that particular package describe the tournament and match.
 
 The package does not need a `loot list` attribute. Loot lists are GC-side data:
 `gc_loot_lists.txt` decides which weapons can be produced, and the package's
@@ -132,6 +132,9 @@ chooses only where the historical format has multiple valid event designs.
   server-only package contents belong in `gc_loot_lists.txt`; sticker selection
   should remain schema-driven rather than be duplicated in an external rules
   file.
+- `gc_loot_lists.txt` is supplemental: definitions should use names absent
+  from the client schema. Duplicate loot-list names are ignored rather than
+  silently merged with client data.
 
 Research references:
 

--- a/docs/souvenirs.md
+++ b/docs/souvenirs.md
@@ -1,0 +1,141 @@
+# Souvenir Packages
+
+csgo_gc can open legacy CS:GO souvenir packages and generate the tournament
+metadata and stickers expected for their Major era. The package definition
+selects the map collection and tournament, while attributes on that particular
+package describe the match.
+
+The package does not need a `loot list` attribute. Loot lists are GC-side data:
+`gc_loot_lists.txt` decides which weapons can be produced, and the package's
+tournament attributes decide which souvenir stickers are applied to the result.
+
+## Creating a Package with RCON
+
+Use `give_item` with a souvenir package defindex and the teams from the match:
+
+```powershell
+rcon -a 127.0.0.1:37016 -p 1 "give_item 4013 tournament_team0=31 tournament_team1=1"
+```
+
+Package `4013` is the EMS One Katowice 2014 Souvenir Package. Its item
+definition already supplies tournament event `3`, so `tournament_event=3` is
+optional. This example produces the dedicated Katowice 2014 event sticker and
+the Virtus.Pro and Ninjas in Pyjamas Foil team stickers when the package is
+opened.
+
+The supported tournament parameters are:
+
+| Parameter | Attribute | Meaning |
+| --- | ---: | --- |
+| `tournament_event` | 137 | Tournament event id. Usually inherited from the package definition. |
+| `tournament_stage` | 138 | Tournament stage id. Optional; retained on the resulting souvenir. |
+| `tournament_team0` | 139 | First team id. |
+| `tournament_team1` | 140 | Second team id. |
+| `tournament_mvp` | 223 | MVP Steam account id for autograph-era souvenirs. |
+
+These values identify tournament records, not sticker-kit defindexes. csgo_gc
+looks up the correct sticker variants in `items_game.txt`.
+
+### Cologne 2015 through Berlin 2019
+
+Souvenirs from the autograph era use a fourth Gold sticker belonging to the
+match MVP. Supply the player's 32-bit Steam account id with `tournament_mvp`:
+
+```powershell
+rcon -a 127.0.0.1:37016 -p 1 "give_item 4132 tournament_team0=46 tournament_team1=1 tournament_mvp=64640068"
+```
+
+In this example:
+
+- `4132` is the ESL One Cologne 2015 Mirage Souvenir Package.
+- Team `46` is Team EnVyUs.
+- Team `1` is Ninjas in Pyjamas.
+- Account id `64640068` selects the Gold kennyS autograph for event `7`.
+
+If `tournament_mvp` is omitted, the package still opens, but the resulting item
+only has the event and two team stickers and is not a complete match-specific
+souvenir for this era.
+
+### Stockholm 2021 and Later CS:GO Majors
+
+Beginning with Stockholm 2021, the fourth sticker is the Gold map sticker, not
+an MVP autograph. csgo_gc derives the map automatically from the package
+definition:
+
+```powershell
+rcon -a 127.0.0.1:37016 -p 1 "give_item 4810 tournament_team0=12 tournament_team1=59"
+```
+
+Package `4810` is the Stockholm 2021 Mirage package. This produces the event,
+Natus Vincere, G2 Esports, and `de_mirage_gold` stickers. Do not supply
+`tournament_mvp` for this format.
+
+## Editing `inventory.txt`
+
+The same metadata can be added manually to a souvenir package in
+`csgo_gc/inventory.txt`. For an autograph-era package, its `attributes` block
+can contain:
+
+```text
+"attributes"
+{
+    "137"    "7"
+    "139"    "46"
+    "140"    "1"
+    "223"    "64640068"
+}
+```
+
+Attribute `137` can be omitted when the correct package definition already
+contains the tournament event. The values must still describe a sensible
+match: csgo_gc resolves sticker kits but does not verify that the specified
+teams and MVP actually played one another historically.
+
+After creating a package through RCON, inspect and persist it with:
+
+```powershell
+rcon -a 127.0.0.1:37016 -p 1 "item_info <item-id>"
+rcon -a 127.0.0.1:37016 -p 1 save_inventory
+```
+
+## Sticker Formats by Era
+
+The finish and fourth sticker changed during CS:GO's lifetime. csgo_gc selects
+these variants automatically:
+
+| Tournament era | Generated stickers |
+| --- | --- |
+| DreamHack Winter 2013 | Tournament-themed sticker; no team metadata was available. |
+| EMS Katowice and ESL One Cologne 2014 | Dedicated event sticker and two team Foil stickers. |
+| DreamHack Winter 2014 | Event sticker and two team Gold stickers. |
+| ESL One Katowice 2015 | Event Gold and two team Gold stickers. |
+| ESL One Cologne 2015 through Berlin 2019 | Event Gold, two team Golds, and an MVP Gold autograph. |
+| Stockholm 2021 through Paris 2023 | Event Gold, two team Golds, and a Gold map sticker. |
+
+Early events contain multiple sticker finishes with the same tournament/team
+metadata. Selecting the first matching schema entry is incorrect and is also
+nondeterministic when entries are stored in an unordered map. The implementation
+therefore selects the era-appropriate suffix (`_foil` or `_gold`) and randomly
+chooses only where the historical format has multiple valid event designs.
+
+## Notes for Maintainers
+
+- Sticker-kit tournament fields are parsed from `items_game.txt`:
+  `tournament_event_id`, `tournament_team_id`, and `tournament_player_id`.
+- Attribute `223`, `tournament mvp account id`, supplies the match-specific
+  player for the 2015-2019 autograph format.
+- The standalone map Gold stickers (`de_mirage_gold`, `de_nuke_gold`, and so
+  on) do not carry a tournament id. For Stockholm 2021 and later packages, the
+  map is derived from the package name such as
+  `crate_stockh2021_promo_de_mirage`.
+- Package loot contents and souvenir sticker generation are separate. Missing
+  server-only package contents belong in `gc_loot_lists.txt`; sticker selection
+  should remain schema-driven rather than be duplicated in an external rules
+  file.
+
+Research references:
+
+- [Valve: The Major is Back (Stockholm 2021)](https://store.steampowered.com/news/app/730/view/4103335143107243030)
+- [Valve: The Paris 2023 Major](https://store.steampowered.com/news/app/730/view/5138087875081246097)
+- [Final CS:GO `items_game.txt` tracked by SteamTracking](https://github.com/SteamTracking/GameTracking-CS2/blob/e63fc7fdb8dfb4f1873f0db214c0cc16613d5beb/csgo/scripts/items/items_game.txt)
+- [Structured sticker-kit export used for cross-checking variants](https://github.com/zwolof/schema-gen/blob/054ce0d1c0b20ab18927d9aa59922abb5d2566c8/exported/sticker_kits.json)

--- a/examples/gc_loot_lists.txt
+++ b/examples/gc_loot_lists.txt
@@ -1,0 +1,20 @@
+"legacy_souvenir_2013_2014"
+{
+	"item_sets"
+	{
+		"set_dust_2"		"1"
+		"set_italy"		"1"
+		"set_lake"		"1"
+		"set_mirage"		"1"
+		"set_safehouse"		"1"
+		"set_train"		"1"
+	}
+}
+"crate_dhw13_promo"
+{
+	"legacy_souvenir_2013_2014"		"1"
+}
+"crate_ems14_promo"
+{
+	"legacy_souvenir_2013_2014"		"1"
+}


### PR DESCRIPTION
Resolve #20.

## Summary
- Add support for legacy souvenir loot lists in GC item handling and schema parsing
- Wire the new loot-list behavior through client, server, inventory, and souvenir code paths
- Update docs, examples, build metadata, and CI to reflect the new configuration and workflow

## Testing
- Not run (not requested)
- Covered by code changes across the GC pipeline and updated example/config documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended RCON `give_item` to accept tournament metadata (event, stage, team0/team1, and MVP) and apply it to created items.
  * Enhanced souvenir package sticker/metadata selection across historical formats, including updated handling of the “fourth” sticker slot (MVP autograph vs map gold).
  * Added supplemental loot-list support, including reusable `item_sets` and legacy souvenir loot-list examples.

* **Documentation**
  * Added a new souvenirs guide and expanded RCON/config documentation with tournament parameter examples and era-specific notes.

* **Chores**
  * Updated release packaging to include the supplemental `gc_loot_lists.txt` example.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->