### PR TITLE
Fix RCON startup with an empty password

### DIFF
--- a/csgo_gc/config.cpp
+++ b/csgo_gc/config.cpp
@@ -32,11 +32,6 @@ GCConfig::GCConfig()
         m_rconBindAddress = rcon->GetString("bind_address", m_rconBindAddress);
         m_rconPort = rcon->GetNumber("port", m_rconPort);
         m_rconPassword = rcon->GetString("password", m_rconPassword);
-
-        if (m_rconEnabled && m_rconPassword.empty())
-        {
-            Platform::Print("WARNING: RCON is enabled with an empty password; any Source RCON password will authenticate. Keep bind_address local or set rcon.password.\n");
-        }
     }
 
     const KeyValue *ranks = config.GetSubkey("ranks");

--- a/csgo_gc/rcon_server.cpp
+++ b/csgo_gc/rcon_server.cpp
@@ -179,16 +179,23 @@ RconServer::~RconServer()
 
 void RconServer::Start()
 {
-    Platform::Print("RCON: config enabled=%d bind_address=%s port=%u protocol=source password=%s\n",
-        GetConfig().RconEnabled() ? 1 : 0,
-        GetConfig().RconBindAddress().c_str(),
-        GetConfig().RconPort(),
-        GetConfig().RconPassword().empty() ? "empty" : "set");
+    const GCConfig &config = GetConfig();
 
-    if (!GetConfig().RconEnabled())
+    Platform::Print("RCON: config enabled=%d bind_address=%s port=%u protocol=source password=%s\n",
+        config.RconEnabled() ? 1 : 0,
+        config.RconBindAddress().c_str(),
+        config.RconPort(),
+        config.RconPassword().empty() ? "empty" : "set");
+
+    if (!config.RconEnabled())
     {
         Platform::Print("RCON: disabled\n");
         return;
+    }
+
+    if (config.RconPassword().empty())
+    {
+        Platform::Print("WARNING: RCON is enabled with an empty password; any Source RCON password will authenticate. Keep bind_address local or set rcon.password.\n");
     }
 
     bool expected = false;


### PR DESCRIPTION
Fixes #33.

## Summary

- avoid logging while the global GC configuration is still being initialized
- move the empty RCON password warning to `RconServer::Start`
- reuse the fully initialized configuration while starting the RCON listener

## Root cause

Enabling RCON without a password caused `GCConfig` construction to call `Platform::Print`. The logging path calls `GetConfig()` to read the configured log level, recursively requesting the same function-local static configuration object before its construction had completed. This could prevent the game from launching.

## Verification

- Built the 32-bit Release `csgo_gc` target successfully with Visual Studio BuildTools

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed an unnecessary warning during configuration loading when RCON is enabled without a password.
  * Added a clear startup warning when RCON is enabled without a password, while allowing the server to continue starting.
  * Improved RCON startup configuration messages for clearer status visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->