### PR TITLE
Fix keyless container opening classification

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.20)
 
 project(csgo_gc)
 
+include(CTest)
+
 set(CMAKE_CXX_STANDARD 17)
 
 find_package(Threads REQUIRED)

--- a/csgo_gc/CMakeLists.txt
+++ b/csgo_gc/CMakeLists.txt
@@ -64,3 +64,24 @@ if (OUTDIR)
         $<TARGET_FILE:csgo_gc>
         ${OUTDIR}/csgo_gc/${GC_LIB_DIR}/$<TARGET_FILE_NAME:csgo_gc>)
 endif()
+
+if (BUILD_TESTING)
+    add_executable(item_schema_tests
+        item_schema_tests.cpp
+        item_schema.cpp
+        keyvalue.cpp)
+
+    target_precompile_headers(item_schema_tests PRIVATE stdafx.h)
+    target_include_directories(item_schema_tests PRIVATE ../protobufs)
+    target_sources(item_schema_tests PRIVATE ${PROTOBUFS})
+    target_link_libraries(item_schema_tests PRIVATE libprotobuf-lite)
+
+    if (MSVC)
+        target_compile_options(item_schema_tests PRIVATE /W4 /wd4244 /wd4819)
+        target_compile_definitions(item_schema_tests PRIVATE _CRT_SECURE_NO_WARNINGS)
+    else()
+        target_compile_options(item_schema_tests PRIVATE -Wall -Wextra)
+    endif()
+
+    add_test(NAME item_schema_tests COMMAND item_schema_tests)
+endif()

--- a/csgo_gc/gc_client.cpp
+++ b/csgo_gc/gc_client.cpp
@@ -1607,8 +1607,7 @@ void ClientGC::UnlockCrate(GCMessageRead &messageRead)
     const CSOEconItem *crate = m_inventory.GetItem(crateId);
     if (keyId == 0
         && crate
-        && crate->def_index() >= SouvenirDefIndexMin
-        && crate->def_index() <= SouvenirDefIndexMax
+        && m_inventory.GetItemSchema().IsSouvenirPackage(*crate)
         && m_inventory.OpenSouvenirPackage(crateId, destroyCrate, newItem, notification))
     {
         Platform::Print("SOUVENIR PACKAGE OPENING %llu\n", crateId);

--- a/csgo_gc/gc_const_csgo.h
+++ b/csgo_gc/gc_const_csgo.h
@@ -14,10 +14,6 @@ constexpr uint64_t ItemIdDefaultItemMask = 0xfull << 60;
 // technically 5 but there are attributes for 6 stickers...
 constexpr int MaxStickers = 6;
 
-// souvenir package def_index range (4006..5225)
-constexpr uint32_t SouvenirDefIndexMin = 4006;
-constexpr uint32_t SouvenirDefIndexMax = 5225;
-
 enum RankType : uint32_t
 {
     RankTypeCompetitive = 6,

--- a/csgo_gc/item_schema.cpp
+++ b/csgo_gc/item_schema.cpp
@@ -122,7 +122,17 @@ uint32_t LootListItem::CaseRarity() const
 }
 
 ItemSchema::ItemSchema()
+    : ItemSchema{ true }
 {
+}
+
+ItemSchema::ItemSchema(bool loadFiles)
+{
+    if (!loadFiles)
+    {
+        return;
+    }
+
     KeyValue itemSchema{ "root" };
     if (!itemSchema.ParseFromFile("csgo/scripts/items/items_game.txt"))
     {
@@ -706,6 +716,10 @@ void ItemSchema::ParseItems(const KeyValue *itemsKey, const KeyValue *prefabsKey
         if (itemInfo.m_isCoupon)
         {
             assert(itemInfo.m_lootListName.size());
+        }
+        else
+        {
+            assert(!itemInfo.m_willProduceStatTrak);
         }
     }
 }

--- a/csgo_gc/item_schema.cpp
+++ b/csgo_gc/item_schema.cpp
@@ -428,18 +428,91 @@ const LootList *ItemSchema::GetCrateLootList(uint32_t crateDefIndex) const
         return nullptr;
     }
 
-    if (!itemSearch->second.m_supplyCrateSeries)
+    const ItemInfo &itemInfo = itemSearch->second;
+
+    if (itemInfo.m_supplyCrateSeries)
     {
-        return nullptr;
+        auto lootListSearch = m_revolvingLootLists.find(itemInfo.m_supplyCrateSeries);
+        if (lootListSearch != m_revolvingLootLists.end())
+        {
+            return &lootListSearch->second;
+        }
     }
 
-    auto lootListSearch = m_revolvingLootLists.find(itemSearch->second.m_supplyCrateSeries);
-    if (lootListSearch == m_revolvingLootLists.end())
+    // Self-opening collection packages, agent containers and tournament
+    // capsules point directly at a loot list instead of a revolving series.
+    // Coupon definitions also use loot_list_name, but their list describes
+    // the purchased item rather than contents that can be opened.
+    if (!itemInfo.m_isCoupon && !itemInfo.m_lootListName.empty())
     {
-        return nullptr;
+        auto lootListSearch = m_lootLists.find(itemInfo.m_lootListName);
+        if (lootListSearch != m_lootLists.end())
+        {
+            return &lootListSearch->second;
+        }
     }
 
-    return &lootListSearch->second;
+    return nullptr;
+}
+
+static bool LootListContainsItemType(const LootList &lootList, LootListItemType type)
+{
+    for (const LootListItem &item : lootList.items)
+    {
+        if (item.type == type)
+        {
+            return true;
+        }
+    }
+
+    for (const LootList *subList : lootList.subLists)
+    {
+        if (subList && LootListContainsItemType(*subList, type))
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool ItemSchema::IsSouvenirPackage(const CSOEconItem &item) const
+{
+    const ItemInfo *itemInfo = ItemInfoByDefIndex(item.def_index());
+    if (!itemInfo)
+    {
+        return false;
+    }
+
+    const LootList *lootList = GetCrateLootList(item.def_index());
+    if (!lootList || !LootListContainsItemType(*lootList, LootListItemPaintable))
+    {
+        // Tournament sticker capsules can carry event metadata too, but their
+        // loot lists contain stickers rather than painted souvenir weapons.
+        return false;
+    }
+
+    // The common souvenir package prefabs identify both legacy and modern
+    // packages without relying on a broad def_index range.
+    for (const std::string &prefab : itemInfo->m_prefabs)
+    {
+        if (prefab.find("souvenir") != std::string::npos)
+        {
+            return true;
+        }
+    }
+
+    uint32_t tournamentEventId = itemInfo->m_tournament.eventId;
+    for (const CSOEconItemAttribute &attribute : item.attribute())
+    {
+        if (attribute.def_index() == AttributeTournamentEventId)
+        {
+            tournamentEventId = AttributeUint32(&attribute);
+            break;
+        }
+    }
+
+    return tournamentEventId != 0;
 }
 
 bool ItemSchema::CreateItemFromLootListItem(Random &random,
@@ -479,10 +552,18 @@ bool ItemSchema::CreateItemFromLootListItem(Random &random,
 
     if (lootListItem.type == LootListItemSticker)
     {
-        // mikkotodo anything else?
         CSOEconItemAttribute *attribute = item.add_attribute();
         attribute->set_def_index(ItemSchema::AttributeStickerId0);
         SetAttributeUint32(attribute, lootListItem.stickerKitInfo->m_defIndex);
+
+        // Tournament capsules produce normal sticker items that retain their
+        // event metadata. This is distinct from souvenir weapon generation.
+        if (lootListItem.stickerKitInfo->m_tournamentEventId)
+        {
+            attribute = item.add_attribute();
+            attribute->set_def_index(ItemSchema::AttributeTournamentEventId);
+            SetAttributeUint32(attribute, lootListItem.stickerKitInfo->m_tournamentEventId);
+        }
     }
     else if (lootListItem.type == LootListItemSpray)
     {
@@ -622,17 +703,7 @@ void ItemSchema::ParseItems(const KeyValue *itemsKey, const KeyValue *prefabsKey
 
         // FIXME: remove, temp slop to make sure we parse correctly
         auto &itemInfo = emplace.first->second;
-        if (!itemInfo.m_isCoupon)
-        {
-            // FIXME: self opening purchases
-            if (itemInfo.m_lootListName.size())
-            {
-                Platform::Print("Non coupon item associated loot list in %s!!!\n", itemInfo.m_name.c_str());
-            }
-
-            assert(!itemInfo.m_willProduceStatTrak);
-        }
-        else
+        if (itemInfo.m_isCoupon)
         {
             assert(itemInfo.m_lootListName.size());
         }

--- a/csgo_gc/item_schema.h
+++ b/csgo_gc/item_schema.h
@@ -304,6 +304,8 @@ public:
     };
 
 private:
+    explicit ItemSchema(bool loadFiles);
+
     void ParseItems(const KeyValue *itemsKey, const KeyValue *prefabsKey);
     void ParseItemRecursive(ItemInfo &info, const KeyValue &itemKey, const KeyValue *prefabsKey);
     void ParseAttributes(const KeyValue *attributesKey);
@@ -334,4 +336,6 @@ private:
     std::unordered_map<std::string, ItemSet> m_itemSets;
 
     std::unordered_map<uint32_t, const LootList &> m_revolvingLootLists;
+
+    friend class ItemSchemaTestFixture;
 };

--- a/csgo_gc/item_schema.h
+++ b/csgo_gc/item_schema.h
@@ -155,6 +155,10 @@ public:
     // for case opening
     const LootList *GetCrateLootList(uint32_t crateDefIndex) const;
 
+    // Legacy souvenir packages are opened through UnlockCrate with no key.
+    // Distinguish them from other self-opening containers using schema data.
+    bool IsSouvenirPackage(const CSOEconItem &item) const;
+
     // for case opening
     bool CreateItemFromLootListItem(Random &random,
         const LootListItem &lootListItem,

--- a/csgo_gc/item_schema_tests.cpp
+++ b/csgo_gc/item_schema_tests.cpp
@@ -1,0 +1,101 @@
+#include "stdafx.h"
+#include "item_schema.h"
+#include "keyvalue.h"
+
+namespace Platform
+{
+
+void Print(const char *, ...)
+{
+}
+
+}
+
+class ItemSchemaTestFixture
+{
+public:
+    ItemSchemaTestFixture()
+        : schema{ false }
+    {
+        KeyValue tournamentEventAttribute{ "137" };
+        tournamentEventAttribute.AddNumber("stored_as_integer", 1);
+        schema.m_attributeInfo.emplace(
+            ItemSchema::AttributeTournamentEventId,
+            AttributeInfo{ tournamentEventAttribute });
+
+        schema.m_itemInfo.reserve(2);
+        schema.m_lootLists.reserve(4);
+    }
+
+    void AddTournamentStickerCapsule(uint32_t defIndex)
+    {
+        ItemInfo &itemInfo = schema.m_itemInfo.try_emplace(defIndex, defIndex).first->second;
+        itemInfo.m_lootListName = "tournament_capsule";
+
+        LootList &lootList = schema.m_lootLists["tournament_capsule"];
+        lootList.items.emplace_back().type = LootListItemSticker;
+    }
+
+    void AddNestedSouvenirPackage(uint32_t defIndex)
+    {
+        ItemInfo &itemInfo = schema.m_itemInfo.try_emplace(defIndex, defIndex).first->second;
+        itemInfo.m_supplyCrateSeries = 1;
+        itemInfo.m_prefabs.push_back("weapon_case_souvenirpkg");
+
+        LootList &paintedItems = schema.m_lootLists["painted_items"];
+        paintedItems.items.emplace_back().type = LootListItemPaintable;
+
+        LootList &nestedItems = schema.m_lootLists["nested_items"];
+        nestedItems.subLists.push_back(&paintedItems);
+
+        LootList &packageContents = schema.m_lootLists["package_contents"];
+        packageContents.subLists.push_back(&nestedItems);
+
+        schema.m_revolvingLootLists.try_emplace(1, packageContents);
+    }
+
+    ItemSchema schema;
+};
+
+static bool TournamentStickerCapsuleIsNotSouvenir()
+{
+    ItemSchemaTestFixture fixture;
+    fixture.AddTournamentStickerCapsule(9000);
+
+    CSOEconItem capsule;
+    capsule.set_def_index(9000);
+    capsule.set_quality(ItemSchema::QualityTournament);
+
+    CSOEconItemAttribute *eventAttribute = capsule.add_attribute();
+    eventAttribute->set_def_index(ItemSchema::AttributeTournamentEventId);
+    fixture.schema.SetAttributeUint32(eventAttribute, 21);
+
+    return !fixture.schema.IsSouvenirPackage(capsule);
+}
+
+static bool NestedPaintedLootListIsSouvenir()
+{
+    ItemSchemaTestFixture fixture;
+    fixture.AddNestedSouvenirPackage(9001);
+
+    CSOEconItem package;
+    package.set_def_index(9001);
+    package.set_quality(ItemSchema::QualityUnique);
+
+    return fixture.schema.IsSouvenirPackage(package);
+}
+
+int main()
+{
+    if (!TournamentStickerCapsuleIsNotSouvenir())
+    {
+        return 1;
+    }
+
+    if (!NestedPaintedLootListIsSouvenir())
+    {
+        return 2;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
Resolve direct loot lists for self-opening containers, identify souvenir packages from schema data, and preserve tournament metadata on sticker capsule rewards.

Fixes #39

Fixes #42

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved identification of souvenir packages using their loot contents and tournament metadata.
  * Improved handling of self-opening containers and loot lists, including nested loot lists.
  * Preserved tournament event information when generating stickers from tournament capsules.
  * Refined coupon validation to avoid incorrect checks on non-coupon items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->