### PR TITLE
Fix inventory files being erased after load failures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,7 @@ jobs:
         cmake `
           --build "${{ github.workspace }}/build" `
           --config ${{ matrix.build_type }} `
-          --target csgo srcds csgo_gc gc_message_tests item_schema_tests
+          --target csgo srcds csgo_gc gc_message_tests item_schema_tests keyvalue_tests
         ctest `
           --test-dir "${{ github.workspace }}/build" `
           --build-config ${{ matrix.build_type }} `

--- a/csgo_gc/CMakeLists.txt
+++ b/csgo_gc/CMakeLists.txt
@@ -146,4 +146,20 @@ if (BUILD_TESTING)
     endif()
 
     add_test(NAME item_schema_tests COMMAND item_schema_tests)
+
+    add_executable(keyvalue_tests
+        keyvalue_tests.cpp
+        keyvalue.cpp)
+
+    target_precompile_headers(keyvalue_tests PRIVATE stdafx.h)
+    target_link_libraries(keyvalue_tests PRIVATE csgo_gc_protobufs)
+
+    if (MSVC)
+        target_compile_options(keyvalue_tests PRIVATE /W4 /wd4244 /wd4819)
+        target_compile_definitions(keyvalue_tests PRIVATE _CRT_SECURE_NO_WARNINGS)
+    else()
+        target_compile_options(keyvalue_tests PRIVATE -Wall -Wextra)
+    endif()
+
+    add_test(NAME keyvalue_tests COMMAND keyvalue_tests)
 endif()

--- a/csgo_gc/gc_message_tests.cpp
+++ b/csgo_gc/gc_message_tests.cpp
@@ -1,8 +1,11 @@
 #include "stdafx.h"
 #include "gc_client.h"
 #include "gc_message.h"
+#include "keyvalue.h"
 
 #include <cstring>
+#include <filesystem>
+#include <cstdio>
 
 namespace Platform
 {
@@ -135,9 +138,59 @@ static bool BasicStructHeaderSerializationIsUnchanged()
     return valid && offset == message.Size();
 }
 
+static bool InventoryPersistenceProtectsFiles()
+{
+    constexpr const char *InventoryDirectory = "csgo_gc";
+    constexpr const char *InventoryPath = "csgo_gc/inventory.txt";
+    constexpr std::string_view MalformedInventory{ "\"items\"\n{\n\"2\"\n{\n" };
+
+    std::error_code error;
+    std::filesystem::create_directory(InventoryDirectory, error);
+    if (error)
+    {
+        return false;
+    }
+
+    FILE *f = fopen(InventoryPath, "wb");
+    if (!f)
+    {
+        return false;
+    }
+
+    bool wroteFile = fwrite(MalformedInventory.data(), 1, MalformedInventory.size(), f)
+        == MalformedInventory.size();
+    wroteFile &= fclose(f) == 0;
+    if (!wroteFile)
+    {
+        return false;
+    }
+
+    {
+        Inventory inventory{ 76561197960265729ull };
+    }
+
+    bool preserved = LoadFile(InventoryPath) == MalformedInventory;
+    std::filesystem::remove(InventoryPath, error);
+
+    {
+        Inventory inventory{ 76561197960265729ull };
+    }
+
+    KeyValue savedInventory{ "inventory" };
+    bool validEmptyInventory = savedInventory.ParseFromFile(InventoryPath)
+        && savedInventory.GetNumber<int>("format_version") == 1;
+
+    error.clear();
+    std::filesystem::remove(InventoryPath, error);
+    error.clear();
+    std::filesystem::remove(InventoryDirectory, error);
+    return preserved && validEmptyInventory;
+}
+
 int main()
 {
     return ExtendedCraftResponseSerialization()
         && TruncatedCraftRequestGetsInvalidResponse()
-        && BasicStructHeaderSerializationIsUnchanged() ? 0 : 1;
+        && BasicStructHeaderSerializationIsUnchanged()
+        && InventoryPersistenceProtectsFiles() ? 0 : 1;
 }

--- a/csgo_gc/inventory.cpp
+++ b/csgo_gc/inventory.cpp
@@ -218,8 +218,20 @@ CSOEconItem &Inventory::CreateItem(uint32_t defIndex, ItemOrigin origin, Unackno
 void Inventory::ReadFromFile()
 {
     KeyValue inventoryKey{ "inventory" };
-    if (!inventoryKey.ParseFromFile(InventoryFilePath))
+    KeyValueFileResult result = inventoryKey.ParseFromFileDetailed(InventoryFilePath);
+    if (result == KeyValueFileResult::NotFound)
     {
+        return;
+    }
+
+    if (result != KeyValueFileResult::Success)
+    {
+        m_saveEnabled = false;
+
+        const char *reason = result == KeyValueFileResult::Empty ? "file is empty"
+            : result == KeyValueFileResult::ReadError ? "file could not be read"
+            : "file has invalid KeyValues syntax";
+        Platform::Print("Inventory: refusing to overwrite %s because %s\n", InventoryFilePath, reason);
         return;
     }
 
@@ -308,7 +320,14 @@ void Inventory::ReadItem(const KeyValue &itemKey, CSOEconItem &item) const
 
 void Inventory::WriteToFile() const
 {
+    if (!m_saveEnabled)
+    {
+        Platform::Print("Inventory: save skipped to preserve unreadable %s\n", InventoryFilePath);
+        return;
+    }
+
     KeyValue inventoryKey{ "inventory" };
+    inventoryKey.AddNumber("format_version", 1);
 
     {
         KeyValue &itemsKey = inventoryKey.AddSubkey("items");
@@ -332,7 +351,10 @@ void Inventory::WriteToFile() const
         }
     }
 
-    inventoryKey.WriteToFile(InventoryFilePath);
+    if (!inventoryKey.WriteToFile(InventoryFilePath))
+    {
+        Platform::Print("Inventory: failed to save %s; original file was preserved\n", InventoryFilePath);
+    }
 }
 
 void Inventory::WriteItem(KeyValue &itemKey, const CSOEconItem &item) const

--- a/csgo_gc/inventory.h
+++ b/csgo_gc/inventory.h
@@ -246,4 +246,5 @@ private:
     uint32_t m_lastHighItemId{};
     ItemMap m_items;
     std::vector<CSOEconDefaultEquippedDefinitionInstanceClient> m_defaultEquips;
+    bool m_saveEnabled{ true };
 };

--- a/csgo_gc/keyvalue.cpp
+++ b/csgo_gc/keyvalue.cpp
@@ -1,5 +1,11 @@
 #include "stdafx.h"
 #include "keyvalue.h"
+#include <cerrno>
+#include <cstdio>
+
+#if defined(_WIN32)
+#include <windows.h>
+#endif
 
 constexpr auto SubkeyReserveCount = 8;
 
@@ -54,27 +60,27 @@ public:
             m_ptr++;
         }
 
-        if (m_ptr[0] != '/' || m_ptr[1] != '/')
+        if (m_ptr[0] != '/' || m_end - m_ptr < 2 || m_ptr[1] != '/')
         {
             return true;
         }
 
         m_ptr += 2;
 
-        while (*m_ptr != '\n')
+        while (!IsEndOfFile() && *m_ptr != '\n')
         {
-            if (IsEndOfFile())
-            {
-                return false;
-            }
-
             m_ptr++;
+        }
+
+        if (IsEndOfFile())
+        {
+            return false;
         }
 
         goto start;
     }
 
-    std::string_view ParseString()
+    bool ParseString(std::string_view &string)
     {
         m_ptr++; // skip the start quote
 
@@ -85,11 +91,16 @@ public:
             m_ptr++;
         }
 
+        if (IsEndOfFile())
+        {
+            return false;
+        }
+
         size_t length = m_ptr - start;
-
         m_ptr++; // skip the end quote
+        string = { &start[0], length };
 
-        return { &start[0], length };
+        return true;
     }
 
     char PeekCharacter() const
@@ -140,6 +151,42 @@ std::string LoadFile(const char *path)
     return buffer;
 }
 
+static KeyValueFileResult LoadKeyValueFile(const char *path, std::string &buffer)
+{
+    errno = 0;
+    FILE *f = fopen(path, "rb");
+    if (!f)
+    {
+        return errno == ENOENT ? KeyValueFileResult::NotFound : KeyValueFileResult::ReadError;
+    }
+
+    if (fseek(f, 0, SEEK_END) != 0)
+    {
+        fclose(f);
+        return KeyValueFileResult::ReadError;
+    }
+
+    long size = ftell(f);
+    if (size < 0 || fseek(f, 0, SEEK_SET) != 0)
+    {
+        fclose(f);
+        return KeyValueFileResult::ReadError;
+    }
+
+    if (size == 0)
+    {
+        fclose(f);
+        return KeyValueFileResult::Empty;
+    }
+
+    buffer.resize(static_cast<size_t>(size));
+    size_t bytesRead = fread(buffer.data(), 1, buffer.size(), f);
+    bool readFailed = bytesRead != buffer.size() || ferror(f);
+    readFailed |= fclose(f) != 0;
+
+    return readFailed ? KeyValueFileResult::ReadError : KeyValueFileResult::Success;
+}
+
 KeyValue::KeyValue(std::string_view name)
     : m_name{ name }
 {
@@ -147,19 +194,43 @@ KeyValue::KeyValue(std::string_view name)
 
 bool KeyValue::ParseFromFile(const char *path)
 {
-    std::string data = LoadFile(path);
-    if (data.empty())
+    return ParseFromFileDetailed(path) == KeyValueFileResult::Success;
+}
+
+KeyValueFileResult KeyValue::ParseFromFileDetailed(const char *path)
+{
+    std::string data;
+    KeyValueFileResult result = LoadKeyValueFile(path, data);
+    if (result != KeyValueFileResult::Success)
     {
-        return false;
+        return result;
     }
 
-    KeyValueParser parser{ data };
-    return Parse(parser);
+    std::string_view dataView{ data };
+    constexpr std::string_view Utf8Bom{ "\xef\xbb\xbf", 3 };
+    if (dataView.starts_with(Utf8Bom))
+    {
+        dataView.remove_prefix(Utf8Bom.size());
+    }
+
+    if (dataView.empty())
+    {
+        return KeyValueFileResult::Empty;
+    }
+
+    m_subkeys.clear();
+    m_string.clear();
+
+    KeyValueParser parser{ dataView };
+    return Parse(parser) ? KeyValueFileResult::Success : KeyValueFileResult::InvalidFormat;
 }
 
 bool KeyValue::WriteToFile(const char *path)
 {
-    FILE *f = fopen(path, "wb");
+    std::string temporaryPath = path;
+    temporaryPath.append(".tmp");
+
+    FILE *f = fopen(temporaryPath.c_str(), "wb");
     if (!f)
     {
         return false;
@@ -167,8 +238,27 @@ bool KeyValue::WriteToFile(const char *path)
 
     WriteToFile(f, 0);
 
-    fclose(f);
-    return true;
+    bool writeSucceeded = !ferror(f) && fflush(f) == 0;
+    writeSucceeded &= fclose(f) == 0;
+    if (!writeSucceeded)
+    {
+        remove(temporaryPath.c_str());
+        return false;
+    }
+
+#if defined(_WIN32)
+    bool replaced = MoveFileExA(temporaryPath.c_str(), path,
+        MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH) != FALSE;
+#else
+    bool replaced = rename(temporaryPath.c_str(), path) == 0;
+#endif
+
+    if (!replaced)
+    {
+        remove(temporaryPath.c_str());
+    }
+
+    return replaced;
 }
 
 static void BinaryWriteCommand(std::string &buffer, BinaryCommand cmd)
@@ -208,7 +298,7 @@ void KeyValue::BinaryWriteToString(std::string &buffer)
     BinaryWriteCommand(buffer, BinaryCommand::Terminate);
 }
 
-bool KeyValue::Parse(KeyValueParser &parser)
+bool KeyValue::Parse(KeyValueParser &parser, bool expectClosingBrace)
 {
     m_subkeys.reserve(SubkeyReserveCount);
 
@@ -216,7 +306,7 @@ bool KeyValue::Parse(KeyValueParser &parser)
     {
         if (!parser.NextToken())
         {
-            return true;
+            return !expectClosingBrace;
         }
 
         KeyValue *current;
@@ -224,12 +314,19 @@ bool KeyValue::Parse(KeyValueParser &parser)
         switch (parser.PeekCharacter())
         {
         case '"':
-            current = FindOrCreateSubkey(parser.ParseString());
+            {
+                std::string_view name;
+                if (!parser.ParseString(name))
+                {
+                    return false;
+                }
+                current = FindOrCreateSubkey(name);
+            }
             break;
 
         case '}':
             parser.SkipCharacter();
-            return true;
+            return expectClosingBrace;
 
         default:
             return false;
@@ -243,12 +340,19 @@ bool KeyValue::Parse(KeyValueParser &parser)
         switch (parser.PeekCharacter())
         {
         case '"':
-            current->m_string = parser.ParseString();
+            {
+                std::string_view value;
+                if (!parser.ParseString(value))
+                {
+                    return false;
+                }
+                current->m_string = value;
+            }
             break;
 
         case '{':
             parser.SkipCharacter();
-            if (!current->Parse(parser))
+            if (!current->Parse(parser, true))
             {
                 return false;
             }

--- a/csgo_gc/keyvalue.cpp
+++ b/csgo_gc/keyvalue.cpp
@@ -4,10 +4,15 @@
 #include <cstdio>
 
 #if defined(_WIN32)
+#include <io.h>
+#include <process.h>
 #include <windows.h>
+#else
+#include <unistd.h>
 #endif
 
 constexpr auto SubkeyReserveCount = 8;
+static std::atomic<uint64_t> s_temporaryFileCounter{};
 
 // for writing binary keyvalues
 enum class BinaryCommand : uint8_t
@@ -218,17 +223,29 @@ KeyValueFileResult KeyValue::ParseFromFileDetailed(const char *path)
         return KeyValueFileResult::Empty;
     }
 
-    m_subkeys.clear();
-    m_string.clear();
-
+    KeyValue parsed{ m_name };
     KeyValueParser parser{ dataView };
-    return Parse(parser) ? KeyValueFileResult::Success : KeyValueFileResult::InvalidFormat;
+    if (!parsed.Parse(parser))
+    {
+        return KeyValueFileResult::InvalidFormat;
+    }
+
+    *this = std::move(parsed);
+    return KeyValueFileResult::Success;
 }
 
 bool KeyValue::WriteToFile(const char *path)
 {
     std::string temporaryPath = path;
-    temporaryPath.append(".tmp");
+    temporaryPath.append(".tmp.");
+#if defined(_WIN32)
+    temporaryPath.append(std::to_string(_getpid()));
+#else
+    temporaryPath.append(std::to_string(getpid()));
+#endif
+    temporaryPath.push_back('.');
+    temporaryPath.append(std::to_string(
+        s_temporaryFileCounter.fetch_add(1, std::memory_order_relaxed)));
 
     FILE *f = fopen(temporaryPath.c_str(), "wb");
     if (!f)
@@ -239,6 +256,17 @@ bool KeyValue::WriteToFile(const char *path)
     WriteToFile(f, 0);
 
     bool writeSucceeded = !ferror(f) && fflush(f) == 0;
+#if defined(_WIN32)
+    if (writeSucceeded)
+    {
+        writeSucceeded = _commit(_fileno(f)) == 0;
+    }
+#else
+    if (writeSucceeded)
+    {
+        writeSucceeded = fsync(fileno(f)) == 0;
+    }
+#endif
     writeSucceeded &= fclose(f) == 0;
     if (!writeSucceeded)
     {

--- a/csgo_gc/keyvalue.h
+++ b/csgo_gc/keyvalue.h
@@ -2,6 +2,15 @@
 
 class KeyValueParser;
 
+enum class KeyValueFileResult
+{
+    Success,
+    NotFound,
+    Empty,
+    ReadError,
+    InvalidFormat
+};
+
 // not really the right place for this...
 template<typename T>
 inline T FromString(std::string_view string)
@@ -39,6 +48,7 @@ public:
     explicit KeyValue(std::string_view name);
 
     bool ParseFromFile(const char *path);
+    KeyValueFileResult ParseFromFileDetailed(const char *path);
     bool WriteToFile(const char *path);
 
     void BinaryWriteToString(std::string &buffer);
@@ -88,7 +98,7 @@ public:
     }
 
 private:
-    bool Parse(KeyValueParser &parser);
+    bool Parse(KeyValueParser &parser, bool expectClosingBrace = false);
     KeyValue *FindOrCreateSubkey(std::string_view name);
     void WriteToFile(FILE *f, int indent);
 

--- a/csgo_gc/keyvalue_tests.cpp
+++ b/csgo_gc/keyvalue_tests.cpp
@@ -1,0 +1,104 @@
+#include "stdafx.h"
+#include "keyvalue.h"
+#include <cstdio>
+
+namespace
+{
+
+constexpr const char *MissingPath = "keyvalue_test_missing.txt";
+constexpr const char *EmptyPath = "keyvalue_test_empty.txt";
+constexpr const char *MalformedPath = "keyvalue_test_malformed.txt";
+constexpr const char *BomPath = "keyvalue_test_bom.txt";
+constexpr const char *OutputPath = "keyvalue_test_output.txt";
+
+void RemoveTestFiles()
+{
+    remove(MissingPath);
+    remove(EmptyPath);
+    remove(MalformedPath);
+    remove(BomPath);
+    remove(OutputPath);
+    remove("keyvalue_test_output.txt.tmp");
+}
+
+bool WriteBytes(const char *path, std::string_view data)
+{
+    FILE *f = fopen(path, "wb");
+    if (!f)
+    {
+        return false;
+    }
+
+    bool success = fwrite(data.data(), 1, data.size(), f) == data.size();
+    success &= fclose(f) == 0;
+    return success;
+}
+
+bool DetailedFileResultsAreReported()
+{
+    KeyValue key{ "test" };
+    if (key.ParseFromFileDetailed(MissingPath) != KeyValueFileResult::NotFound)
+    {
+        return false;
+    }
+
+    if (!WriteBytes(EmptyPath, {})
+        || key.ParseFromFileDetailed(EmptyPath) != KeyValueFileResult::Empty)
+    {
+        return false;
+    }
+
+    if (!WriteBytes(MalformedPath, "\"items\"\n{\n\"value\" \"42\"\n")
+        || key.ParseFromFileDetailed(MalformedPath) != KeyValueFileResult::InvalidFormat)
+    {
+        return false;
+    }
+
+    return true;
+}
+
+bool Utf8BomIsAccepted()
+{
+    constexpr std::string_view Contents{ "\xef\xbb\xbf\"value\" \"42\"\n" };
+    if (!WriteBytes(BomPath, Contents))
+    {
+        return false;
+    }
+
+    KeyValue key{ "test" };
+    return key.ParseFromFileDetailed(BomPath) == KeyValueFileResult::Success
+        && key.GetNumber<int>("value") == 42;
+}
+
+bool ExistingFileIsAtomicallyReplaced()
+{
+    if (!WriteBytes(OutputPath, "old contents"))
+    {
+        return false;
+    }
+
+    KeyValue output{ "test" };
+    output.AddNumber("value", 1729);
+    if (!output.WriteToFile(OutputPath))
+    {
+        return false;
+    }
+
+    KeyValue input{ "test" };
+    return input.ParseFromFileDetailed(OutputPath) == KeyValueFileResult::Success
+        && input.GetNumber<int>("value") == 1729;
+}
+
+} // namespace
+
+int main()
+{
+    RemoveTestFiles();
+
+    bool success = DetailedFileResultsAreReported()
+        && Utf8BomIsAccepted()
+        && ExistingFileIsAtomicallyReplaced();
+
+    RemoveTestFiles();
+    return success ? 0 : 1;
+}

--- a/csgo_gc/keyvalue_tests.cpp
+++ b/csgo_gc/keyvalue_tests.cpp
@@ -48,8 +48,11 @@ bool DetailedFileResultsAreReported()
         return false;
     }
 
+    key.AddNumber("preserved", 7);
     if (!WriteBytes(MalformedPath, "\"items\"\n{\n\"value\" \"42\"\n")
-        || key.ParseFromFileDetailed(MalformedPath) != KeyValueFileResult::InvalidFormat)
+        || key.ParseFromFileDetailed(MalformedPath) != KeyValueFileResult::InvalidFormat
+        || key.GetNumber<int>("preserved") != 7
+        || key.GetSubkey("items"))
     {
         return false;
     }
@@ -66,8 +69,10 @@ bool Utf8BomIsAccepted()
     }
 
     KeyValue key{ "test" };
+    key.AddNumber("old", 1);
     return key.ParseFromFileDetailed(BomPath) == KeyValueFileResult::Success
-        && key.GetNumber<int>("value") == 42;
+        && key.GetNumber<int>("value") == 42
+        && !key.GetSubkey("old");
 }
 
 bool ExistingFileIsAtomicallyReplaced()


### PR DESCRIPTION
## Summary

- preserve empty, unreadable, or malformed inventory files instead of overwriting them during shutdown
- write KeyValues files through a temporary file and atomically replace the destination
- make empty inventories serialize to a valid non-zero-length file
- accept UTF-8 BOMs and reject truncated KeyValues input safely
- add regression coverage for file parsing, atomic replacement, and inventory preservation

## Testing

- built the Windows x86 Release csgo_gc target
- passed gc_message_tests, item_schema_tests, and keyvalue_tests
- manually verified inventory persistence in-game

Fixes #50

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inventory file handling for missing, empty, unreadable, and malformed files.
  * Prevented invalid or failed inventory data from overwriting existing files.
  * Added safer file writing with temporary files and replacement checks.
  * Improved parsing of nested data, comments, strings, and UTF-8 BOM files.

* **Tests**
  * Added coverage for malformed, empty, missing, and valid data files.
  * Verified inventory data is preserved after parsing failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->