### PR TITLE
Handle RCON listener startup failures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,8 +84,7 @@ jobs:
           -DBUILD_TESTING=ON
         cmake `
           --build "${{ github.workspace }}/build" `
-          --config ${{ matrix.build_type }} `
-          --target csgo srcds csgo_gc gc_message_tests item_schema_tests keyvalue_tests
+          --config ${{ matrix.build_type }}
         ctest `
           --test-dir "${{ github.workspace }}/build" `
           --build-config ${{ matrix.build_type }} `

--- a/csgo_gc/CMakeLists.txt
+++ b/csgo_gc/CMakeLists.txt
@@ -162,4 +162,32 @@ if (BUILD_TESTING)
     endif()
 
     add_test(NAME keyvalue_tests COMMAND keyvalue_tests)
+
+    add_executable(rcon_server_tests
+        config.cpp
+        keyvalue.cpp
+        rcon_server.cpp
+        rcon_server_tests.cpp)
+
+    target_precompile_headers(rcon_server_tests PRIVATE stdafx.h)
+    target_link_libraries(rcon_server_tests PRIVATE
+        csgo_gc_protobufs
+        Threads::Threads)
+
+    if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
+        target_link_libraries(rcon_server_tests PRIVATE ws2_32)
+    endif()
+
+    if (MSVC)
+        target_compile_options(rcon_server_tests PRIVATE /W4 /wd4244 /wd4819)
+        target_compile_definitions(rcon_server_tests PRIVATE _CRT_SECURE_NO_WARNINGS)
+    else()
+        target_compile_options(rcon_server_tests PRIVATE -Wall -Wextra)
+    endif()
+
+    set(RCON_SERVER_TEST_WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/rcon_server_test_workdir")
+    file(MAKE_DIRECTORY "${RCON_SERVER_TEST_WORKING_DIRECTORY}")
+    add_test(NAME rcon_server_tests COMMAND rcon_server_tests)
+    set_tests_properties(rcon_server_tests PROPERTIES
+        WORKING_DIRECTORY "${RCON_SERVER_TEST_WORKING_DIRECTORY}")
 endif()

--- a/csgo_gc/rcon_server.cpp
+++ b/csgo_gc/rcon_server.cpp
@@ -3,6 +3,8 @@
 #include "config.h"
 #include "gc_client.h"
 
+#include <system_error>
+
 #ifdef _WIN32
 #include <winsock2.h>
 #include <ws2tcpip.h>
@@ -68,6 +70,15 @@ void ShutdownSocket(SocketType socket)
     shutdown(socket, SD_BOTH);
 #else
     shutdown(socket, SHUT_RDWR);
+#endif
+}
+
+int LastSocketError()
+{
+#ifdef _WIN32
+    return WSAGetLastError();
+#else
+    return errno;
 #endif
 }
 
@@ -179,6 +190,7 @@ RconServer::~RconServer()
 
 void RconServer::Start()
 {
+    std::lock_guard lifecycleLock{ m_lifecycleMutex };
     const GCConfig &config = GetConfig();
 
     Platform::Print("RCON: config enabled=%d bind_address=%s port=%u protocol=source password=%s\n",
@@ -198,28 +210,45 @@ void RconServer::Start()
         Platform::Print("WARNING: RCON is enabled with an empty password; any Source RCON password will authenticate. Keep bind_address local or set rcon.password.\n");
     }
 
-    bool expected = false;
-    if (!m_running.compare_exchange_strong(expected, true))
+    switch (m_listenerState.load())
     {
+    case ListenerState::Starting:
+    case ListenerState::Running:
         Platform::Print("RCON: already running\n");
         return;
+
+    case ListenerState::Failed:
+        Platform::Print("RCON: disabled for this process after listener failure\n");
+        return;
+
+    case ListenerState::Stopped:
+        Platform::Print("RCON: already stopped\n");
+        return;
+
+    case ListenerState::NotStarted:
+        break;
     }
 
+    m_listenerState.store(ListenerState::Starting);
+    m_running.store(true);
     Platform::Print("RCON: starting listener thread\n");
-    m_thread = std::thread{ &RconServer::ThreadMain, this };
+    try
+    {
+        m_thread = std::thread{ &RconServer::ThreadMain, this };
+    }
+    catch (const std::system_error &error)
+    {
+        MarkListenerFailed();
+        Platform::Print("RCON: failed to start listener thread (error %d); disabled for this process\n",
+            error.code().value());
+    }
 }
 
 void RconServer::Stop()
 {
-    bool expected = true;
-    if (!m_running.compare_exchange_strong(expected, false))
-    {
-        if (m_thread.joinable())
-        {
-            m_thread.join();
-        }
-        return;
-    }
+    std::lock_guard lifecycleLock{ m_lifecycleMutex };
+    m_listenerState.store(ListenerState::Stopped);
+    m_running.store(false);
 
     SocketType listenSocket = InvalidSocket;
     {
@@ -261,10 +290,11 @@ void RconServer::ThreadMain()
 {
 #ifdef _WIN32
     WSADATA wsaData;
-    if (WSAStartup(MAKEWORD(2, 2), &wsaData) != 0)
+    int startupError = WSAStartup(MAKEWORD(2, 2), &wsaData);
+    if (startupError != 0)
     {
-        Platform::Print("RCON: WSAStartup failed\n");
-        m_running.store(false);
+        MarkListenerFailed();
+        Platform::Print("RCON: WSAStartup failed (error %d); disabled for this process\n", startupError);
         return;
     }
 #endif
@@ -279,10 +309,11 @@ void RconServer::ThreadMain()
     int gai = getaddrinfo(GetConfig().RconBindAddress().c_str(), port.c_str(), &hints, &result);
     if (gai != 0)
     {
-        Platform::Print("RCON: getaddrinfo failed for %s:%s\n",
+        MarkListenerFailed();
+        Platform::Print("RCON: getaddrinfo failed for %s:%s (error %d); disabled for this process\n",
             GetConfig().RconBindAddress().c_str(),
-            port.c_str());
-        m_running.store(false);
+            port.c_str(),
+            gai);
 #ifdef _WIN32
         WSACleanup();
 #endif
@@ -290,23 +321,37 @@ void RconServer::ThreadMain()
     }
 
     SocketType listenSocket = InvalidSocket;
+    const char *failedOperation = "socket";
+    int socketError = 0;
     for (addrinfo *it = result; it; it = it->ai_next)
     {
         listenSocket = socket(it->ai_family, it->ai_socktype, it->ai_protocol);
         if (listenSocket == InvalidSocket)
         {
+            failedOperation = "socket";
+            socketError = LastSocketError();
             continue;
         }
 
         int reuse = 1;
         setsockopt(listenSocket, SOL_SOCKET, SO_REUSEADDR, reinterpret_cast<const char *>(&reuse), sizeof(reuse));
 
-        if (bind(listenSocket, it->ai_addr, static_cast<int>(it->ai_addrlen)) == 0
-            && listen(listenSocket, 8) == 0)
+        if (bind(listenSocket, it->ai_addr, static_cast<int>(it->ai_addrlen)) != 0)
+        {
+            failedOperation = "bind";
+            socketError = LastSocketError();
+            CloseSocket(listenSocket);
+            listenSocket = InvalidSocket;
+            continue;
+        }
+
+        if (listen(listenSocket, 8) == 0)
         {
             break;
         }
 
+        failedOperation = "listen";
+        socketError = LastSocketError();
         CloseSocket(listenSocket);
         listenSocket = InvalidSocket;
     }
@@ -315,10 +360,22 @@ void RconServer::ThreadMain()
 
     if (listenSocket == InvalidSocket)
     {
-        Platform::Print("RCON: failed to listen on %s:%s\n",
+        MarkListenerFailed();
+        Platform::Print("RCON: %s failed on %s:%s (socket error %d); disabled for this process\n",
+            failedOperation,
             GetConfig().RconBindAddress().c_str(),
-            port.c_str());
-        m_running.store(false);
+            port.c_str(),
+            socketError);
+#ifdef _WIN32
+        WSACleanup();
+#endif
+        return;
+    }
+
+    ListenerState expected = ListenerState::Starting;
+    if (!m_listenerState.compare_exchange_strong(expected, ListenerState::Running))
+    {
+        CloseSocket(listenSocket);
 #ifdef _WIN32
         WSACleanup();
 #endif
@@ -327,6 +384,14 @@ void RconServer::ThreadMain()
 
     {
         std::lock_guard lock{ m_mutex };
+        if (!m_running.load())
+        {
+            CloseSocket(listenSocket);
+#ifdef _WIN32
+            WSACleanup();
+#endif
+            return;
+        }
         m_listenSocket = ToHandle(listenSocket);
     }
 
@@ -339,7 +404,8 @@ void RconServer::ThreadMain()
         {
             if (m_running.load())
             {
-                Platform::Print("RCON: accept failed\n");
+                Platform::Print("RCON: accept failed (socket error %d); disabled for this process\n",
+                    LastSocketError());
             }
             break;
         }
@@ -353,14 +419,28 @@ void RconServer::ThreadMain()
         m_listenSocket = ToHandle(InvalidSocket);
     }
 
-    if (m_running.load())
+    bool listenerFailed = m_running.exchange(false);
+    if (listenerFailed)
     {
         CloseSocket(listenSocket);
+        MarkListenerFailed();
     }
 
 #ifdef _WIN32
     WSACleanup();
 #endif
+}
+
+void RconServer::MarkListenerFailed()
+{
+    m_running.store(false);
+
+    ListenerState expected = ListenerState::Starting;
+    if (!m_listenerState.compare_exchange_strong(expected, ListenerState::Failed))
+    {
+        expected = ListenerState::Running;
+        m_listenerState.compare_exchange_strong(expected, ListenerState::Failed);
+    }
 }
 
 void RconServer::HandleConnection(uintptr_t socketHandle)

--- a/csgo_gc/rcon_server.cpp
+++ b/csgo_gc/rcon_server.cpp
@@ -297,6 +297,11 @@ void RconServer::ThreadMain()
         Platform::Print("RCON: WSAStartup failed (error %d); disabled for this process\n", startupError);
         return;
     }
+
+    struct WinsockCleanup
+    {
+        ~WinsockCleanup() { WSACleanup(); }
+    } winsockCleanup;
 #endif
 
     addrinfo hints{};
@@ -314,9 +319,6 @@ void RconServer::ThreadMain()
             GetConfig().RconBindAddress().c_str(),
             port.c_str(),
             gai);
-#ifdef _WIN32
-        WSACleanup();
-#endif
         return;
     }
 
@@ -366,9 +368,6 @@ void RconServer::ThreadMain()
             GetConfig().RconBindAddress().c_str(),
             port.c_str(),
             socketError);
-#ifdef _WIN32
-        WSACleanup();
-#endif
         return;
     }
 
@@ -376,9 +375,6 @@ void RconServer::ThreadMain()
     if (!m_listenerState.compare_exchange_strong(expected, ListenerState::Running))
     {
         CloseSocket(listenSocket);
-#ifdef _WIN32
-        WSACleanup();
-#endif
         return;
     }
 
@@ -387,9 +383,6 @@ void RconServer::ThreadMain()
         if (!m_running.load())
         {
             CloseSocket(listenSocket);
-#ifdef _WIN32
-            WSACleanup();
-#endif
             return;
         }
         m_listenSocket = ToHandle(listenSocket);
@@ -426,9 +419,6 @@ void RconServer::ThreadMain()
         MarkListenerFailed();
     }
 
-#ifdef _WIN32
-    WSACleanup();
-#endif
 }
 
 void RconServer::MarkListenerFailed()

--- a/csgo_gc/rcon_server.h
+++ b/csgo_gc/rcon_server.h
@@ -15,7 +15,17 @@ public:
     void UnregisterClient(ClientGC *client);
 
 private:
+    enum class ListenerState
+    {
+        NotStarted,
+        Starting,
+        Running,
+        Failed,
+        Stopped
+    };
+
     void ThreadMain();
+    void MarkListenerFailed();
     void HandleConnection(uintptr_t socketHandle);
     bool HandlePacketBuffer(uintptr_t socketHandle, std::string &buffer, bool &authenticated);
     bool HandlePacket(uintptr_t socketHandle, int32_t requestId, int32_t type, std::string_view body, bool &authenticated);
@@ -25,6 +35,7 @@ private:
 
     class ActiveClientCommand;
 
+    std::mutex m_lifecycleMutex;
     std::mutex m_mutex;
     std::condition_variable m_clientIdle;
     ClientGC *m_client{};
@@ -32,5 +43,6 @@ private:
     std::thread m_thread;
     std::vector<std::thread> m_connectionThreads;
     std::atomic<bool> m_running{ false };
+    std::atomic<ListenerState> m_listenerState{ ListenerState::NotStarted };
     uintptr_t m_listenSocket{ UINTPTR_MAX };
 };

--- a/csgo_gc/rcon_server_tests.cpp
+++ b/csgo_gc/rcon_server_tests.cpp
@@ -1,0 +1,124 @@
+#include "stdafx.h"
+#include "gc_client.h"
+#include "rcon_server.h"
+
+#include <cstdarg>
+#include <cstdio>
+#include <filesystem>
+
+namespace
+{
+
+std::mutex s_logMutex;
+std::condition_variable s_logChanged;
+std::vector<std::string> s_logMessages;
+
+bool WriteConfig()
+{
+    std::error_code error;
+    std::filesystem::create_directories("csgo_gc", error);
+    if (error)
+    {
+        return false;
+    }
+
+    constexpr std::string_view config{
+        "\"rcon\"\n"
+        "{\n"
+        "    \"enabled\" \"1\"\n"
+        "    \"bind_address\" \"192.0.2.1\"\n"
+        "    \"port\" \"37016\"\n"
+        "    \"password\" \"test-password\"\n"
+        "}\n"
+    };
+
+    FILE *file = fopen("csgo_gc/config.txt", "wb");
+    if (!file)
+    {
+        return false;
+    }
+
+    bool success = fwrite(config.data(), 1, config.size(), file) == config.size();
+    success &= fclose(file) == 0;
+    return success;
+}
+
+bool WaitForLog(std::string_view fragment)
+{
+    std::unique_lock lock{ s_logMutex };
+    return s_logChanged.wait_for(lock, std::chrono::seconds{ 5 }, [fragment] {
+        return std::any_of(s_logMessages.begin(), s_logMessages.end(), [fragment](const std::string &message) {
+            return message.find(fragment) != std::string::npos;
+        });
+    });
+}
+
+size_t CountLogs(std::string_view fragment)
+{
+    std::lock_guard lock{ s_logMutex };
+    return static_cast<size_t>(std::count_if(s_logMessages.begin(), s_logMessages.end(), [fragment](const std::string &message) {
+        return message.find(fragment) != std::string::npos;
+    }));
+}
+
+bool ListenerFailureDisablesRconWithoutRetrying()
+{
+    if (!WriteConfig())
+    {
+        return false;
+    }
+
+    RconServer server;
+    server.Start();
+    if (!WaitForLog("RCON: bind failed on 192.0.2.1:37016"))
+    {
+        return false;
+    }
+
+    server.RegisterClient(nullptr);
+    server.Stop();
+
+    return CountLogs("RCON: starting listener thread") == 1
+        && CountLogs("RCON: disabled for this process after listener failure") == 1;
+}
+
+} // namespace
+
+namespace Platform
+{
+
+void Print(const char *format, ...)
+{
+    char buffer[1024];
+    va_list args;
+    va_start(args, format);
+    vsnprintf(buffer, sizeof(buffer), format, args);
+    va_end(args);
+
+    {
+        std::lock_guard lock{ s_logMutex };
+        s_logMessages.emplace_back(buffer);
+    }
+    s_logChanged.notify_all();
+}
+
+} // namespace Platform
+
+std::string ClientGC::RunRconCommand(std::string)
+{
+    return {};
+}
+
+std::string ClientGC::RconCommandUsageList()
+{
+    return {};
+}
+
+int main()
+{
+    bool success = ListenerFailureDisablesRconWithoutRetrying();
+
+    std::error_code error;
+    std::filesystem::remove_all("csgo_gc", error);
+    return success ? 0 : 1;
+}


### PR DESCRIPTION
Fix #52

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RCON server startup and shutdown reliability.
  * Added clearer handling and reporting of socket and listener failures.
  * Prevented startup race conditions and correctly handles thread-creation failures.
  * Ensured failed listeners are cleaned up and permanently disabled when necessary.

* **Tests**
  * Added automated coverage for RCON listener failures, startup behavior, client registration, and shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->