### PR TITLE
Support souvenir sticker slot assignment

### DIFF
--- a/csgo_gc/CMakeLists.txt
+++ b/csgo_gc/CMakeLists.txt
@@ -147,6 +147,25 @@ if (BUILD_TESTING)
 
     add_test(NAME item_schema_tests COMMAND item_schema_tests)
 
+    add_executable(souvenir_tests
+        config.cpp
+        item_schema.cpp
+        keyvalue.cpp
+        souvenir.cpp
+        souvenir_tests.cpp)
+
+    target_precompile_headers(souvenir_tests PRIVATE stdafx.h)
+    target_link_libraries(souvenir_tests PRIVATE csgo_gc_protobufs)
+
+    if (MSVC)
+        target_compile_options(souvenir_tests PRIVATE /W4 /wd4244 /wd4819)
+        target_compile_definitions(souvenir_tests PRIVATE _CRT_SECURE_NO_WARNINGS)
+    else()
+        target_compile_options(souvenir_tests PRIVATE -Wall -Wextra)
+    endif()
+
+    add_test(NAME souvenir_tests COMMAND souvenir_tests)
+
     add_executable(keyvalue_tests
         keyvalue_tests.cpp
         keyvalue.cpp)

--- a/csgo_gc/gc_message_tests.cpp
+++ b/csgo_gc/gc_message_tests.cpp
@@ -2,9 +2,9 @@
 #include "gc_client.h"
 #include "gc_message.h"
 #include "keyvalue.h"
+#include "test_filesystem.h"
 
 #include <cstring>
-#include <filesystem>
 #include <cstdio>
 
 namespace Platform
@@ -144,9 +144,7 @@ static bool InventoryPersistenceProtectsFiles()
     constexpr const char *InventoryPath = "csgo_gc/inventory.txt";
     constexpr std::string_view MalformedInventory{ "\"items\"\n{\n\"2\"\n{\n" };
 
-    std::error_code error;
-    std::filesystem::create_directory(InventoryDirectory, error);
-    if (error)
+    if (!TestFilesystem::MakeDirectory(InventoryDirectory))
     {
         return false;
     }
@@ -170,7 +168,7 @@ static bool InventoryPersistenceProtectsFiles()
     }
 
     bool preserved = LoadFile(InventoryPath) == MalformedInventory;
-    std::filesystem::remove(InventoryPath, error);
+    TestFilesystem::RemoveFile(InventoryPath);
 
     {
         Inventory inventory{ 76561197960265729ull };
@@ -180,10 +178,8 @@ static bool InventoryPersistenceProtectsFiles()
     bool validEmptyInventory = savedInventory.ParseFromFile(InventoryPath)
         && savedInventory.GetNumber<int>("format_version") == 1;
 
-    error.clear();
-    std::filesystem::remove(InventoryPath, error);
-    error.clear();
-    std::filesystem::remove(InventoryDirectory, error);
+    TestFilesystem::RemoveFile(InventoryPath);
+    TestFilesystem::RemoveDirectory(InventoryDirectory);
     return preserved && validEmptyInventory;
 }
 

--- a/csgo_gc/item_schema.cpp
+++ b/csgo_gc/item_schema.cpp
@@ -68,6 +68,7 @@ ItemInfo::ItemInfo(uint32_t defIndex)
     , m_quality{ ItemSchema::QualityNormal }
     , m_level{ 1 }
     , m_supplyCrateSeries{ 0 }
+    , m_stickerSlotCount{ 0 }
     , m_canSticker{ false }
     , m_canPatch{ false }
     , m_nameable{ false }
@@ -838,6 +839,22 @@ void ItemSchema::ParseItemRecursive(ItemInfo &info, const KeyValue &itemKey, con
     if (lootListName.size())
     {
         info.m_lootListName = lootListName;
+    }
+
+    const KeyValue *stickers = itemKey.GetSubkey("stickers");
+    if (stickers)
+    {
+        for (const KeyValue &sticker : *stickers)
+        {
+            uint32_t slot = FromString<uint32_t>(sticker.Name());
+            if (slot >= static_cast<uint32_t>(MaxStickers))
+            {
+                Platform::Print("Item %u has unsupported sticker slot %u\n", info.m_defIndex, slot);
+                continue;
+            }
+
+            info.m_stickerSlotCount = std::max(info.m_stickerSlotCount, slot + 1);
+        }
     }
 
     info.m_willProduceStatTrak = itemKey.GetNumber("will_produce_stattrak", false);

--- a/csgo_gc/item_schema.h
+++ b/csgo_gc/item_schema.h
@@ -40,6 +40,7 @@ public:
     uint32_t m_quality;
     uint32_t m_level;
     uint32_t m_supplyCrateSeries; // cases only
+    uint32_t m_stickerSlotCount;
     TournamentMetadata m_tournament;
     std::string m_itemType;
     std::vector<std::string> m_prefabs;
@@ -338,4 +339,5 @@ private:
     std::unordered_map<uint32_t, const LootList &> m_revolvingLootLists;
 
     friend class ItemSchemaTestFixture;
+    friend class SouvenirTestFixture;
 };

--- a/csgo_gc/item_schema_tests.cpp
+++ b/csgo_gc/item_schema_tests.cpp
@@ -54,6 +54,34 @@ public:
         schema.m_revolvingLootLists.try_emplace(1, packageContents);
     }
 
+    bool ParseStickerSlotCounts()
+    {
+        KeyValue prefabs{ "prefabs" };
+
+        KeyValue &fourSlotPrefab = prefabs.AddSubkey("four_slot_weapon");
+        KeyValue &fourSlots = fourSlotPrefab.AddSubkey("stickers");
+        fourSlots.AddSubkey("0");
+        fourSlots.AddSubkey("1");
+        fourSlots.AddSubkey("2");
+        fourSlots.AddSubkey("3");
+
+        KeyValue &fiveSlotPrefab = prefabs.AddSubkey("five_slot_weapon");
+        fiveSlotPrefab.AddString("prefab", "four_slot_weapon");
+        fiveSlotPrefab.AddSubkey("stickers").AddSubkey("4");
+
+        KeyValue items{ "items" };
+        items.AddSubkey("7").AddString("prefab", "four_slot_weapon");
+        items.AddSubkey("11").AddString("prefab", "five_slot_weapon");
+
+        schema.ParseItems(&items, &prefabs);
+
+        const ItemInfo *fourSlotItem = schema.ItemInfoByDefIndex(7);
+        const ItemInfo *fiveSlotItem = schema.ItemInfoByDefIndex(11);
+        return fourSlotItem && fiveSlotItem
+            && fourSlotItem->m_stickerSlotCount == 4
+            && fiveSlotItem->m_stickerSlotCount == 5;
+    }
+
     ItemSchema schema;
 };
 
@@ -85,6 +113,12 @@ static bool NestedPaintedLootListIsSouvenir()
     return fixture.schema.IsSouvenirPackage(package);
 }
 
+static bool StickerSlotCountsFollowPrefabData()
+{
+    ItemSchemaTestFixture fixture;
+    return fixture.ParseStickerSlotCounts();
+}
+
 int main()
 {
     if (!TournamentStickerCapsuleIsNotSouvenir())
@@ -95,6 +129,11 @@ int main()
     if (!NestedPaintedLootListIsSouvenir())
     {
         return 2;
+    }
+
+    if (!StickerSlotCountsFollowPrefabData())
+    {
+        return 3;
     }
 
     return 0;

--- a/csgo_gc/random.h
+++ b/csgo_gc/random.h
@@ -3,6 +3,16 @@
 class Random
 {
 public:
+    Random()
+        : m_engine{ std::random_device{}() }
+    {
+    }
+
+    explicit Random(uint32_t seed)
+        : m_engine{ seed }
+    {
+    }
+
     template<typename T>
     T Integer(T min, T max)
     {
@@ -21,5 +31,5 @@ public:
     }
 
 private:
-    std::mt19937 m_engine{ std::random_device{}() };
+    std::mt19937 m_engine;
 };

--- a/csgo_gc/rcon_server_tests.cpp
+++ b/csgo_gc/rcon_server_tests.cpp
@@ -1,10 +1,10 @@
 #include "stdafx.h"
 #include "gc_client.h"
 #include "rcon_server.h"
+#include "test_filesystem.h"
 
 #include <cstdarg>
 #include <cstdio>
-#include <filesystem>
 
 namespace
 {
@@ -15,9 +15,7 @@ std::vector<std::string> s_logMessages;
 
 bool WriteConfig()
 {
-    std::error_code error;
-    std::filesystem::create_directories("csgo_gc", error);
-    if (error)
+    if (!TestFilesystem::MakeDirectory("csgo_gc"))
     {
         return false;
     }
@@ -118,7 +116,7 @@ int main()
 {
     bool success = ListenerFailureDisablesRconWithoutRetrying();
 
-    std::error_code error;
-    std::filesystem::remove_all("csgo_gc", error);
+    TestFilesystem::RemoveFile("csgo_gc/config.txt");
+    TestFilesystem::RemoveDirectory("csgo_gc");
     return success ? 0 : 1;
 }

--- a/csgo_gc/souvenir.cpp
+++ b/csgo_gc/souvenir.cpp
@@ -40,6 +40,16 @@ namespace SouvenirTournament
     constexpr uint32_t Paris2023 = 21;
 }
 
+namespace DreamHack2013Sticker
+{
+    constexpr float MinWear = 0.2f;
+    constexpr float MaxWear = 0.3f;
+    constexpr float MinScale = 1.0f;
+    constexpr float MaxScale = 1.2f;
+    constexpr float MinRotation = -10.0f;
+    constexpr float MaxRotation = 10.0f;
+}
+
 enum class SouvenirFormat
 {
     Unknown,
@@ -307,11 +317,18 @@ bool SouvenirOpening::OpenPackage(const CSOEconItem &package, CSOEconItem &item)
     uint32_t team1StickerKit = team1Kit ? team1Kit->m_defIndex : 0;
     uint32_t fourthStickerKit = fourthKit ? fourthKit->m_defIndex : 0;
 
-    Platform::Print("SouvenirOpening: event %u stage %u teams %u/%u mvp %u stickers %u/%u/%u/%u\n",
-        tournament.eventId, tournament.stageId, tournament.team0Id, tournament.team1Id, tournament.mvpAccountId,
-        eventStickerKit, team0StickerKit, team1StickerKit, fourthStickerKit);
+    const ItemInfo *itemInfo = m_itemSchema.ItemInfoByDefIndex(item.def_index());
+    uint32_t stickerSlotCount = itemInfo ? itemInfo->m_stickerSlotCount : 0;
 
-    ApplyTournamentAttributes(item, eventStickerKit, team0StickerKit, team1StickerKit, fourthStickerKit);
+    Platform::Print("SouvenirOpening: event %u stage %u teams %u/%u mvp %u stickers %u/%u/%u/%u slots %u\n",
+        tournament.eventId, tournament.stageId, tournament.team0Id, tournament.team1Id, tournament.mvpAccountId,
+        eventStickerKit, team0StickerKit, team1StickerKit, fourthStickerKit, stickerSlotCount);
+
+    if (!ApplyTournamentAttributes(item, stickerSlotCount, format == SouvenirFormat::EventOnly,
+            eventStickerKit, team0StickerKit, team1StickerKit, fourthStickerKit))
+    {
+        return false;
+    }
 
     return true;
 }
@@ -373,49 +390,96 @@ const LootListItem *SouvenirOpening::SelectItem(const std::vector<const LootList
     return nullptr;
 }
 
-void SouvenirOpening::ApplyTournamentAttributes(CSOEconItem &item, uint32_t eventStickerKit, uint32_t team1StickerKit, uint32_t team2StickerKit, uint32_t fourthStickerKit)
+bool SouvenirOpening::ApplyTournamentAttributes(CSOEconItem &item,
+    uint32_t stickerSlotCount,
+    bool dreamHack2013,
+    uint32_t eventStickerKit,
+    uint32_t team1StickerKit,
+    uint32_t team2StickerKit,
+    uint32_t fourthStickerKit)
 {
-    // Souvenir stickers are mint condition with default scale and rotation.
-    auto addSticker = [&](uint32_t stickerIdAttr, uint32_t wearAttr, uint32_t scaleAttr, uint32_t rotationAttr, uint32_t stickerKitDefIndex)
+    std::vector<uint32_t> stickerKits;
+    for (uint32_t stickerKit : { eventStickerKit, team1StickerKit, team2StickerKit, fourthStickerKit })
     {
-        if (stickerKitDefIndex == 0)
+        if (stickerKit != 0)
         {
-            return;
+            stickerKits.push_back(stickerKit);
         }
+    }
+
+    if (stickerKits.empty())
+    {
+        return true;
+    }
+
+    if (stickerSlotCount > static_cast<uint32_t>(MaxStickers)
+        || stickerKits.size() > stickerSlotCount)
+    {
+        Platform::Print("SouvenirOpening: item def %u has %u sticker slots for %zu stickers\n",
+            item.def_index(), stickerSlotCount, stickerKits.size());
+        return false;
+    }
+
+    std::array<uint32_t, MaxStickers> slots{};
+    for (uint32_t slot = 0; slot < stickerSlotCount; slot++)
+    {
+        slots[slot] = slot;
+    }
+
+    // Shuffle all valid slots, then use the first N. This produces a uniform
+    // assignment without placing two stickers in the same slot.
+    for (size_t count = stickerSlotCount; count > 1; count--)
+    {
+        size_t other = m_random.Integer<size_t>(0, count - 1);
+        std::swap(slots[count - 1], slots[other]);
+    }
+
+    for (size_t i = 0; i < stickerKits.size(); i++)
+    {
+        uint32_t slot = slots[i];
+        uint32_t stickerIdAttribute = ItemSchema::AttributeStickerId0 + slot * 4;
+        uint32_t stickerWearAttribute = ItemSchema::AttributeStickerWear0 + slot * 4;
+        uint32_t stickerScaleAttribute = ItemSchema::AttributeStickerScale0 + slot * 4;
+        uint32_t stickerRotationAttribute = ItemSchema::AttributeStickerRotation0 + slot * 4;
+
+        float wear = dreamHack2013
+            ? m_random.Float(DreamHack2013Sticker::MinWear, DreamHack2013Sticker::MaxWear)
+            : 0.0f;
+        float scale = dreamHack2013
+            ? m_random.Float(DreamHack2013Sticker::MinScale, DreamHack2013Sticker::MaxScale)
+            : 1.0f;
+        float rotation = dreamHack2013
+            ? m_random.Float(DreamHack2013Sticker::MinRotation, DreamHack2013Sticker::MaxRotation)
+            : 0.0f;
 
         CSOEconItemAttribute *attribute = item.add_attribute();
-        attribute->set_def_index(stickerIdAttr);
-        m_itemSchema.SetAttributeUint32(attribute, stickerKitDefIndex);
+        attribute->set_def_index(stickerIdAttribute);
+        if (!m_itemSchema.SetAttributeUint32(attribute, stickerKits[i]))
+        {
+            return false;
+        }
 
         attribute = item.add_attribute();
-        attribute->set_def_index(wearAttr);
-        m_itemSchema.SetAttributeFloat(attribute, 0.0f);
+        attribute->set_def_index(stickerWearAttribute);
+        if (!m_itemSchema.SetAttributeFloat(attribute, wear))
+        {
+            return false;
+        }
 
         attribute = item.add_attribute();
-        attribute->set_def_index(scaleAttr);
-        m_itemSchema.SetAttributeFloat(attribute, 1.0f);
+        attribute->set_def_index(stickerScaleAttribute);
+        if (!m_itemSchema.SetAttributeFloat(attribute, scale))
+        {
+            return false;
+        }
 
         attribute = item.add_attribute();
-        attribute->set_def_index(rotationAttr);
-        m_itemSchema.SetAttributeFloat(attribute, 0.0f);
-    };
-
-    // event sticker (slot 0)
-    addSticker(ItemSchema::AttributeStickerId0, ItemSchema::AttributeStickerWear0,
-        ItemSchema::AttributeStickerScale0, ItemSchema::AttributeStickerRotation0, eventStickerKit);
-
-    // team 1 sticker (slot 1)
-    addSticker(ItemSchema::AttributeStickerId1, ItemSchema::AttributeStickerWear1,
-        ItemSchema::AttributeStickerScale1, ItemSchema::AttributeStickerRotation1, team1StickerKit);
-
-    // team 2 sticker (slot 2)
-    addSticker(ItemSchema::AttributeStickerId2, ItemSchema::AttributeStickerWear2,
-        ItemSchema::AttributeStickerScale2, ItemSchema::AttributeStickerRotation2, team2StickerKit);
-
-    // MVP autograph (2015-2019) or map gold sticker (2021+) in slot 3.
-    if (fourthStickerKit != 0)
-    {
-        addSticker(ItemSchema::AttributeStickerId3, ItemSchema::AttributeStickerWear3,
-            ItemSchema::AttributeStickerScale3, ItemSchema::AttributeStickerRotation3, fourthStickerKit);
+        attribute->set_def_index(stickerRotationAttribute);
+        if (!m_itemSchema.SetAttributeFloat(attribute, rotation))
+        {
+            return false;
+        }
     }
+
+    return true;
 }

--- a/csgo_gc/souvenir.h
+++ b/csgo_gc/souvenir.h
@@ -15,8 +15,16 @@ public:
 
 private:
     const LootListItem *SelectItem(const std::vector<const LootListItem *> &items);
-    void ApplyTournamentAttributes(CSOEconItem &item, uint32_t eventStickerKit, uint32_t team1StickerKit, uint32_t team2StickerKit, uint32_t fourthStickerKit);
+    bool ApplyTournamentAttributes(CSOEconItem &item,
+        uint32_t stickerSlotCount,
+        bool dreamHack2013,
+        uint32_t eventStickerKit,
+        uint32_t team1StickerKit,
+        uint32_t team2StickerKit,
+        uint32_t fourthStickerKit);
 
     const ItemSchema &m_itemSchema;
     Random &m_random;
+
+    friend class SouvenirTestFixture;
 };

--- a/csgo_gc/souvenir_tests.cpp
+++ b/csgo_gc/souvenir_tests.cpp
@@ -1,0 +1,321 @@
+#include "stdafx.h"
+#include "item_schema.h"
+#include "keyvalue.h"
+#include "random.h"
+#include "souvenir.h"
+
+namespace Platform
+{
+
+void Print(const char *, ...)
+{
+}
+
+}
+
+class SouvenirTestFixture
+{
+public:
+    explicit SouvenirTestFixture(uint32_t seed)
+        : schema{ false }
+        , random{ seed }
+        , opening{ schema, random }
+    {
+        for (uint32_t slot = 0; slot < static_cast<uint32_t>(MaxStickers); slot++)
+        {
+            AddAttribute(ItemSchema::AttributeStickerId0 + slot * 4, true);
+            AddAttribute(ItemSchema::AttributeStickerWear0 + slot * 4, false);
+            AddAttribute(ItemSchema::AttributeStickerScale0 + slot * 4, false);
+            AddAttribute(ItemSchema::AttributeStickerRotation0 + slot * 4, false);
+        }
+    }
+
+    bool Apply(CSOEconItem &item,
+        uint32_t stickerSlotCount,
+        bool dreamHack2013,
+        uint32_t eventStickerKit,
+        uint32_t team1StickerKit = 0,
+        uint32_t team2StickerKit = 0,
+        uint32_t fourthStickerKit = 0)
+    {
+        return opening.ApplyTournamentAttributes(item, stickerSlotCount, dreamHack2013,
+            eventStickerKit, team1StickerKit, team2StickerKit, fourthStickerKit);
+    }
+
+    std::optional<uint32_t> StickerId(const CSOEconItem &item, uint32_t slot) const
+    {
+        const CSOEconItemAttribute *attribute = FindAttribute(item, ItemSchema::AttributeStickerId0 + slot * 4);
+        return attribute ? std::optional<uint32_t>{ schema.AttributeUint32(attribute) } : std::nullopt;
+    }
+
+    std::optional<float> StickerWear(const CSOEconItem &item, uint32_t slot) const
+    {
+        const CSOEconItemAttribute *attribute = FindAttribute(item, ItemSchema::AttributeStickerWear0 + slot * 4);
+        return attribute ? std::optional<float>{ schema.AttributeFloat(attribute) } : std::nullopt;
+    }
+
+    std::optional<float> StickerScale(const CSOEconItem &item, uint32_t slot) const
+    {
+        const CSOEconItemAttribute *attribute = FindAttribute(item, ItemSchema::AttributeStickerScale0 + slot * 4);
+        return attribute ? std::optional<float>{ schema.AttributeFloat(attribute) } : std::nullopt;
+    }
+
+    std::optional<float> StickerRotation(const CSOEconItem &item, uint32_t slot) const
+    {
+        const CSOEconItemAttribute *attribute = FindAttribute(item, ItemSchema::AttributeStickerRotation0 + slot * 4);
+        return attribute ? std::optional<float>{ schema.AttributeFloat(attribute) } : std::nullopt;
+    }
+
+private:
+    void AddAttribute(uint32_t defIndex, bool integer)
+    {
+        KeyValue key{ std::to_string(defIndex) };
+        if (integer)
+        {
+            key.AddNumber("stored_as_integer", 1);
+        }
+
+        schema.m_attributeInfo.emplace(defIndex, AttributeInfo{ key });
+    }
+
+    static const CSOEconItemAttribute *FindAttribute(const CSOEconItem &item, uint32_t defIndex)
+    {
+        for (const CSOEconItemAttribute &attribute : item.attribute())
+        {
+            if (attribute.def_index() == defIndex)
+            {
+                return &attribute;
+            }
+        }
+
+        return nullptr;
+    }
+
+    ItemSchema schema;
+    Random random;
+    SouvenirOpening opening;
+};
+
+static bool SingleStickerUsesEveryAvailableSlot()
+{
+    uint32_t regularSlotsSeen = 0;
+    uint32_t fiveSlotsSeen = 0;
+
+    for (uint32_t seed = 0; seed < 256; seed++)
+    {
+        SouvenirTestFixture fixture{ seed };
+
+        CSOEconItem regularItem;
+        regularItem.set_def_index(7);
+        if (!fixture.Apply(regularItem, 4, false, 101))
+        {
+            return false;
+        }
+
+        CSOEconItem fiveSlotItem;
+        fiveSlotItem.set_def_index(11);
+        if (!fixture.Apply(fiveSlotItem, 5, false, 101))
+        {
+            return false;
+        }
+
+        uint32_t regularStickerCount = 0;
+        uint32_t fiveSlotStickerCount = 0;
+        for (uint32_t slot = 0; slot < static_cast<uint32_t>(MaxStickers); slot++)
+        {
+            std::optional<uint32_t> regularSticker = fixture.StickerId(regularItem, slot);
+            if (regularSticker)
+            {
+                if (*regularSticker != 101 || slot >= 4)
+                {
+                    return false;
+                }
+
+                regularSlotsSeen |= 1u << slot;
+                regularStickerCount++;
+            }
+
+            std::optional<uint32_t> fiveSlotSticker = fixture.StickerId(fiveSlotItem, slot);
+            if (fiveSlotSticker)
+            {
+                if (*fiveSlotSticker != 101 || slot >= 5)
+                {
+                    return false;
+                }
+
+                fiveSlotsSeen |= 1u << slot;
+                fiveSlotStickerCount++;
+            }
+        }
+
+        if (regularStickerCount != 1 || fiveSlotStickerCount != 1)
+        {
+            return false;
+        }
+    }
+
+    return regularSlotsSeen == 0xf && fiveSlotsSeen == 0x1f;
+}
+
+static bool MultipleStickersUseUniqueSlots()
+{
+    std::unordered_set<std::string> assignments;
+
+    for (uint32_t seed = 0; seed < 64; seed++)
+    {
+        SouvenirTestFixture fixture{ seed };
+        CSOEconItem item;
+        item.set_def_index(7);
+
+        if (!fixture.Apply(item, 4, false, 101, 102, 103, 104))
+        {
+            return false;
+        }
+
+        std::unordered_set<uint32_t> stickerKits;
+        std::string assignment;
+        for (uint32_t slot = 0; slot < 4; slot++)
+        {
+            std::optional<uint32_t> sticker = fixture.StickerId(item, slot);
+            if (!sticker)
+            {
+                return false;
+            }
+
+            stickerKits.insert(*sticker);
+            assignment += std::to_string(*sticker);
+            assignment.push_back(',');
+        }
+
+        if (stickerKits != std::unordered_set<uint32_t>{ 101, 102, 103, 104 })
+        {
+            return false;
+        }
+
+        assignments.insert(std::move(assignment));
+    }
+
+    return assignments.size() > 1;
+}
+
+static bool ModernSouvenirsKeepDefaultStickerValues()
+{
+    SouvenirTestFixture fixture{ 1234 };
+    CSOEconItem item;
+    item.set_def_index(7);
+
+    if (!fixture.Apply(item, 4, false, 101))
+    {
+        return false;
+    }
+
+    for (uint32_t slot = 0; slot < 4; slot++)
+    {
+        if (!fixture.StickerId(item, slot))
+        {
+            continue;
+        }
+
+        return fixture.StickerWear(item, slot) == 0.0f
+            && fixture.StickerScale(item, slot) == 1.0f
+            && fixture.StickerRotation(item, slot) == 0.0f;
+    }
+
+    return false;
+}
+
+static bool DreamHack2013StickerValuesAreRandomizedInRange()
+{
+    std::optional<float> firstWear;
+    std::optional<float> firstScale;
+    std::optional<float> firstRotation;
+    bool wearChanged = false;
+    bool scaleChanged = false;
+    bool rotationChanged = false;
+
+    for (uint32_t seed = 0; seed < 64; seed++)
+    {
+        SouvenirTestFixture fixture{ seed };
+        CSOEconItem item;
+        item.set_def_index(7);
+
+        if (!fixture.Apply(item, 4, true, 101))
+        {
+            return false;
+        }
+
+        for (uint32_t slot = 0; slot < 4; slot++)
+        {
+            if (!fixture.StickerId(item, slot))
+            {
+                continue;
+            }
+
+            std::optional<float> wear = fixture.StickerWear(item, slot);
+            std::optional<float> scale = fixture.StickerScale(item, slot);
+            std::optional<float> rotation = fixture.StickerRotation(item, slot);
+            if (!wear || !scale || !rotation
+                || *wear < 0.2f || *wear > 0.3f
+                || *scale < 1.0f || *scale > 1.2f
+                || *rotation < -10.0f || *rotation > 10.0f)
+            {
+                return false;
+            }
+
+            if (!firstWear)
+            {
+                firstWear = wear;
+                firstScale = scale;
+                firstRotation = rotation;
+            }
+            else
+            {
+                wearChanged |= *wear != *firstWear;
+                scaleChanged |= *scale != *firstScale;
+                rotationChanged |= *rotation != *firstRotation;
+            }
+        }
+    }
+
+    return wearChanged && scaleChanged && rotationChanged;
+}
+
+static bool TooManyStickersFailWithoutAttributes()
+{
+    SouvenirTestFixture fixture{ 0 };
+    CSOEconItem item;
+    item.set_def_index(7);
+
+    return !fixture.Apply(item, 3, false, 101, 102, 103, 104)
+        && item.attribute_size() == 0;
+}
+
+int main()
+{
+    if (!SingleStickerUsesEveryAvailableSlot())
+    {
+        return 1;
+    }
+
+    if (!MultipleStickersUseUniqueSlots())
+    {
+        return 2;
+    }
+
+    if (!ModernSouvenirsKeepDefaultStickerValues())
+    {
+        return 3;
+    }
+
+    if (!DreamHack2013StickerValuesAreRandomizedInRange())
+    {
+        return 4;
+    }
+
+    if (!TooManyStickersFailWithoutAttributes())
+    {
+        return 5;
+    }
+
+    return 0;
+}

--- a/csgo_gc/test_filesystem.h
+++ b/csgo_gc/test_filesystem.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <cerrno>
+#include <cstdio>
+
+#ifdef _WIN32
+#include <direct.h>
+#else
+#include <sys/stat.h>
+#include <unistd.h>
+#endif
+
+namespace TestFilesystem
+{
+
+inline bool MakeDirectory(const char *path)
+{
+#ifdef _WIN32
+    const int result = _mkdir(path);
+#else
+    const int result = mkdir(path, 0755);
+#endif
+    return result == 0 || errno == EEXIST;
+}
+
+inline void RemoveFile(const char *path)
+{
+    std::remove(path);
+}
+
+inline void RemoveDirectory(const char *path)
+{
+#ifdef _WIN32
+    _rmdir(path);
+#else
+    rmdir(path);
+#endif
+}
+
+} // namespace TestFilesystem


### PR DESCRIPTION
Fix #55

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Souvenir items now detect their available sticker slots and support multiple tournament stickers with unique placement.
  * DreamHack 2013 souvenir stickers receive appropriate randomized wear, scale, and rotation values.
  * Souvenir creation now reports failures when sticker capacity is insufficient or attributes cannot be applied.

* **Tests**
  * Added automated coverage for sticker-slot inheritance, multi-sticker assignment, modern defaults, DreamHack 2013 ranges, and capacity failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->