### PR TITLE
Fix trade-up craft completion state

### DIFF
--- a/csgo_gc/CMakeLists.txt
+++ b/csgo_gc/CMakeLists.txt
@@ -67,13 +67,27 @@ endif()
 
 if (BUILD_TESTING)
     add_executable(gc_message_tests
+        case_opening.cpp
+        config.cpp
+        gc_client.cpp
+        gc_shared.cpp
+        graffiti.cpp
         gc_message_tests.cpp
-        gc_message.cpp)
+        gc_message.cpp
+        inventory.cpp
+        item_schema.cpp
+        item_utils.cpp
+        keyvalue.cpp
+        souvenir.cpp)
 
     target_precompile_headers(gc_message_tests PRIVATE stdafx.h)
     target_include_directories(gc_message_tests PRIVATE ../protobufs)
     target_sources(gc_message_tests PRIVATE ${PROTOBUFS})
-    target_link_libraries(gc_message_tests PRIVATE libprotobuf-lite)
+    target_link_libraries(gc_message_tests PRIVATE
+        cryptopp
+        libprotobuf-lite
+        steam_api
+        Threads::Threads)
 
     if (MSVC)
         target_compile_options(gc_message_tests PRIVATE /W4 /wd4244 /wd4819)

--- a/csgo_gc/CMakeLists.txt
+++ b/csgo_gc/CMakeLists.txt
@@ -66,6 +66,24 @@ if (OUTDIR)
 endif()
 
 if (BUILD_TESTING)
+    add_executable(gc_message_tests
+        gc_message_tests.cpp
+        gc_message.cpp)
+
+    target_precompile_headers(gc_message_tests PRIVATE stdafx.h)
+    target_include_directories(gc_message_tests PRIVATE ../protobufs)
+    target_sources(gc_message_tests PRIVATE ${PROTOBUFS})
+    target_link_libraries(gc_message_tests PRIVATE libprotobuf-lite)
+
+    if (MSVC)
+        target_compile_options(gc_message_tests PRIVATE /W4 /wd4244 /wd4819)
+        target_compile_definitions(gc_message_tests PRIVATE _CRT_SECURE_NO_WARNINGS)
+    else()
+        target_compile_options(gc_message_tests PRIVATE -Wall -Wextra)
+    endif()
+
+    add_test(NAME gc_message_tests COMMAND gc_message_tests)
+
     add_executable(item_schema_tests
         item_schema_tests.cpp
         item_schema.cpp

--- a/csgo_gc/gc_client.cpp
+++ b/csgo_gc/gc_client.cpp
@@ -1727,6 +1727,20 @@ void ClientGC::Craft(GCMessageRead &messageRead)
     
     int16_t recipe = static_cast<int16_t>(messageRead.ReadUint16());
     int16_t itemCount = static_cast<int16_t>(messageRead.ReadUint16());
+
+    auto sendResponse = [this](int16_t responseIndex, EGCMsgResponse response, uint64_t craftedItemId = 0)
+    {
+        GCMessageWrite messageWrite{ k_EMsgGCCraftResponse, GCMessageWrite::StructHeader::Extended };
+        messageWrite.WriteUint16(static_cast<uint16_t>(responseIndex));
+        messageWrite.WriteUint32(static_cast<uint32_t>(response));
+        messageWrite.WriteUint16(craftedItemId ? 1 : 0);
+        if (craftedItemId)
+        {
+            messageWrite.WriteUint64(craftedItemId);
+        }
+
+        PostToHost(HostEvent::Message, messageWrite.TypeMasked(), messageWrite.Data(), messageWrite.Size());
+    };
     
     if (!messageRead.IsValid())
     {
@@ -1743,7 +1757,15 @@ void ClientGC::Craft(GCMessageRead &messageRead)
         || (recipe >= 10 && recipe <= 15);
     if (!isTradeUpRecipe)
     {
-        Platform::Print("Unsupported craft recipe %d, ignoring\n", recipe);
+        Platform::Print("Unsupported craft recipe %d\n", recipe);
+        sendResponse(recipe, k_EGCMsgResponseInvalid);
+        return;
+    }
+
+    if (itemCount != 10)
+    {
+        Platform::Print("Trade-up requires exactly 10 items, got %d\n", itemCount);
+        sendResponse(recipe, k_EGCMsgResponseInvalid);
         return;
     }
     
@@ -1756,7 +1778,8 @@ void ClientGC::Craft(GCMessageRead &messageRead)
         uint64_t itemId = messageRead.ReadUint64();
         if (!messageRead.IsValid())
         {
-            Platform::Print("Parsing CMsgGCCraft item %d failed, ignoring\n", i);
+            Platform::Print("Parsing CMsgGCCraft item %d failed\n", i);
+            sendResponse(recipe, k_EGCMsgResponseInvalid);
             return;
 
         }
@@ -1792,10 +1815,10 @@ void ClientGC::Craft(GCMessageRead &messageRead)
 
     std::vector<CMsgSOSingleObject> destroyItems;
     CMsgSOSingleObject newItem;
-    CMsgGCItemCustomizationNotification notification;
+    int16_t responseRecipeIndex = recipe;
     CSOEconItem *craftedItem = nullptr;
     
-    if (m_inventory.TradeUp(inputItemIds, destroyItems, newItem, notification, &craftedItem))
+    if (m_inventory.TradeUp(inputItemIds, destroyItems, newItem, responseRecipeIndex, &craftedItem))
     {
         // Destroy all input items
         for (auto &destroy : destroyItems)
@@ -1805,9 +1828,9 @@ void ClientGC::Craft(GCMessageRead &messageRead)
         
         // Create the new item
         SendMessageToGame(true, k_ESOMsg_Create, newItem);
-        
-        // Send notification
-        SendMessageToGame(false, k_EMsgGCItemCustomizationNotification, notification);
+
+        assert(craftedItem);
+        sendResponse(responseRecipeIndex, k_EGCMsgResponseOK, craftedItem ? craftedItem->id() : 0);
 
         if (craftedItem)
         {
@@ -1832,6 +1855,7 @@ void ClientGC::Craft(GCMessageRead &messageRead)
     else
     {
         Platform::Print("Trade-up failed: input validation failed\n");
+        sendResponse(recipe, k_EGCMsgResponseDenied);
     }
 }
 

--- a/csgo_gc/gc_client.cpp
+++ b/csgo_gc/gc_client.cpp
@@ -1730,21 +1730,14 @@ void ClientGC::Craft(GCMessageRead &messageRead)
 
     auto sendResponse = [this](int16_t responseIndex, EGCMsgResponse response, uint64_t craftedItemId = 0)
     {
-        GCMessageWrite messageWrite{ k_EMsgGCCraftResponse, GCMessageWrite::StructHeader::Extended };
-        messageWrite.WriteUint16(static_cast<uint16_t>(responseIndex));
-        messageWrite.WriteUint32(static_cast<uint32_t>(response));
-        messageWrite.WriteUint16(craftedItemId ? 1 : 0);
-        if (craftedItemId)
-        {
-            messageWrite.WriteUint64(craftedItemId);
-        }
-
+        GCMessageWrite messageWrite = BuildCraftResponseMessage(responseIndex, response, craftedItemId);
         PostToHost(HostEvent::Message, messageWrite.TypeMasked(), messageWrite.Data(), messageWrite.Size());
     };
     
     if (!messageRead.IsValid())
     {
-        Platform::Print("Parsing CMsgGCCraft header failed, ignoring\n");
+        Platform::Print("Parsing CMsgGCCraft header failed\n");
+        sendResponse(recipe, k_EGCMsgResponseInvalid);
         return;
     }
     

--- a/csgo_gc/gc_message.cpp
+++ b/csgo_gc/gc_message.cpp
@@ -145,14 +145,24 @@ GCMessageWrite::GCMessageWrite(uint32_t type, const google::protobuf::MessageLit
 }
 
 GCMessageWrite::GCMessageWrite(uint32_t type)
+    : GCMessageWrite{ type, StructHeader::Basic }
 {
-    // write the non protobuf messge hader
-    // mikkotoodo using GameStructMsgHeader is wrong here!!! we should be using the fat one
-    // however we're not sending these to the game (yet) so it doesn't matter
+}
+
+GCMessageWrite::GCMessageWrite(uint32_t type, StructHeader header)
+{
+    // The basic header is used by the project's internal network messages. Game-bound
+    // struct messages use GCMsgHdrEx_t, which appends the header version and job ids.
     WriteUint32(type);
     WriteUint32(0);
     WriteUint64(0);
-    WriteUint16(0);
+    WriteUint16(header == StructHeader::Extended ? 1 : 0);
+
+    if (header == StructHeader::Extended)
+    {
+        WriteUint64(JobIdInvalid);
+        WriteUint64(JobIdInvalid);
+    }
 }
 
 GCMessageWrite::GCMessageWrite(const void *data, uint32_t size)

--- a/csgo_gc/gc_message.cpp
+++ b/csgo_gc/gc_message.cpp
@@ -177,3 +177,19 @@ void GCMessageWrite::WriteData(const void *data, uint32_t size)
     const uint8_t *bytes = reinterpret_cast<const uint8_t *>(data);
     m_buffer.insert(m_buffer.end(), bytes, bytes + size);
 }
+
+GCMessageWrite BuildCraftResponseMessage(int16_t responseIndex,
+    EGCMsgResponse response,
+    uint64_t craftedItemId)
+{
+    GCMessageWrite message{ k_EMsgGCCraftResponse, GCMessageWrite::StructHeader::Extended };
+    message.WriteUint16(static_cast<uint16_t>(responseIndex));
+    message.WriteUint32(static_cast<uint32_t>(response));
+    message.WriteUint16(craftedItemId ? 1 : 0);
+    if (craftedItemId)
+    {
+        message.WriteUint64(craftedItemId);
+    }
+
+    return message;
+}

--- a/csgo_gc/gc_message.h
+++ b/csgo_gc/gc_message.h
@@ -115,3 +115,7 @@ public:
 private:
     std::vector<uint8_t> m_buffer;
 };
+
+GCMessageWrite BuildCraftResponseMessage(int16_t responseIndex,
+    EGCMsgResponse response,
+    uint64_t craftedItemId = 0);

--- a/csgo_gc/gc_message.h
+++ b/csgo_gc/gc_message.h
@@ -65,11 +65,18 @@ private:
 class GCMessageWrite
 {
 public:
+    enum class StructHeader
+    {
+        Basic,
+        Extended
+    };
+
     // protobuf messages
     GCMessageWrite(uint32_t type, const google::protobuf::MessageLite &message, uint64_t jobId = JobIdInvalid);
 
     // non protobuf messages, data written with the writer functions
     GCMessageWrite(uint32_t type);
+    GCMessageWrite(uint32_t type, StructHeader header);
 
     // already serialized data that just gets copied over, type parsed from the message
     GCMessageWrite(const void *data, uint32_t size);

--- a/csgo_gc/gc_message_tests.cpp
+++ b/csgo_gc/gc_message_tests.cpp
@@ -1,0 +1,85 @@
+#include "stdafx.h"
+#include "gc_message.h"
+
+#include <cstring>
+
+namespace Platform
+{
+
+void Print(const char *, ...)
+{
+}
+
+}
+
+template<typename T>
+static bool ValueAt(const uint8_t *data, size_t offset, T expected)
+{
+    T actual{};
+    std::memcpy(&actual, data + offset, sizeof(actual));
+    return actual == expected;
+}
+
+static bool ExtendedCraftResponseSerialization()
+{
+    constexpr int16_t responseIndex = 12;
+    constexpr uint64_t craftedItemId = 0x1122334455667788ull;
+
+    GCMessageWrite message{ k_EMsgGCCraftResponse, GCMessageWrite::StructHeader::Extended };
+    message.WriteUint16(static_cast<uint16_t>(responseIndex));
+    message.WriteUint32(k_EGCMsgResponseOK);
+    message.WriteUint16(1);
+    message.WriteUint64(craftedItemId);
+
+    const auto *data = static_cast<const uint8_t *>(message.Data());
+    size_t offset = 0;
+
+    bool valid = ValueAt(data, offset, static_cast<uint32_t>(k_EMsgGCCraftResponse));
+    offset += sizeof(uint32_t);
+    valid &= ValueAt(data, offset, uint32_t{ 0 });
+    offset += sizeof(uint32_t);
+    valid &= ValueAt(data, offset, uint64_t{ 0 });
+    offset += sizeof(uint64_t);
+    valid &= ValueAt(data, offset, uint16_t{ 1 });
+    offset += sizeof(uint16_t);
+    valid &= ValueAt(data, offset, JobIdInvalid);
+    offset += sizeof(uint64_t);
+    valid &= ValueAt(data, offset, JobIdInvalid);
+    offset += sizeof(uint64_t);
+    valid &= ValueAt(data, offset, responseIndex);
+    offset += sizeof(int16_t);
+    valid &= ValueAt(data, offset, static_cast<uint32_t>(k_EGCMsgResponseOK));
+    offset += sizeof(uint32_t);
+    valid &= ValueAt(data, offset, uint16_t{ 1 });
+    offset += sizeof(uint16_t);
+    valid &= ValueAt(data, offset, craftedItemId);
+    offset += sizeof(uint64_t);
+
+    return valid && offset == message.Size();
+}
+
+static bool BasicStructHeaderSerializationIsUnchanged()
+{
+    constexpr uint32_t messageType = 1;
+    GCMessageWrite message{ messageType };
+
+    const auto *data = static_cast<const uint8_t *>(message.Data());
+    size_t offset = 0;
+
+    bool valid = ValueAt(data, offset, messageType);
+    offset += sizeof(uint32_t);
+    valid &= ValueAt(data, offset, uint32_t{ 0 });
+    offset += sizeof(uint32_t);
+    valid &= ValueAt(data, offset, uint64_t{ 0 });
+    offset += sizeof(uint64_t);
+    valid &= ValueAt(data, offset, uint16_t{ 0 });
+    offset += sizeof(uint16_t);
+
+    return valid && offset == message.Size();
+}
+
+int main()
+{
+    return ExtendedCraftResponseSerialization()
+        && BasicStructHeaderSerializationIsUnchanged() ? 0 : 1;
+}

--- a/csgo_gc/gc_message_tests.cpp
+++ b/csgo_gc/gc_message_tests.cpp
@@ -25,11 +25,10 @@ static bool ExtendedCraftResponseSerialization()
     constexpr int16_t responseIndex = 12;
     constexpr uint64_t craftedItemId = 0x1122334455667788ull;
 
-    GCMessageWrite message{ k_EMsgGCCraftResponse, GCMessageWrite::StructHeader::Extended };
-    message.WriteUint16(static_cast<uint16_t>(responseIndex));
-    message.WriteUint32(k_EGCMsgResponseOK);
-    message.WriteUint16(1);
-    message.WriteUint64(craftedItemId);
+    GCMessageWrite message = BuildCraftResponseMessage(
+        responseIndex,
+        k_EGCMsgResponseOK,
+        craftedItemId);
 
     const auto *data = static_cast<const uint8_t *>(message.Data());
     size_t offset = 0;
@@ -58,6 +57,35 @@ static bool ExtendedCraftResponseSerialization()
     return valid && offset == message.Size();
 }
 
+static bool TruncatedCraftRequestGetsInvalidResponse()
+{
+    constexpr int16_t recipe = -3;
+
+    GCMessageWrite request{ k_EMsgGCCraft };
+    request.WriteUint16(static_cast<uint16_t>(recipe));
+
+    GCMessageRead requestRead{ k_EMsgGCCraft, request.Data(), request.Size() };
+    int16_t responseIndex = static_cast<int16_t>(requestRead.ReadUint16());
+    requestRead.ReadUint16();
+    if (requestRead.IsValid())
+    {
+        return false;
+    }
+
+    GCMessageWrite response = BuildCraftResponseMessage(
+        responseIndex,
+        k_EGCMsgResponseInvalid);
+    const auto *data = static_cast<const uint8_t *>(response.Data());
+    constexpr size_t responseBodyOffset = sizeof(uint32_t) + sizeof(uint32_t)
+        + sizeof(uint64_t) + sizeof(uint16_t) + sizeof(uint64_t) + sizeof(uint64_t);
+
+    return ValueAt(data, responseBodyOffset, recipe)
+        && ValueAt(data, responseBodyOffset + sizeof(int16_t),
+            static_cast<uint32_t>(k_EGCMsgResponseInvalid))
+        && ValueAt(data, responseBodyOffset + sizeof(int16_t) + sizeof(uint32_t), uint16_t{ 0 })
+        && response.Size() == responseBodyOffset + sizeof(int16_t) + sizeof(uint32_t) + sizeof(uint16_t);
+}
+
 static bool BasicStructHeaderSerializationIsUnchanged()
 {
     constexpr uint32_t messageType = 1;
@@ -81,5 +109,6 @@ static bool BasicStructHeaderSerializationIsUnchanged()
 int main()
 {
     return ExtendedCraftResponseSerialization()
+        && TruncatedCraftRequestGetsInvalidResponse()
         && BasicStructHeaderSerializationIsUnchanged() ? 0 : 1;
 }

--- a/csgo_gc/gc_message_tests.cpp
+++ b/csgo_gc/gc_message_tests.cpp
@@ -1,4 +1,5 @@
 #include "stdafx.h"
+#include "gc_client.h"
 #include "gc_message.h"
 
 #include <cstring>
@@ -8,6 +9,11 @@ namespace Platform
 
 void Print(const char *, ...)
 {
+}
+
+bool UpdateGraffitiKey(std::string_view, const void *, const void *, size_t)
+{
+    return true;
 }
 
 }
@@ -64,18 +70,40 @@ static bool TruncatedCraftRequestGetsInvalidResponse()
     GCMessageWrite request{ k_EMsgGCCraft };
     request.WriteUint16(static_cast<uint16_t>(recipe));
 
-    GCMessageRead requestRead{ k_EMsgGCCraft, request.Data(), request.Size() };
-    int16_t responseIndex = static_cast<int16_t>(requestRead.ReadUint16());
-    requestRead.ReadUint16();
-    if (requestRead.IsValid())
+    ClientGC gc{ 76561197960265729ull };
+    gc.PostToGC(GCEvent::Message, k_EMsgGCCraft, request.Data(), request.Size());
+
+    std::vector<EventData> events;
+    EventData responseEvent;
+    bool foundResponse = false;
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds{ 1 };
+    while (!foundResponse && std::chrono::steady_clock::now() < deadline)
+    {
+        gc.GetHostEvents(events);
+        for (EventData &event : events)
+        {
+            if (event.type == static_cast<int>(HostEvent::Message)
+                && event.id == k_EMsgGCCraftResponse)
+            {
+                responseEvent = std::move(event);
+                foundResponse = true;
+                break;
+            }
+        }
+
+        events.clear();
+        if (!foundResponse)
+        {
+            std::this_thread::yield();
+        }
+    }
+
+    if (!foundResponse)
     {
         return false;
     }
 
-    GCMessageWrite response = BuildCraftResponseMessage(
-        responseIndex,
-        k_EGCMsgResponseInvalid);
-    const auto *data = static_cast<const uint8_t *>(response.Data());
+    const auto *data = responseEvent.buffer.data();
     constexpr size_t responseBodyOffset = sizeof(uint32_t) + sizeof(uint32_t)
         + sizeof(uint64_t) + sizeof(uint16_t) + sizeof(uint64_t) + sizeof(uint64_t);
 
@@ -83,7 +111,8 @@ static bool TruncatedCraftRequestGetsInvalidResponse()
         && ValueAt(data, responseBodyOffset + sizeof(int16_t),
             static_cast<uint32_t>(k_EGCMsgResponseInvalid))
         && ValueAt(data, responseBodyOffset + sizeof(int16_t) + sizeof(uint32_t), uint16_t{ 0 })
-        && response.Size() == responseBodyOffset + sizeof(int16_t) + sizeof(uint32_t) + sizeof(uint16_t);
+        && responseEvent.buffer.size()
+            == responseBodyOffset + sizeof(int16_t) + sizeof(uint32_t) + sizeof(uint16_t);
 }
 
 static bool BasicStructHeaderSerializationIsUnchanged()

--- a/csgo_gc/inventory.cpp
+++ b/csgo_gc/inventory.cpp
@@ -2264,7 +2264,7 @@ void Inventory::DestroyItem(ItemMap::iterator iterator, CMsgSOSingleObject &mess
 bool Inventory::TradeUp(const std::vector<uint64_t> &inputItemIds,
     std::vector<CMsgSOSingleObject> &destroyItems,
     CMsgSOSingleObject &newItem,
-    CMsgGCItemCustomizationNotification &notification,
+    int16_t &responseRecipeIndex,
     CSOEconItem **outCraftedItem)
 {
     if (inputItemIds.size() != 10)
@@ -2579,9 +2579,8 @@ bool Inventory::TradeUp(const std::vector<uint64_t> &inputItemIds,
     }
 
     ToSingleObject(newItem, outputItem);
-
-    notification.add_item_id(outputItem.id());
-    notification.set_request(k_EGCItemCustomizationNotification_UnlockCrate);
+    responseRecipeIndex = static_cast<int16_t>(inputRarity - ItemSchema::RarityCommon
+        + (hasStatTrak ? 10 : 0));
 
     if (outCraftedItem)
     {

--- a/csgo_gc/inventory.h
+++ b/csgo_gc/inventory.h
@@ -163,7 +163,7 @@ public:
     bool TradeUp(const std::vector<uint64_t> &inputItemIds,
         std::vector<CMsgSOSingleObject> &destroyItems,
         CMsgSOSingleObject &newItem,
-        CMsgGCItemCustomizationNotification &notification,
+        int16_t &responseRecipeIndex,
         CSOEconItem **outCraftedItem = nullptr);
 
     // returns the item id and adds the item to the provided CMsgSOMultipleObjects


### PR DESCRIPTION
## Summary

- send `k_EMsgGCCraftResponse` with the extended struct header and crafted item ID
- return explicit invalid or denied responses instead of leaving the crafting UI waiting
- remove the unrelated unlock-crate notification and return the concrete trade-up recipe index
- add byte-level regression coverage for extended and existing basic struct headers

## Testing

- x86 Release build of `csgo_gc`
- `ctest --test-dir build -C Release --output-on-failure`
- in-game trade-up completion, consumed inputs, visible output, and subsequent inventory deletion

Closes #37

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added structured craft/trade-up responses covering success, invalid-input, and denied outcomes.
  * Enhanced craft response serialization with an extended non-protobuf header mode and optional crafted-item ID fields.
* **Bug Fixes**
  * Trade-up now immediately returns and sends explicit invalid/denied responses for unsupported recipes, incorrect item counts, or malformed item IDs.
  * Removed the prior success notification flow in favor of the new response messaging.
* **Tests**
  * Added/registered byte-level serialization tests for basic vs extended craft responses and for truncated/invalid requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->