### PR TITLE
Persist item shuffles locally for custom AppIDs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,6 @@ jobs:
         key: vcpkg-${{ matrix.os }}-${{ steps.runner-image.outputs.version }}-${{ steps.vcpkg-commit.outputs.sha }}-${{ hashFiles('vcpkg.json') }}
         restore-keys: |
           vcpkg-${{ matrix.os }}-${{ steps.runner-image.outputs.version }}-${{ steps.vcpkg-commit.outputs.sha }}-
-          vcpkg-${{ matrix.os }}-
 
     - if: matrix.os == 'ubuntu-latest'
       name: Dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,15 +36,21 @@ jobs:
       shell: bash
       run: echo "sha=$(git -C '${{ github.workspace }}/vcpkg' rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
+    - name: Get runner image version
+      id: runner-image
+      shell: bash
+      run: echo "version=${ImageVersion:-unknown}" >> "$GITHUB_OUTPUT"
+
     - name: Cache vcpkg installed packages
       uses: actions/cache@v4
       with:
         path: |
           ${{ github.workspace }}/build/vcpkg_installed
           ${{ github.workspace }}/build_ds/vcpkg_installed
-        key: vcpkg-${{ matrix.os }}-${{ steps.vcpkg-commit.outputs.sha }}-${{ hashFiles('vcpkg.json') }}
+        key: vcpkg-${{ matrix.os }}-${{ steps.runner-image.outputs.version }}-${{ steps.vcpkg-commit.outputs.sha }}-${{ hashFiles('vcpkg.json') }}
         restore-keys: |
-          vcpkg-${{ matrix.os }}-${{ steps.vcpkg-commit.outputs.sha }}-
+          vcpkg-${{ matrix.os }}-${{ steps.runner-image.outputs.version }}-${{ steps.vcpkg-commit.outputs.sha }}-
+          vcpkg-${{ matrix.os }}-
 
     - if: matrix.os == 'ubuntu-latest'
       name: Dependencies

--- a/csgo_gc/CMakeLists.txt
+++ b/csgo_gc/CMakeLists.txt
@@ -36,6 +36,7 @@ add_library(csgo_gc SHARED
     networking_client.cpp
     networking_server.cpp
     rcon_server.cpp
+    saved_item_shuffles.cpp
     souvenir.cpp
     steam_hook.cpp)
 
@@ -209,4 +210,28 @@ if (BUILD_TESTING)
     add_test(NAME rcon_server_tests COMMAND rcon_server_tests)
     set_tests_properties(rcon_server_tests PROPERTIES
         WORKING_DIRECTORY "${RCON_SERVER_TEST_WORKING_DIRECTORY}")
+
+    add_executable(saved_item_shuffles_tests
+        saved_item_shuffles.cpp
+        saved_item_shuffles_tests.cpp)
+
+    target_precompile_headers(saved_item_shuffles_tests PRIVATE stdafx.h)
+    target_link_libraries(saved_item_shuffles_tests PRIVATE
+        csgo_gc_protobufs
+        steam_api)
+
+    if (MSVC)
+        target_compile_options(saved_item_shuffles_tests PRIVATE /W4 /wd4244 /wd4819)
+        target_compile_definitions(saved_item_shuffles_tests PRIVATE _CRT_SECURE_NO_WARNINGS)
+    else()
+        target_compile_options(saved_item_shuffles_tests PRIVATE -Wall -Wextra)
+    endif()
+
+    set(SAVED_ITEM_SHUFFLES_TEST_WORKING_DIRECTORY
+        "${CMAKE_CURRENT_BINARY_DIR}/saved_item_shuffles_test_workdir")
+    file(MAKE_DIRECTORY
+        "${SAVED_ITEM_SHUFFLES_TEST_WORKING_DIRECTORY}/csgo_gc")
+    add_test(NAME saved_item_shuffles_tests COMMAND saved_item_shuffles_tests)
+    set_tests_properties(saved_item_shuffles_tests PROPERTIES
+        WORKING_DIRECTORY "${SAVED_ITEM_SHUFFLES_TEST_WORKING_DIRECTORY}")
 endif()

--- a/csgo_gc/saved_item_shuffles.cpp
+++ b/csgo_gc/saved_item_shuffles.cpp
@@ -1,9 +1,11 @@
 #include "stdafx.h"
 #include "saved_item_shuffles.h"
 
+#include <algorithm>
 #include <cerrno>
 #include <cstdio>
 #include <cstring>
+#include <deque>
 #include <limits>
 #include <mutex>
 #include <unordered_map>
@@ -29,6 +31,8 @@ constexpr uint64_t WriteCallPrefix = 0x4353474f00000000ULL;
 constexpr uint64_t ReadCallPrefix = 0x4353475200000000ULL;
 constexpr uint64_t WriteCallPrefixMask = 0xffffffff00000000ULL;
 constexpr uint64_t WriteCallSuccessMask = 1;
+constexpr size_t MaxPendingReadCalls = 16;
+constexpr size_t MaxPendingReadBytes = k_unMaxCloudFileChunkSize;
 
 std::atomic<uint32_t> s_temporaryFileCounter;
 std::atomic<uint32_t> s_writeCallCounter{ 1 };
@@ -44,6 +48,64 @@ struct ReadCall
 
 std::mutex s_readCallsMutex;
 std::unordered_map<SteamAPICall_t, ReadCall> s_readCalls;
+std::deque<SteamAPICall_t> s_readCallOrder;
+size_t s_pendingReadBytes;
+
+bool SeekFile(FILE *file, int64 offset, int origin)
+{
+#ifdef _WIN32
+    return _fseeki64(file, offset, origin) == 0;
+#else
+    return fseeko(file, static_cast<off_t>(offset), origin) == 0;
+#endif
+}
+
+int64 TellFile(FILE *file)
+{
+#ifdef _WIN32
+    return _ftelli64(file);
+#else
+    return static_cast<int64>(ftello(file));
+#endif
+}
+
+void EraseReadCallLocked(SteamAPICall_t call)
+{
+    auto it = s_readCalls.find(call);
+    if (it == s_readCalls.end())
+    {
+        return;
+    }
+
+    s_pendingReadBytes -= it->second.data.size();
+    s_readCalls.erase(it);
+    auto orderIt = std::find(s_readCallOrder.begin(), s_readCallOrder.end(), call);
+    if (orderIt != s_readCallOrder.end())
+    {
+        s_readCallOrder.erase(orderIt);
+    }
+}
+
+void StoreReadCallLocked(SteamAPICall_t call, ReadCall readCall)
+{
+    while (!s_readCallOrder.empty()
+        && (s_readCalls.size() >= MaxPendingReadCalls
+            || s_pendingReadBytes + readCall.data.size() > MaxPendingReadBytes))
+    {
+        SteamAPICall_t oldest = s_readCallOrder.front();
+        s_readCallOrder.pop_front();
+        auto it = s_readCalls.find(oldest);
+        if (it != s_readCalls.end())
+        {
+            s_pendingReadBytes -= it->second.data.size();
+            s_readCalls.erase(it);
+        }
+    }
+
+    s_pendingReadBytes += readCall.data.size();
+    s_readCalls.emplace(call, std::move(readCall));
+    s_readCallOrder.push_back(call);
+}
 
 bool PathsEqual(const char *left, const char *right)
 {
@@ -424,16 +486,25 @@ SteamAPICall_t MakeReadCall(uint32 offset, uint32 size)
         }
         else
         {
-#ifdef _WIN32
-            bool failed = _fseeki64(file, offset, SEEK_SET) != 0;
-#else
-            bool failed = fseeko(file, static_cast<off_t>(offset), SEEK_SET) != 0;
-#endif
+            bool failed = !SeekFile(file, 0, SEEK_END);
+            int64 fileSize = failed ? -1 : TellFile(file);
+            failed |= fileSize < 0;
+            uint32 bytesToRead = 0;
             if (!failed)
             {
-                readCall.data.resize(size);
-                size_t bytesRead = size
-                    ? fread(readCall.data.data(), 1, size, file)
+                if (static_cast<uint64_t>(offset) < static_cast<uint64_t>(fileSize))
+                {
+                    uint64_t remaining = static_cast<uint64_t>(fileSize) - offset;
+                    bytesToRead = static_cast<uint32>(
+                        (std::min)(static_cast<uint64_t>(size), remaining));
+                }
+                failed = bytesToRead && !SeekFile(file, offset, SEEK_SET);
+            }
+            if (!failed)
+            {
+                readCall.data.resize(bytesToRead);
+                size_t bytesRead = bytesToRead
+                    ? fread(readCall.data.data(), 1, bytesToRead, file)
                     : 0;
                 failed = ferror(file) != 0;
                 readCall.data.resize(bytesRead);
@@ -453,7 +524,7 @@ SteamAPICall_t MakeReadCall(uint32 offset, uint32 size)
     }
 
     std::scoped_lock lock{ s_readCallsMutex };
-    s_readCalls.emplace(call, std::move(readCall));
+    StoreReadCallLocked(call, std::move(readCall));
     return call;
 }
 
@@ -502,7 +573,7 @@ bool GetReadCallResult(SteamAPICall_t call, void *callback, int callbackSize,
 
     if (it->second.result != k_EResultOK)
     {
-        s_readCalls.erase(it);
+        EraseReadCallLocked(call);
     }
     return true;
 }
@@ -531,7 +602,7 @@ bool CompleteReadCall(SteamAPICall_t call, void *buffer, uint32 bufferSize)
     {
         memcpy(buffer, it->second.data.data(), it->second.data.size());
     }
-    s_readCalls.erase(it);
+    EraseReadCallLocked(call);
     return true;
 }
 

--- a/csgo_gc/saved_item_shuffles.cpp
+++ b/csgo_gc/saved_item_shuffles.cpp
@@ -1,0 +1,268 @@
+#include "stdafx.h"
+#include "saved_item_shuffles.h"
+
+#include <cerrno>
+#include <cstdio>
+#include <cstring>
+#include <limits>
+
+#ifdef _WIN32
+#include <io.h>
+#include <process.h>
+#include <windows.h>
+#else
+#include <unistd.h>
+#endif
+
+namespace SavedItemShuffles
+{
+
+namespace
+{
+
+constexpr uint32_t OriginalAppId = 730;
+constexpr uint64_t WriteCallPrefix = 0x4353474f00000000ULL;
+constexpr uint64_t WriteCallPrefixMask = 0xffffffff00000000ULL;
+constexpr uint64_t WriteCallSuccessMask = 1;
+
+std::atomic<uint32_t> s_temporaryFileCounter;
+std::atomic<uint32_t> s_writeCallCounter{ 1 };
+
+bool PathsEqual(const char *left, const char *right)
+{
+    if (!left || !right)
+    {
+        return false;
+    }
+
+    while (*left && *right)
+    {
+        unsigned char a = static_cast<unsigned char>(*left++);
+        unsigned char b = static_cast<unsigned char>(*right++);
+        if (std::tolower(a) != std::tolower(b))
+        {
+            return false;
+        }
+    }
+
+    return *left == *right;
+}
+
+void PrintFileError(const char *operation)
+{
+    Platform::Print("Saved item shuffles: %s %s failed (%d: %s)\n",
+        operation, LocalPath, errno, std::strerror(errno));
+}
+
+std::string TemporaryPath()
+{
+    std::string path = LocalPath;
+    path.append(".tmp.");
+#ifdef _WIN32
+    path.append(std::to_string(_getpid()));
+#else
+    path.append(std::to_string(getpid()));
+#endif
+    path.push_back('.');
+    path.append(std::to_string(
+        s_temporaryFileCounter.fetch_add(1, std::memory_order_relaxed)));
+    return path;
+}
+
+bool ReplaceFile(const char *source, const char *destination)
+{
+#ifdef _WIN32
+    if (MoveFileExA(source, destination,
+            MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH))
+    {
+        return true;
+    }
+
+    Platform::Print("Saved item shuffles: replacing %s failed (Windows error %lu)\n",
+        destination, static_cast<unsigned long>(GetLastError()));
+    return false;
+#else
+    if (rename(source, destination) == 0)
+    {
+        return true;
+    }
+
+    PrintFileError("replacing");
+    return false;
+#endif
+}
+
+} // namespace
+
+bool ShouldUseLocalStorage(uint32_t appId, const char *remotePath)
+{
+    return appId != OriginalAppId && PathsEqual(remotePath, RemotePath);
+}
+
+bool FileWrite(const void *data, uint32_t size)
+{
+    if (!data || size > k_unMaxCloudFileChunkSize)
+    {
+        return false;
+    }
+
+    std::string temporaryPath = TemporaryPath();
+    FILE *file = fopen(temporaryPath.c_str(), "wb");
+    if (!file)
+    {
+        PrintFileError("opening");
+        return false;
+    }
+
+    bool succeeded = fwrite(data, 1, size, file) == size;
+    succeeded &= !ferror(file) && fflush(file) == 0;
+#ifdef _WIN32
+    if (succeeded)
+    {
+        succeeded = _commit(_fileno(file)) == 0;
+    }
+#else
+    if (succeeded)
+    {
+        succeeded = fsync(fileno(file)) == 0;
+    }
+#endif
+    succeeded &= fclose(file) == 0;
+
+    if (!succeeded)
+    {
+        PrintFileError("writing");
+        remove(temporaryPath.c_str());
+        return false;
+    }
+
+    if (!ReplaceFile(temporaryPath.c_str(), LocalPath))
+    {
+        remove(temporaryPath.c_str());
+        return false;
+    }
+
+    return true;
+}
+
+int32 FileRead(void *data, int32 size)
+{
+    if (!data || size <= 0)
+    {
+        return 0;
+    }
+
+    errno = 0;
+    FILE *file = fopen(LocalPath, "rb");
+    if (!file)
+    {
+        if (errno != ENOENT)
+        {
+            PrintFileError("opening");
+        }
+        return 0;
+    }
+
+    size_t bytesRead = fread(data, 1, static_cast<size_t>(size), file);
+    bool failed = ferror(file) != 0 || fclose(file) != 0;
+    if (failed)
+    {
+        PrintFileError("reading");
+        return 0;
+    }
+
+    return static_cast<int32>(bytesRead);
+}
+
+bool FileExists()
+{
+    errno = 0;
+    FILE *file = fopen(LocalPath, "rb");
+    if (!file)
+    {
+        if (errno != ENOENT)
+        {
+            PrintFileError("opening");
+        }
+        return false;
+    }
+
+    if (fclose(file) != 0)
+    {
+        PrintFileError("closing");
+        return false;
+    }
+
+    return true;
+}
+
+int32 GetFileSize()
+{
+    errno = 0;
+    FILE *file = fopen(LocalPath, "rb");
+    if (!file)
+    {
+        if (errno != ENOENT)
+        {
+            PrintFileError("opening");
+        }
+        return 0;
+    }
+
+    bool failed = fseek(file, 0, SEEK_END) != 0;
+    long size = failed ? -1 : ftell(file);
+    failed |= size < 0 || size > (std::numeric_limits<int32>::max)();
+    failed |= fclose(file) != 0;
+    if (failed)
+    {
+        PrintFileError("measuring");
+        return 0;
+    }
+
+    return static_cast<int32>(size);
+}
+
+SteamAPICall_t MakeWriteCall(bool success)
+{
+    uint64_t sequence = s_writeCallCounter.fetch_add(1, std::memory_order_relaxed);
+    sequence &= 0x7fffffffULL;
+    return WriteCallPrefix | (sequence << 1) | (success ? WriteCallSuccessMask : 0);
+}
+
+bool IsWriteCall(SteamAPICall_t call)
+{
+    return (call & WriteCallPrefixMask) == WriteCallPrefix;
+}
+
+bool WriteCallSucceeded(SteamAPICall_t call)
+{
+    return IsWriteCall(call) && (call & WriteCallSuccessMask) != 0;
+}
+
+bool GetWriteCallResult(SteamAPICall_t call, void *callback, int callbackSize,
+    int expectedCallback, bool *failed)
+{
+    if (!IsWriteCall(call)
+        || !callback
+        || callbackSize != sizeof(RemoteStorageFileWriteAsyncComplete_t)
+        || expectedCallback != RemoteStorageFileWriteAsyncComplete_t::k_iCallback)
+    {
+        if (failed)
+        {
+            *failed = true;
+        }
+        return false;
+    }
+
+    if (failed)
+    {
+        *failed = false;
+    }
+
+    RemoteStorageFileWriteAsyncComplete_t result{};
+    result.m_eResult = WriteCallSucceeded(call) ? k_EResultOK : k_EResultFail;
+    memcpy(callback, &result, sizeof(result));
+    return true;
+}
+
+} // namespace SavedItemShuffles

--- a/csgo_gc/saved_item_shuffles.cpp
+++ b/csgo_gc/saved_item_shuffles.cpp
@@ -5,12 +5,16 @@
 #include <cstdio>
 #include <cstring>
 #include <limits>
+#include <mutex>
+#include <unordered_map>
+#include <vector>
 
 #ifdef _WIN32
 #include <io.h>
 #include <process.h>
 #include <windows.h>
 #else
+#include <sys/stat.h>
 #include <unistd.h>
 #endif
 
@@ -22,11 +26,24 @@ namespace
 
 constexpr uint32_t OriginalAppId = 730;
 constexpr uint64_t WriteCallPrefix = 0x4353474f00000000ULL;
+constexpr uint64_t ReadCallPrefix = 0x4353475200000000ULL;
 constexpr uint64_t WriteCallPrefixMask = 0xffffffff00000000ULL;
 constexpr uint64_t WriteCallSuccessMask = 1;
 
 std::atomic<uint32_t> s_temporaryFileCounter;
 std::atomic<uint32_t> s_writeCallCounter{ 1 };
+std::atomic<uint32_t> s_readCallCounter{ 1 };
+
+struct ReadCall
+{
+    EResult result{ k_EResultFail };
+    uint32 offset{};
+    uint32 requestedSize{};
+    std::vector<uint8_t> data;
+};
+
+std::mutex s_readCallsMutex;
+std::unordered_map<SteamAPICall_t, ReadCall> s_readCalls;
 
 bool PathsEqual(const char *left, const char *right)
 {
@@ -52,6 +69,49 @@ void PrintFileError(const char *operation)
 {
     Platform::Print("Saved item shuffles: %s %s failed (%d: %s)\n",
         operation, LocalPath, errno, std::strerror(errno));
+}
+
+bool EnsureDirectoryExists()
+{
+#ifdef _WIN32
+    if (CreateDirectoryA(DirectoryPath, nullptr))
+    {
+        return true;
+    }
+
+    DWORD error = GetLastError();
+    if (error == ERROR_ALREADY_EXISTS)
+    {
+        DWORD attributes = GetFileAttributesA(DirectoryPath);
+        if (attributes != INVALID_FILE_ATTRIBUTES
+            && (attributes & FILE_ATTRIBUTE_DIRECTORY))
+        {
+            return true;
+        }
+    }
+
+    Platform::Print("Saved item shuffles: creating %s failed (Windows error %lu)\n",
+        DirectoryPath, static_cast<unsigned long>(error));
+    return false;
+#else
+    if (mkdir(DirectoryPath, 0755) == 0)
+    {
+        return true;
+    }
+
+    if (errno == EEXIST)
+    {
+        struct stat status{};
+        if (stat(DirectoryPath, &status) == 0 && S_ISDIR(status.st_mode))
+        {
+            return true;
+        }
+    }
+
+    Platform::Print("Saved item shuffles: creating %s failed (%d: %s)\n",
+        DirectoryPath, errno, std::strerror(errno));
+    return false;
+#endif
 }
 
 std::string TemporaryPath()
@@ -102,6 +162,11 @@ bool ShouldUseLocalStorage(uint32_t appId, const char *remotePath)
 bool FileWrite(const void *data, uint32_t size)
 {
     if (!data || size > k_unMaxCloudFileChunkSize)
+    {
+        return false;
+    }
+
+    if (!EnsureDirectoryExists())
     {
         return false;
     }
@@ -174,6 +239,28 @@ int32 FileRead(void *data, int32 size)
     return static_cast<int32>(bytesRead);
 }
 
+bool FileForget()
+{
+    // There is no cloud copy to forget. Keep the local file, matching Steam's
+    // behavior of removing cloud persistence without deleting local data.
+    return FileExists();
+}
+
+bool FileDelete()
+{
+    errno = 0;
+    if (remove(LocalPath) == 0)
+    {
+        return true;
+    }
+
+    if (errno != ENOENT)
+    {
+        PrintFileError("deleting");
+    }
+    return false;
+}
+
 bool FileExists()
 {
     errno = 0;
@@ -194,6 +281,11 @@ bool FileExists()
     }
 
     return true;
+}
+
+bool FilePersisted()
+{
+    return FileExists();
 }
 
 int32 GetFileSize()
@@ -220,6 +312,44 @@ int32 GetFileSize()
     }
 
     return static_cast<int32>(size);
+}
+
+int64 GetFileTimestamp()
+{
+#ifdef _WIN32
+    WIN32_FILE_ATTRIBUTE_DATA attributes{};
+    if (!GetFileAttributesExA(LocalPath, GetFileExInfoStandard, &attributes))
+    {
+        DWORD error = GetLastError();
+        if (error != ERROR_FILE_NOT_FOUND && error != ERROR_PATH_NOT_FOUND)
+        {
+            Platform::Print("Saved item shuffles: getting timestamp for %s failed (Windows error %lu)\n",
+                LocalPath, static_cast<unsigned long>(error));
+        }
+        return 0;
+    }
+
+    ULARGE_INTEGER timestamp{};
+    timestamp.LowPart = attributes.ftLastWriteTime.dwLowDateTime;
+    timestamp.HighPart = attributes.ftLastWriteTime.dwHighDateTime;
+    constexpr uint64_t WindowsToUnixEpoch = 116444736000000000ULL;
+    if (timestamp.QuadPart < WindowsToUnixEpoch)
+    {
+        return 0;
+    }
+    return static_cast<int64>((timestamp.QuadPart - WindowsToUnixEpoch) / 10000000ULL);
+#else
+    struct stat status{};
+    if (stat(LocalPath, &status) != 0)
+    {
+        if (errno != ENOENT)
+        {
+            PrintFileError("getting timestamp for");
+        }
+        return 0;
+    }
+    return static_cast<int64>(status.st_mtime);
+#endif
 }
 
 SteamAPICall_t MakeWriteCall(bool success)
@@ -262,6 +392,146 @@ bool GetWriteCallResult(SteamAPICall_t call, void *callback, int callbackSize,
     RemoteStorageFileWriteAsyncComplete_t result{};
     result.m_eResult = WriteCallSucceeded(call) ? k_EResultOK : k_EResultFail;
     memcpy(callback, &result, sizeof(result));
+    return true;
+}
+
+SteamAPICall_t MakeReadCall(uint32 offset, uint32 size)
+{
+    uint64_t sequence = s_readCallCounter.fetch_add(1, std::memory_order_relaxed);
+    SteamAPICall_t call = ReadCallPrefix | sequence;
+
+    ReadCall readCall;
+    readCall.offset = offset;
+    readCall.requestedSize = size;
+    if (size > k_unMaxCloudFileChunkSize)
+    {
+        readCall.result = k_EResultInvalidParam;
+    }
+    else
+    {
+        errno = 0;
+        FILE *file = fopen(LocalPath, "rb");
+        if (!file)
+        {
+            if (errno == ENOENT)
+            {
+                readCall.result = k_EResultFileNotFound;
+            }
+            else
+            {
+                PrintFileError("opening");
+            }
+        }
+        else
+        {
+#ifdef _WIN32
+            bool failed = _fseeki64(file, offset, SEEK_SET) != 0;
+#else
+            bool failed = fseeko(file, static_cast<off_t>(offset), SEEK_SET) != 0;
+#endif
+            if (!failed)
+            {
+                readCall.data.resize(size);
+                size_t bytesRead = size
+                    ? fread(readCall.data.data(), 1, size, file)
+                    : 0;
+                failed = ferror(file) != 0;
+                readCall.data.resize(bytesRead);
+            }
+            failed |= fclose(file) != 0;
+
+            if (failed)
+            {
+                PrintFileError("reading");
+                readCall.data.clear();
+            }
+            else
+            {
+                readCall.result = k_EResultOK;
+            }
+        }
+    }
+
+    std::scoped_lock lock{ s_readCallsMutex };
+    s_readCalls.emplace(call, std::move(readCall));
+    return call;
+}
+
+bool IsReadCall(SteamAPICall_t call)
+{
+    return (call & WriteCallPrefixMask) == ReadCallPrefix;
+}
+
+bool GetReadCallResult(SteamAPICall_t call, void *callback, int callbackSize,
+    int expectedCallback, bool *failed)
+{
+    if (!IsReadCall(call)
+        || !callback
+        || callbackSize != sizeof(RemoteStorageFileReadAsyncComplete_t)
+        || expectedCallback != RemoteStorageFileReadAsyncComplete_t::k_iCallback)
+    {
+        if (failed)
+        {
+            *failed = true;
+        }
+        return false;
+    }
+
+    std::scoped_lock lock{ s_readCallsMutex };
+    auto it = s_readCalls.find(call);
+    if (it == s_readCalls.end())
+    {
+        if (failed)
+        {
+            *failed = true;
+        }
+        return false;
+    }
+
+    if (failed)
+    {
+        *failed = false;
+    }
+
+    RemoteStorageFileReadAsyncComplete_t result{};
+    result.m_hFileReadAsync = call;
+    result.m_eResult = it->second.result;
+    result.m_nOffset = it->second.offset;
+    result.m_cubRead = static_cast<uint32>(it->second.data.size());
+    memcpy(callback, &result, sizeof(result));
+
+    if (it->second.result != k_EResultOK)
+    {
+        s_readCalls.erase(it);
+    }
+    return true;
+}
+
+bool CompleteReadCall(SteamAPICall_t call, void *buffer, uint32 bufferSize)
+{
+    if (!IsReadCall(call))
+    {
+        return false;
+    }
+
+    std::scoped_lock lock{ s_readCallsMutex };
+    auto it = s_readCalls.find(call);
+    if (it == s_readCalls.end() || it->second.result != k_EResultOK)
+    {
+        return false;
+    }
+
+    if (bufferSize < it->second.requestedSize
+        || (!buffer && it->second.requestedSize))
+    {
+        return false;
+    }
+
+    if (!it->second.data.empty())
+    {
+        memcpy(buffer, it->second.data.data(), it->second.data.size());
+    }
+    s_readCalls.erase(it);
     return true;
 }
 

--- a/csgo_gc/saved_item_shuffles.h
+++ b/csgo_gc/saved_item_shuffles.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <steam/isteamremotestorage.h>
+
+namespace SavedItemShuffles
+{
+
+constexpr const char *RemotePath = "cfg/csgo_saved_item_shuffles.txt";
+constexpr const char *LocalPath = "csgo_gc/saved_item_shuffles.txt";
+
+bool ShouldUseLocalStorage(uint32_t appId, const char *remotePath);
+
+bool FileWrite(const void *data, uint32_t size);
+int32 FileRead(void *data, int32 size);
+bool FileExists();
+int32 GetFileSize();
+
+SteamAPICall_t MakeWriteCall(bool success);
+bool IsWriteCall(SteamAPICall_t call);
+bool WriteCallSucceeded(SteamAPICall_t call);
+bool GetWriteCallResult(SteamAPICall_t call, void *callback, int callbackSize,
+    int expectedCallback, bool *failed);
+
+} // namespace SavedItemShuffles

--- a/csgo_gc/saved_item_shuffles.h
+++ b/csgo_gc/saved_item_shuffles.h
@@ -6,19 +6,30 @@ namespace SavedItemShuffles
 {
 
 constexpr const char *RemotePath = "cfg/csgo_saved_item_shuffles.txt";
+constexpr const char *DirectoryPath = "csgo_gc";
 constexpr const char *LocalPath = "csgo_gc/saved_item_shuffles.txt";
 
 bool ShouldUseLocalStorage(uint32_t appId, const char *remotePath);
 
 bool FileWrite(const void *data, uint32_t size);
 int32 FileRead(void *data, int32 size);
+bool FileForget();
+bool FileDelete();
 bool FileExists();
+bool FilePersisted();
 int32 GetFileSize();
+int64 GetFileTimestamp();
 
 SteamAPICall_t MakeWriteCall(bool success);
 bool IsWriteCall(SteamAPICall_t call);
 bool WriteCallSucceeded(SteamAPICall_t call);
 bool GetWriteCallResult(SteamAPICall_t call, void *callback, int callbackSize,
     int expectedCallback, bool *failed);
+
+SteamAPICall_t MakeReadCall(uint32 offset, uint32 size);
+bool IsReadCall(SteamAPICall_t call);
+bool GetReadCallResult(SteamAPICall_t call, void *callback, int callbackSize,
+    int expectedCallback, bool *failed);
+bool CompleteReadCall(SteamAPICall_t call, void *buffer, uint32 bufferSize);
 
 } // namespace SavedItemShuffles

--- a/csgo_gc/saved_item_shuffles_tests.cpp
+++ b/csgo_gc/saved_item_shuffles_tests.cpp
@@ -1,10 +1,17 @@
 #include "stdafx.h"
 #include "saved_item_shuffles.h"
 
-#include <filesystem>
+#include <cerrno>
+#include <cstdio>
+#include <cstring>
+#include <string>
 
 #ifdef _WIN32
 #include <windows.h>
+#else
+#include <dirent.h>
+#include <sys/stat.h>
+#include <unistd.h>
 #endif
 
 namespace Platform
@@ -19,7 +26,7 @@ void Print(const char *, ...)
 namespace
 {
 
-namespace fs = std::filesystem;
+constexpr const char *TemporaryFilePrefix = "saved_item_shuffles.txt.tmp.";
 
 bool Check(bool condition, const char *expression, int line)
 {
@@ -32,11 +39,107 @@ bool Check(bool condition, const char *expression, int line)
 
 #define CHECK(expression) Check((expression), #expression, __LINE__)
 
-void ResetStorage()
+bool RemoveStoragePath()
 {
-    std::error_code error;
-    fs::remove_all("csgo_gc", error);
-    fs::create_directory("csgo_gc", error);
+#ifdef _WIN32
+    DWORD attributes = GetFileAttributesA(SavedItemShuffles::DirectoryPath);
+    if (attributes == INVALID_FILE_ATTRIBUTES)
+    {
+        DWORD error = GetLastError();
+        return error == ERROR_FILE_NOT_FOUND || error == ERROR_PATH_NOT_FOUND;
+    }
+
+    if (!(attributes & FILE_ATTRIBUTE_DIRECTORY))
+    {
+        return DeleteFileA(SavedItemShuffles::DirectoryPath) != 0;
+    }
+
+    std::string pattern = SavedItemShuffles::DirectoryPath;
+    pattern.append("\\*");
+    WIN32_FIND_DATAA entry{};
+    HANDLE search = FindFirstFileA(pattern.c_str(), &entry);
+    if (search != INVALID_HANDLE_VALUE)
+    {
+        bool succeeded = true;
+        do
+        {
+            if (!strcmp(entry.cFileName, ".") || !strcmp(entry.cFileName, ".."))
+            {
+                continue;
+            }
+
+            std::string path = SavedItemShuffles::DirectoryPath;
+            path.push_back('\\');
+            path.append(entry.cFileName);
+            if ((entry.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
+                || !DeleteFileA(path.c_str()))
+            {
+                succeeded = false;
+            }
+        } while (FindNextFileA(search, &entry));
+        FindClose(search);
+        if (!succeeded)
+        {
+            return false;
+        }
+    }
+    else if (GetLastError() != ERROR_FILE_NOT_FOUND)
+    {
+        return false;
+    }
+
+    return RemoveDirectoryA(SavedItemShuffles::DirectoryPath) != 0;
+#else
+    struct stat status{};
+    if (lstat(SavedItemShuffles::DirectoryPath, &status) != 0)
+    {
+        return errno == ENOENT;
+    }
+
+    if (!S_ISDIR(status.st_mode))
+    {
+        return unlink(SavedItemShuffles::DirectoryPath) == 0;
+    }
+
+    DIR *directory = opendir(SavedItemShuffles::DirectoryPath);
+    if (!directory)
+    {
+        return false;
+    }
+
+    bool succeeded = true;
+    while (dirent *entry = readdir(directory))
+    {
+        if (!strcmp(entry->d_name, ".") || !strcmp(entry->d_name, ".."))
+        {
+            continue;
+        }
+
+        std::string path = SavedItemShuffles::DirectoryPath;
+        path.push_back('/');
+        path.append(entry->d_name);
+        if (unlink(path.c_str()) != 0)
+        {
+            succeeded = false;
+        }
+    }
+    succeeded &= closedir(directory) == 0;
+    return succeeded && rmdir(SavedItemShuffles::DirectoryPath) == 0;
+#endif
+}
+
+bool CreateStorageDirectory()
+{
+#ifdef _WIN32
+    return CreateDirectoryA(SavedItemShuffles::DirectoryPath, nullptr) != 0;
+#else
+    return mkdir(SavedItemShuffles::DirectoryPath, 0755) == 0;
+#endif
+}
+
+bool ResetStorage()
+{
+    return RemoveStoragePath() && CreateStorageDirectory();
 }
 
 bool RoutingIsConservative()
@@ -53,17 +156,27 @@ bool RoutingIsConservative()
 
 bool MissingFileUsesSteamSemantics()
 {
-    ResetStorage();
+    if (!CHECK(ResetStorage()))
+    {
+        return false;
+    }
     std::array<uint8_t, 4> buffer{};
 
     return CHECK(!SavedItemShuffles::FileExists())
+        && CHECK(!SavedItemShuffles::FilePersisted())
+        && CHECK(!SavedItemShuffles::FileForget())
+        && CHECK(!SavedItemShuffles::FileDelete())
         && CHECK(SavedItemShuffles::GetFileSize() == 0)
+        && CHECK(SavedItemShuffles::GetFileTimestamp() == 0)
         && CHECK(SavedItemShuffles::FileRead(buffer.data(), buffer.size()) == 0);
 }
 
 bool BinaryDataCanBeWrittenReadAndOverwritten()
 {
-    ResetStorage();
+    if (!CHECK(ResetStorage()))
+    {
+        return false;
+    }
     const std::array<uint8_t, 7> first{ 0, 1, 2, 0xff, 0, 4, 5 };
     const std::array<uint8_t, 4> second{ 9, 0, 8, 7 };
     std::array<uint8_t, 8> buffer{};
@@ -86,7 +199,10 @@ bool BinaryDataCanBeWrittenReadAndOverwritten()
 
 bool InvalidBuffersAndSizesFail()
 {
-    ResetStorage();
+    if (!CHECK(ResetStorage()))
+    {
+        return false;
+    }
     uint8_t byte = 42;
 
     return CHECK(!SavedItemShuffles::FileWrite(nullptr, 1))
@@ -97,33 +213,90 @@ bool InvalidBuffersAndSizesFail()
         && CHECK(!SavedItemShuffles::FileExists());
 }
 
-bool MissingDirectoryMakesWritesFail()
+bool MissingDirectoryIsCreatedOnWrite()
 {
-    ResetStorage();
-    std::error_code error;
-    fs::remove_all("csgo_gc", error);
+    if (!CHECK(ResetStorage()) || !CHECK(RemoveStoragePath()))
+    {
+        return false;
+    }
+
     uint8_t byte = 42;
-    bool failed = !SavedItemShuffles::FileWrite(&byte, 1);
-    fs::create_directory("csgo_gc", error);
-    return CHECK(failed);
+    uint8_t result = 0;
+    return CHECK(SavedItemShuffles::FileWrite(&byte, 1))
+        && CHECK(SavedItemShuffles::FileExists())
+        && CHECK(SavedItemShuffles::FileRead(&result, 1) == 1)
+        && CHECK(result == byte);
+}
+
+bool DirectoryCreationFailureStopsWrite()
+{
+    if (!CHECK(ResetStorage()) || !CHECK(RemoveStoragePath()))
+    {
+        return false;
+    }
+
+    FILE *blockingFile = fopen(SavedItemShuffles::DirectoryPath, "wb");
+    if (!CHECK(blockingFile != nullptr))
+    {
+        return false;
+    }
+    bool closed = fclose(blockingFile) == 0;
+
+    uint8_t byte = 42;
+    return CHECK(closed)
+        && CHECK(!SavedItemShuffles::FileWrite(&byte, 1));
 }
 
 bool NoTemporaryFilesRemain()
 {
-    for (const auto &entry : fs::directory_iterator("csgo_gc"))
+#ifdef _WIN32
+    std::string pattern = SavedItemShuffles::DirectoryPath;
+    pattern.append("\\*");
+    WIN32_FIND_DATAA entry{};
+    HANDLE search = FindFirstFileA(pattern.c_str(), &entry);
+    if (!CHECK(search != INVALID_HANDLE_VALUE))
     {
-        std::string name = entry.path().filename().string();
-        if (!CHECK(!name.starts_with("saved_item_shuffles.txt.tmp.")))
+        return false;
+    }
+
+    bool succeeded = true;
+    do
+    {
+        if (!strncmp(entry.cFileName, TemporaryFilePrefix,
+                strlen(TemporaryFilePrefix)))
         {
-            return false;
+            succeeded = CHECK(false);
+        }
+    } while (FindNextFileA(search, &entry));
+    FindClose(search);
+    return succeeded;
+#else
+    DIR *directory = opendir(SavedItemShuffles::DirectoryPath);
+    if (!CHECK(directory != nullptr))
+    {
+        return false;
+    }
+
+    bool succeeded = true;
+    while (dirent *entry = readdir(directory))
+    {
+        if (!strncmp(entry->d_name, TemporaryFilePrefix,
+                strlen(TemporaryFilePrefix)))
+        {
+            succeeded = CHECK(false);
         }
     }
-    return true;
+    succeeded &= closedir(directory) == 0;
+    return succeeded;
+#endif
 }
 
 bool SuccessfulReplacementLeavesNoTemporaryFile()
 {
-    ResetStorage();
+    if (!CHECK(ResetStorage()))
+    {
+        return false;
+    }
     const std::array<uint8_t, 3> data{ 1, 2, 3 };
     if (!CHECK(SavedItemShuffles::FileWrite(data.data(), data.size())))
     {
@@ -136,7 +309,10 @@ bool SuccessfulReplacementLeavesNoTemporaryFile()
 #ifdef _WIN32
 bool FailedReplacementPreservesOldFile()
 {
-    ResetStorage();
+    if (!CHECK(ResetStorage()))
+    {
+        return false;
+    }
     const std::array<uint8_t, 3> oldData{ 1, 2, 3 };
     const std::array<uint8_t, 3> newData{ 4, 5, 6 };
     if (!CHECK(SavedItemShuffles::FileWrite(oldData.data(), oldData.size())))
@@ -163,7 +339,31 @@ bool FailedReplacementPreservesOldFile()
 }
 #endif
 
-bool SyntheticCallsAreUniqueAndReportResults()
+bool MetadataForgetAndDeleteUseLocalFile()
+{
+    if (!CHECK(ResetStorage()))
+    {
+        return false;
+    }
+
+    const std::array<uint8_t, 3> data{ 1, 2, 3 };
+    if (!CHECK(SavedItemShuffles::FileWrite(data.data(), data.size())))
+    {
+        return false;
+    }
+
+    return CHECK(SavedItemShuffles::FilePersisted())
+        && CHECK(SavedItemShuffles::GetFileTimestamp() > 0)
+        && CHECK(SavedItemShuffles::FileForget())
+        && CHECK(SavedItemShuffles::FileExists())
+        && CHECK(SavedItemShuffles::FileDelete())
+        && CHECK(!SavedItemShuffles::FileExists())
+        && CHECK(!SavedItemShuffles::FilePersisted())
+        && CHECK(SavedItemShuffles::GetFileTimestamp() == 0)
+        && CHECK(!SavedItemShuffles::FileDelete());
+}
+
+bool SyntheticWriteCallsAreUniqueAndReportResults()
 {
     SteamAPICall_t successCall = SavedItemShuffles::MakeWriteCall(true);
     SteamAPICall_t failureCall = SavedItemShuffles::MakeWriteCall(false);
@@ -199,7 +399,7 @@ bool SyntheticCallsAreUniqueAndReportResults()
         && CHECK(result.m_eResult == k_EResultFail);
 }
 
-bool SyntheticCallsRejectInvalidResultRequests()
+bool SyntheticWriteCallsRejectInvalidResultRequests()
 {
     SteamAPICall_t call = SavedItemShuffles::MakeWriteCall(true);
     RemoteStorageFileWriteAsyncComplete_t result{};
@@ -234,22 +434,175 @@ bool SyntheticCallsRejectInvalidResultRequests()
         && CHECK(failed);
 }
 
+bool SyntheticReadCallsReturnLocalData()
+{
+    if (!CHECK(ResetStorage()))
+    {
+        return false;
+    }
+
+    const std::array<uint8_t, 6> data{ 0, 1, 2, 3, 4, 5 };
+    if (!CHECK(SavedItemShuffles::FileWrite(data.data(), data.size())))
+    {
+        return false;
+    }
+
+    SteamAPICall_t call = SavedItemShuffles::MakeReadCall(2, 3);
+    SteamAPICall_t anotherCall = SavedItemShuffles::MakeReadCall(0, 1);
+    SteamAPICall_t shortReadCall = SavedItemShuffles::MakeReadCall(4, 4);
+    if (!CHECK(call != anotherCall)
+        || !CHECK(call != shortReadCall)
+        || !CHECK(anotherCall != shortReadCall)
+        || !CHECK(SavedItemShuffles::IsReadCall(call))
+        || !CHECK(SavedItemShuffles::IsReadCall(anotherCall))
+        || !CHECK(!SavedItemShuffles::IsWriteCall(call))
+        || !CHECK(!SavedItemShuffles::IsReadCall(0x6666666666666666ULL)))
+    {
+        return false;
+    }
+
+    RemoteStorageFileReadAsyncComplete_t result{};
+    bool failed = true;
+    if (!CHECK(SavedItemShuffles::GetReadCallResult(call, &result,
+            sizeof(result), result.k_iCallback, &failed))
+        || !CHECK(!failed)
+        || !CHECK(result.m_hFileReadAsync == call)
+        || !CHECK(result.m_eResult == k_EResultOK)
+        || !CHECK(result.m_nOffset == 2)
+        || !CHECK(result.m_cubRead == 3))
+    {
+        return false;
+    }
+
+    std::array<uint8_t, 2> smallBuffer{};
+    if (!CHECK(!SavedItemShuffles::CompleteReadCall(call,
+            smallBuffer.data(), smallBuffer.size())))
+    {
+        return false;
+    }
+
+    std::array<uint8_t, 3> buffer{};
+    std::array<uint8_t, 2> shortBuffer{};
+    std::array<uint8_t, 4> requestedBuffer{};
+    uint8_t firstByte = 0xff;
+    return CHECK(SavedItemShuffles::CompleteReadCall(call,
+               buffer.data(), buffer.size()))
+        && CHECK((buffer == std::array<uint8_t, 3>{ 2, 3, 4 }))
+        && CHECK(!SavedItemShuffles::CompleteReadCall(call,
+            buffer.data(), buffer.size()))
+        && CHECK(SavedItemShuffles::CompleteReadCall(anotherCall, &firstByte, 1))
+        && CHECK(firstByte == 0)
+        && CHECK(!SavedItemShuffles::CompleteReadCall(shortReadCall,
+            shortBuffer.data(), shortBuffer.size()))
+        && CHECK(SavedItemShuffles::CompleteReadCall(shortReadCall,
+            requestedBuffer.data(), requestedBuffer.size()))
+        && CHECK(requestedBuffer[0] == 4)
+        && CHECK(requestedBuffer[1] == 5);
+}
+
+bool SyntheticReadCallsReportFailures()
+{
+    if (!CHECK(ResetStorage()))
+    {
+        return false;
+    }
+
+    SteamAPICall_t missingCall = SavedItemShuffles::MakeReadCall(4, 8);
+    RemoteStorageFileReadAsyncComplete_t result{};
+    bool failed = true;
+    if (!CHECK(SavedItemShuffles::GetReadCallResult(missingCall, &result,
+            sizeof(result), result.k_iCallback, &failed))
+        || !CHECK(!failed)
+        || !CHECK(result.m_hFileReadAsync == missingCall)
+        || !CHECK(result.m_eResult == k_EResultFileNotFound)
+        || !CHECK(result.m_nOffset == 4)
+        || !CHECK(result.m_cubRead == 0)
+        || !CHECK(!SavedItemShuffles::CompleteReadCall(missingCall, nullptr, 0)))
+    {
+        return false;
+    }
+
+    SteamAPICall_t invalidCall = SavedItemShuffles::MakeReadCall(
+        0, k_unMaxCloudFileChunkSize + 1);
+    result = {};
+    failed = true;
+    return CHECK(SavedItemShuffles::GetReadCallResult(invalidCall, &result,
+               sizeof(result), result.k_iCallback, &failed))
+        && CHECK(!failed)
+        && CHECK(result.m_eResult == k_EResultInvalidParam)
+        && CHECK(result.m_cubRead == 0);
+}
+
+bool SyntheticReadCallsRejectInvalidResultRequests()
+{
+    if (!CHECK(ResetStorage()))
+    {
+        return false;
+    }
+
+    const uint8_t data = 42;
+    if (!CHECK(SavedItemShuffles::FileWrite(&data, 1)))
+    {
+        return false;
+    }
+
+    SteamAPICall_t call = SavedItemShuffles::MakeReadCall(0, 1);
+    RemoteStorageFileReadAsyncComplete_t result{};
+    bool failed = false;
+    if (!CHECK(!SavedItemShuffles::GetReadCallResult(call, nullptr,
+            sizeof(result), result.k_iCallback, &failed))
+        || !CHECK(failed))
+    {
+        return false;
+    }
+
+    failed = false;
+    if (!CHECK(!SavedItemShuffles::GetReadCallResult(call, &result,
+            sizeof(result) - 1, result.k_iCallback, &failed))
+        || !CHECK(failed))
+    {
+        return false;
+    }
+
+    failed = false;
+    if (!CHECK(!SavedItemShuffles::GetReadCallResult(call, &result,
+            sizeof(result), result.k_iCallback + 1, &failed))
+        || !CHECK(failed))
+    {
+        return false;
+    }
+
+    failed = false;
+    uint8_t buffer = 0;
+    return CHECK(!SavedItemShuffles::GetReadCallResult(123, &result,
+               sizeof(result), result.k_iCallback, &failed))
+        && CHECK(failed)
+        && CHECK(SavedItemShuffles::CompleteReadCall(call, &buffer, 1))
+        && CHECK(buffer == data);
+}
+
 } // namespace
 
 int main()
 {
-    bool success = RoutingIsConservative()
-        && MissingFileUsesSteamSemantics()
-        && BinaryDataCanBeWrittenReadAndOverwritten()
-        && InvalidBuffersAndSizesFail()
-        && MissingDirectoryMakesWritesFail()
-        && SuccessfulReplacementLeavesNoTemporaryFile()
+    bool success = true;
+    success &= RoutingIsConservative();
+    success &= MissingFileUsesSteamSemantics();
+    success &= BinaryDataCanBeWrittenReadAndOverwritten();
+    success &= InvalidBuffersAndSizesFail();
+    success &= MissingDirectoryIsCreatedOnWrite();
+    success &= DirectoryCreationFailureStopsWrite();
+    success &= SuccessfulReplacementLeavesNoTemporaryFile();
 #ifdef _WIN32
-        && FailedReplacementPreservesOldFile()
+    success &= FailedReplacementPreservesOldFile();
 #endif
-        && SyntheticCallsAreUniqueAndReportResults()
-        && SyntheticCallsRejectInvalidResultRequests();
+    success &= MetadataForgetAndDeleteUseLocalFile();
+    success &= SyntheticWriteCallsAreUniqueAndReportResults();
+    success &= SyntheticWriteCallsRejectInvalidResultRequests();
+    success &= SyntheticReadCallsReturnLocalData();
+    success &= SyntheticReadCallsReportFailures();
+    success &= SyntheticReadCallsRejectInvalidResultRequests();
 
-    ResetStorage();
+    success &= ResetStorage();
     return success ? 0 : 1;
 }

--- a/csgo_gc/saved_item_shuffles_tests.cpp
+++ b/csgo_gc/saved_item_shuffles_tests.cpp
@@ -1,0 +1,255 @@
+#include "stdafx.h"
+#include "saved_item_shuffles.h"
+
+#include <filesystem>
+
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
+namespace Platform
+{
+
+void Print(const char *, ...)
+{
+}
+
+} // namespace Platform
+
+namespace
+{
+
+namespace fs = std::filesystem;
+
+bool Check(bool condition, const char *expression, int line)
+{
+    if (!condition)
+    {
+        fprintf(stderr, "Check failed at line %d: %s\n", line, expression);
+    }
+    return condition;
+}
+
+#define CHECK(expression) Check((expression), #expression, __LINE__)
+
+void ResetStorage()
+{
+    std::error_code error;
+    fs::remove_all("csgo_gc", error);
+    fs::create_directory("csgo_gc", error);
+}
+
+bool RoutingIsConservative()
+{
+    using SavedItemShuffles::ShouldUseLocalStorage;
+
+    return CHECK(!ShouldUseLocalStorage(730, SavedItemShuffles::RemotePath))
+        && CHECK(ShouldUseLocalStorage(4465480, SavedItemShuffles::RemotePath))
+        && CHECK(ShouldUseLocalStorage(1, "CFG/CSGO_SAVED_ITEM_SHUFFLES.TXT"))
+        && CHECK(!ShouldUseLocalStorage(4465480, "cfg/other.txt"))
+        && CHECK(!ShouldUseLocalStorage(4465480, "cfg/csgo_saved_item_shuffles.txt.bak"))
+        && CHECK(!ShouldUseLocalStorage(4465480, nullptr));
+}
+
+bool MissingFileUsesSteamSemantics()
+{
+    ResetStorage();
+    std::array<uint8_t, 4> buffer{};
+
+    return CHECK(!SavedItemShuffles::FileExists())
+        && CHECK(SavedItemShuffles::GetFileSize() == 0)
+        && CHECK(SavedItemShuffles::FileRead(buffer.data(), buffer.size()) == 0);
+}
+
+bool BinaryDataCanBeWrittenReadAndOverwritten()
+{
+    ResetStorage();
+    const std::array<uint8_t, 7> first{ 0, 1, 2, 0xff, 0, 4, 5 };
+    const std::array<uint8_t, 4> second{ 9, 0, 8, 7 };
+    std::array<uint8_t, 8> buffer{};
+
+    if (!CHECK(SavedItemShuffles::FileWrite(first.data(), first.size()))
+        || !CHECK(SavedItemShuffles::FileExists())
+        || !CHECK(SavedItemShuffles::GetFileSize() == static_cast<int32>(first.size()))
+        || !CHECK(SavedItemShuffles::FileRead(buffer.data(), buffer.size()) == static_cast<int32>(first.size()))
+        || !CHECK(std::equal(first.begin(), first.end(), buffer.begin())))
+    {
+        return false;
+    }
+
+    buffer.fill(0);
+    return CHECK(SavedItemShuffles::FileWrite(second.data(), second.size()))
+        && CHECK(SavedItemShuffles::GetFileSize() == static_cast<int32>(second.size()))
+        && CHECK(SavedItemShuffles::FileRead(buffer.data(), buffer.size()) == static_cast<int32>(second.size()))
+        && CHECK(std::equal(second.begin(), second.end(), buffer.begin()));
+}
+
+bool InvalidBuffersAndSizesFail()
+{
+    ResetStorage();
+    uint8_t byte = 42;
+
+    return CHECK(!SavedItemShuffles::FileWrite(nullptr, 1))
+        && CHECK(!SavedItemShuffles::FileWrite(&byte, k_unMaxCloudFileChunkSize + 1))
+        && CHECK(SavedItemShuffles::FileRead(nullptr, 1) == 0)
+        && CHECK(SavedItemShuffles::FileRead(&byte, 0) == 0)
+        && CHECK(SavedItemShuffles::FileRead(&byte, -1) == 0)
+        && CHECK(!SavedItemShuffles::FileExists());
+}
+
+bool MissingDirectoryMakesWritesFail()
+{
+    ResetStorage();
+    std::error_code error;
+    fs::remove_all("csgo_gc", error);
+    uint8_t byte = 42;
+    bool failed = !SavedItemShuffles::FileWrite(&byte, 1);
+    fs::create_directory("csgo_gc", error);
+    return CHECK(failed);
+}
+
+bool NoTemporaryFilesRemain()
+{
+    for (const auto &entry : fs::directory_iterator("csgo_gc"))
+    {
+        std::string name = entry.path().filename().string();
+        if (!CHECK(!name.starts_with("saved_item_shuffles.txt.tmp.")))
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool SuccessfulReplacementLeavesNoTemporaryFile()
+{
+    ResetStorage();
+    const std::array<uint8_t, 3> data{ 1, 2, 3 };
+    if (!CHECK(SavedItemShuffles::FileWrite(data.data(), data.size())))
+    {
+        return false;
+    }
+
+    return NoTemporaryFilesRemain();
+}
+
+#ifdef _WIN32
+bool FailedReplacementPreservesOldFile()
+{
+    ResetStorage();
+    const std::array<uint8_t, 3> oldData{ 1, 2, 3 };
+    const std::array<uint8_t, 3> newData{ 4, 5, 6 };
+    if (!CHECK(SavedItemShuffles::FileWrite(oldData.data(), oldData.size())))
+    {
+        return false;
+    }
+
+    HANDLE file = CreateFileA(SavedItemShuffles::LocalPath, GENERIC_READ,
+        FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_EXISTING,
+        FILE_ATTRIBUTE_NORMAL, nullptr);
+    if (!CHECK(file != INVALID_HANDLE_VALUE))
+    {
+        return false;
+    }
+
+    bool writeFailed = !SavedItemShuffles::FileWrite(newData.data(), newData.size());
+    CloseHandle(file);
+
+    std::array<uint8_t, 3> buffer{};
+    return CHECK(writeFailed)
+        && CHECK(SavedItemShuffles::FileRead(buffer.data(), buffer.size()) == static_cast<int32>(buffer.size()))
+        && CHECK(buffer == oldData)
+        && CHECK(NoTemporaryFilesRemain());
+}
+#endif
+
+bool SyntheticCallsAreUniqueAndReportResults()
+{
+    SteamAPICall_t successCall = SavedItemShuffles::MakeWriteCall(true);
+    SteamAPICall_t failureCall = SavedItemShuffles::MakeWriteCall(false);
+    SteamAPICall_t anotherCall = SavedItemShuffles::MakeWriteCall(true);
+
+    if (!CHECK(successCall != failureCall)
+        || !CHECK(successCall != anotherCall)
+        || !CHECK(failureCall != anotherCall)
+        || !CHECK(SavedItemShuffles::IsWriteCall(successCall))
+        || !CHECK(SavedItemShuffles::IsWriteCall(failureCall))
+        || !CHECK(!SavedItemShuffles::IsWriteCall(0x6666666666666666ULL))
+        || !CHECK(SavedItemShuffles::WriteCallSucceeded(successCall))
+        || !CHECK(!SavedItemShuffles::WriteCallSucceeded(failureCall)))
+    {
+        return false;
+    }
+
+    RemoteStorageFileWriteAsyncComplete_t result{};
+    bool failed = true;
+    if (!CHECK(SavedItemShuffles::GetWriteCallResult(successCall, &result,
+            sizeof(result), result.k_iCallback, &failed))
+        || !CHECK(!failed)
+        || !CHECK(result.m_eResult == k_EResultOK))
+    {
+        return false;
+    }
+
+    failed = true;
+    result = {};
+    return CHECK(SavedItemShuffles::GetWriteCallResult(failureCall, &result,
+               sizeof(result), result.k_iCallback, &failed))
+        && CHECK(!failed)
+        && CHECK(result.m_eResult == k_EResultFail);
+}
+
+bool SyntheticCallsRejectInvalidResultRequests()
+{
+    SteamAPICall_t call = SavedItemShuffles::MakeWriteCall(true);
+    RemoteStorageFileWriteAsyncComplete_t result{};
+    bool failed = false;
+
+    if (!CHECK(!SavedItemShuffles::GetWriteCallResult(call, nullptr,
+            sizeof(result), result.k_iCallback, &failed))
+        || !CHECK(failed))
+    {
+        return false;
+    }
+
+    failed = false;
+    if (!CHECK(!SavedItemShuffles::GetWriteCallResult(call, &result,
+            sizeof(result) - 1, result.k_iCallback, &failed))
+        || !CHECK(failed))
+    {
+        return false;
+    }
+
+    failed = false;
+    if (!CHECK(!SavedItemShuffles::GetWriteCallResult(call, &result,
+            sizeof(result), result.k_iCallback + 1, &failed))
+        || !CHECK(failed))
+    {
+        return false;
+    }
+
+    failed = false;
+    return CHECK(!SavedItemShuffles::GetWriteCallResult(123, &result,
+               sizeof(result), result.k_iCallback, &failed))
+        && CHECK(failed);
+}
+
+} // namespace
+
+int main()
+{
+    bool success = RoutingIsConservative()
+        && MissingFileUsesSteamSemantics()
+        && BinaryDataCanBeWrittenReadAndOverwritten()
+        && InvalidBuffersAndSizesFail()
+        && MissingDirectoryMakesWritesFail()
+        && SuccessfulReplacementLeavesNoTemporaryFile()
+#ifdef _WIN32
+        && FailedReplacementPreservesOldFile()
+#endif
+        && SyntheticCallsAreUniqueAndReportResults()
+        && SyntheticCallsRejectInvalidResultRequests();
+
+    ResetStorage();
+    return success ? 0 : 1;
+}

--- a/csgo_gc/saved_item_shuffles_tests.cpp
+++ b/csgo_gc/saved_item_shuffles_tests.cpp
@@ -27,6 +27,7 @@ namespace
 {
 
 constexpr const char *TemporaryFilePrefix = "saved_item_shuffles.txt.tmp.";
+constexpr const char *LocalFileName = "saved_item_shuffles.txt";
 
 bool Check(bool condition, const char *expression, int line)
 {
@@ -39,7 +40,13 @@ bool Check(bool condition, const char *expression, int line)
 
 #define CHECK(expression) Check((expression), #expression, __LINE__)
 
-bool RemoveStoragePath()
+bool IsStorageFile(const char *name)
+{
+    return !strcmp(name, LocalFileName)
+        || !strncmp(name, TemporaryFilePrefix, strlen(TemporaryFilePrefix));
+}
+
+bool RemoveStoragePath(bool removeDirectory)
 {
 #ifdef _WIN32
     DWORD attributes = GetFileAttributesA(SavedItemShuffles::DirectoryPath);
@@ -58,9 +65,9 @@ bool RemoveStoragePath()
     pattern.append("\\*");
     WIN32_FIND_DATAA entry{};
     HANDLE search = FindFirstFileA(pattern.c_str(), &entry);
+    bool succeeded = true;
     if (search != INVALID_HANDLE_VALUE)
     {
-        bool succeeded = true;
         do
         {
             if (!strcmp(entry.cFileName, ".") || !strcmp(entry.cFileName, ".."))
@@ -68,13 +75,16 @@ bool RemoveStoragePath()
                 continue;
             }
 
-            std::string path = SavedItemShuffles::DirectoryPath;
-            path.push_back('\\');
-            path.append(entry.cFileName);
-            if ((entry.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
-                || !DeleteFileA(path.c_str()))
+            if (IsStorageFile(entry.cFileName))
             {
-                succeeded = false;
+                std::string path = SavedItemShuffles::DirectoryPath;
+                path.push_back('\\');
+                path.append(entry.cFileName);
+                if ((entry.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
+                    || !DeleteFileA(path.c_str()))
+                {
+                    succeeded = false;
+                }
             }
         } while (FindNextFileA(search, &entry));
         FindClose(search);
@@ -88,7 +98,8 @@ bool RemoveStoragePath()
         return false;
     }
 
-    return RemoveDirectoryA(SavedItemShuffles::DirectoryPath) != 0;
+    return succeeded && (!removeDirectory
+        || RemoveDirectoryA(SavedItemShuffles::DirectoryPath) != 0);
 #else
     struct stat status{};
     if (lstat(SavedItemShuffles::DirectoryPath, &status) != 0)
@@ -115,31 +126,101 @@ bool RemoveStoragePath()
             continue;
         }
 
-        std::string path = SavedItemShuffles::DirectoryPath;
-        path.push_back('/');
-        path.append(entry->d_name);
-        if (unlink(path.c_str()) != 0)
+        if (IsStorageFile(entry->d_name))
         {
-            succeeded = false;
+            std::string path = SavedItemShuffles::DirectoryPath;
+            path.push_back('/');
+            path.append(entry->d_name);
+            if (unlink(path.c_str()) != 0)
+            {
+                succeeded = false;
+            }
         }
     }
     succeeded &= closedir(directory) == 0;
-    return succeeded && rmdir(SavedItemShuffles::DirectoryPath) == 0;
+    return succeeded && (!removeDirectory
+        || rmdir(SavedItemShuffles::DirectoryPath) == 0);
 #endif
 }
 
-bool CreateStorageDirectory()
+bool EnsureStorageDirectory()
 {
 #ifdef _WIN32
-    return CreateDirectoryA(SavedItemShuffles::DirectoryPath, nullptr) != 0;
+    if (CreateDirectoryA(SavedItemShuffles::DirectoryPath, nullptr))
+    {
+        return true;
+    }
+    DWORD error = GetLastError();
+    DWORD attributes = GetFileAttributesA(SavedItemShuffles::DirectoryPath);
+    return error == ERROR_ALREADY_EXISTS
+        && attributes != INVALID_FILE_ATTRIBUTES
+        && (attributes & FILE_ATTRIBUTE_DIRECTORY);
 #else
-    return mkdir(SavedItemShuffles::DirectoryPath, 0755) == 0;
+    if (mkdir(SavedItemShuffles::DirectoryPath, 0755) == 0)
+    {
+        return true;
+    }
+    int error = errno;
+    struct stat status{};
+    return error == EEXIST
+        && stat(SavedItemShuffles::DirectoryPath, &status) == 0
+        && S_ISDIR(status.st_mode);
 #endif
 }
 
 bool ResetStorage()
 {
-    return RemoveStoragePath() && CreateStorageDirectory();
+    return RemoveStoragePath(false) && EnsureStorageDirectory();
+}
+
+std::string StoragePath(const char *name)
+{
+    std::string path = SavedItemShuffles::DirectoryPath;
+#ifdef _WIN32
+    path.push_back('\\');
+#else
+    path.push_back('/');
+#endif
+    path.append(name);
+    return path;
+}
+
+bool ResetStoragePreservesUnrelatedFiles()
+{
+    if (!CHECK(ResetStorage()))
+    {
+        return false;
+    }
+
+    const uint8_t data = 42;
+    if (!CHECK(SavedItemShuffles::FileWrite(&data, 1)))
+    {
+        return false;
+    }
+
+    std::string unrelatedPath = StoragePath("saved_item_shuffles_test_unrelated.txt");
+    FILE *unrelatedFile = fopen(unrelatedPath.c_str(), "wb");
+    if (!CHECK(unrelatedFile != nullptr))
+    {
+        return false;
+    }
+    bool created = fwrite(&data, 1, 1, unrelatedFile) == 1;
+    created &= fclose(unrelatedFile) == 0;
+
+    bool reset = created && ResetStorage();
+    FILE *preservedFile = reset ? fopen(unrelatedPath.c_str(), "rb") : nullptr;
+    bool preserved = preservedFile != nullptr;
+    if (preservedFile)
+    {
+        preserved &= fclose(preservedFile) == 0;
+    }
+    bool removed = remove(unrelatedPath.c_str()) == 0;
+
+    return CHECK(created)
+        && CHECK(reset)
+        && CHECK(!SavedItemShuffles::FileExists())
+        && CHECK(preserved)
+        && CHECK(removed);
 }
 
 bool RoutingIsConservative()
@@ -215,7 +296,7 @@ bool InvalidBuffersAndSizesFail()
 
 bool MissingDirectoryIsCreatedOnWrite()
 {
-    if (!CHECK(ResetStorage()) || !CHECK(RemoveStoragePath()))
+    if (!CHECK(ResetStorage()) || !CHECK(RemoveStoragePath(true)))
     {
         return false;
     }
@@ -230,7 +311,7 @@ bool MissingDirectoryIsCreatedOnWrite()
 
 bool DirectoryCreationFailureStopsWrite()
 {
-    if (!CHECK(ResetStorage()) || !CHECK(RemoveStoragePath()))
+    if (!CHECK(ResetStorage()) || !CHECK(RemoveStoragePath(true)))
     {
         return false;
     }
@@ -581,12 +662,54 @@ bool SyntheticReadCallsRejectInvalidResultRequests()
         && CHECK(buffer == data);
 }
 
+bool SyntheticReadCallsEvictOldestPendingCall()
+{
+    if (!CHECK(ResetStorage()))
+    {
+        return false;
+    }
+
+    const uint8_t data = 42;
+    if (!CHECK(SavedItemShuffles::FileWrite(&data, 1)))
+    {
+        return false;
+    }
+
+    std::array<SteamAPICall_t, 17> calls{};
+    for (SteamAPICall_t &call : calls)
+    {
+        call = SavedItemShuffles::MakeReadCall(0, 0);
+    }
+
+    RemoteStorageFileReadAsyncComplete_t result{};
+    bool failed = false;
+    bool success = CHECK(!SavedItemShuffles::GetReadCallResult(calls.front(),
+        &result, sizeof(result), result.k_iCallback, &failed))
+        && CHECK(failed);
+
+    for (size_t index = 1; index < calls.size(); ++index)
+    {
+        result = {};
+        failed = true;
+        success &= CHECK(SavedItemShuffles::GetReadCallResult(calls[index],
+            &result, sizeof(result), result.k_iCallback, &failed));
+        success &= CHECK(!failed);
+        success &= CHECK(result.m_hFileReadAsync == calls[index]);
+        success &= CHECK(result.m_eResult == k_EResultOK);
+        success &= CHECK(result.m_cubRead == 0);
+        success &= CHECK(SavedItemShuffles::CompleteReadCall(
+            calls[index], nullptr, 0));
+    }
+    return success;
+}
+
 } // namespace
 
 int main()
 {
     bool success = true;
     success &= RoutingIsConservative();
+    success &= ResetStoragePreservesUnrelatedFiles();
     success &= MissingFileUsesSteamSemantics();
     success &= BinaryDataCanBeWrittenReadAndOverwritten();
     success &= InvalidBuffersAndSizesFail();
@@ -602,6 +725,7 @@ int main()
     success &= SyntheticReadCallsReturnLocalData();
     success &= SyntheticReadCallsReportFailures();
     success &= SyntheticReadCallsRejectInvalidResultRequests();
+    success &= SyntheticReadCallsEvictOldestPendingCall();
 
     success &= ResetStorage();
     return success ? 0 : 1;

--- a/csgo_gc/steam_hook.cpp
+++ b/csgo_gc/steam_hook.cpp
@@ -636,7 +636,8 @@ public:
             return true;
         }
 
-        if (SavedItemShuffles::IsWriteCall(hSteamAPICall))
+        if (SavedItemShuffles::IsWriteCall(hSteamAPICall)
+            || SavedItemShuffles::IsReadCall(hSteamAPICall))
         {
             if (pbFailed)
             {
@@ -652,7 +653,8 @@ public:
     ESteamAPICallFailure GetAPICallFailureReason(auto original, SteamAPICall_t hSteamAPICall)
     {
         if (hSteamAPICall == CheckSignatureCall
-            || SavedItemShuffles::IsWriteCall(hSteamAPICall))
+            || SavedItemShuffles::IsWriteCall(hSteamAPICall)
+            || SavedItemShuffles::IsReadCall(hSteamAPICall))
         {
             return k_ESteamAPICallFailureNone;
         }
@@ -680,6 +682,12 @@ public:
         if (SavedItemShuffles::IsWriteCall(hSteamAPICall))
         {
             return SavedItemShuffles::GetWriteCallResult(hSteamAPICall,
+                pCallback, cubCallback, iCallbackExpected, pbFailed);
+        }
+
+        if (SavedItemShuffles::IsReadCall(hSteamAPICall))
+        {
+            return SavedItemShuffles::GetReadCallResult(hSteamAPICall,
                 pCallback, cubCallback, iCallbackExpected, pbFailed);
         }
 
@@ -737,6 +745,46 @@ public:
             SavedItemShuffles::FileWrite(pvData, cubData));
     }
 
+    SteamAPICall_t FileReadAsync(auto original, const char *pchFile, uint32 nOffset, uint32 cubToRead)
+    {
+        if (!UseLocalStorage(pchFile))
+        {
+            return original(pchFile, nOffset, cubToRead);
+        }
+
+        return SavedItemShuffles::MakeReadCall(nOffset, cubToRead);
+    }
+
+    bool FileReadAsyncComplete(auto original, SteamAPICall_t hReadCall, void *pvBuffer, uint32 cubToRead)
+    {
+        if (!SavedItemShuffles::IsReadCall(hReadCall))
+        {
+            return original(hReadCall, pvBuffer, cubToRead);
+        }
+
+        return SavedItemShuffles::CompleteReadCall(hReadCall, pvBuffer, cubToRead);
+    }
+
+    bool FileForget(auto original, const char *pchFile)
+    {
+        if (!UseLocalStorage(pchFile))
+        {
+            return original(pchFile);
+        }
+
+        return SavedItemShuffles::FileForget();
+    }
+
+    bool FileDelete(auto original, const char *pchFile)
+    {
+        if (!UseLocalStorage(pchFile))
+        {
+            return original(pchFile);
+        }
+
+        return SavedItemShuffles::FileDelete();
+    }
+
     bool FileExists(auto original, const char *pchFile)
     {
         if (!UseLocalStorage(pchFile))
@@ -747,6 +795,16 @@ public:
         return SavedItemShuffles::FileExists();
     }
 
+    bool FilePersisted(auto original, const char *pchFile)
+    {
+        if (!UseLocalStorage(pchFile))
+        {
+            return original(pchFile);
+        }
+
+        return SavedItemShuffles::FilePersisted();
+    }
+
     int32 GetFileSize(auto original, const char *pchFile)
     {
         if (!UseLocalStorage(pchFile))
@@ -755,6 +813,16 @@ public:
         }
 
         return SavedItemShuffles::GetFileSize();
+    }
+
+    int64 GetFileTimestamp(auto original, const char *pchFile)
+    {
+        if (!UseLocalStorage(pchFile))
+        {
+            return original(pchFile);
+        }
+
+        return SavedItemShuffles::GetFileTimestamp();
     }
 };
 

--- a/csgo_gc/steam_hook.cpp
+++ b/csgo_gc/steam_hook.cpp
@@ -996,6 +996,7 @@ public:
 #include <proxy/steamgameserverproxy014.h>
 #include <proxy/steammatchmakingserversproxy002.h>
 #include <proxy/steamremotestorageproxy014.h>
+#include <proxy/steamremotestorageproxy016.h>
 #include <proxy/steamuserproxy014.h>
 #include <proxy/steamuserproxy015.h>
 #include <proxy/steamuserproxy016.h>
@@ -1127,6 +1128,7 @@ public:
         if (VersionNameIs(version, "STEAMREMOTESTORAGE_INTERFACE_VERSION"))
         {
             PROXY_INTERFACE(SteamRemoteStorage, 014);
+            PROXY_INTERFACE(SteamRemoteStorage, 016);
             Platform::Print("Can't hook %s\n", version);
             return nullptr;
         }

--- a/csgo_gc/steam_hook.cpp
+++ b/csgo_gc/steam_hook.cpp
@@ -16,6 +16,7 @@
 #include "gc_server.h"
 #include "platform.h"
 #include "rcon_server.h"
+#include "saved_item_shuffles.h"
 #include <funchook.h>
 
 #ifdef _WIN32
@@ -635,21 +636,29 @@ public:
             return true;
         }
 
+        if (SavedItemShuffles::IsWriteCall(hSteamAPICall))
+        {
+            if (pbFailed)
+            {
+                *pbFailed = false;
+            }
+
+            return true;
+        }
+
         return original(hSteamAPICall, pbFailed);
     }
 
-    // yeah we won't get here
-    //ESteamAPICallFailure GetAPICallFailureReason(auto original, SteamAPICall_t hSteamAPICall)
-    //{
-    //    if (hSteamAPICall == CheckSignatureCall)
-    //    {
-    //        // not properly handled, shouldn't get here
-    //        assert(false);
-    //        return k_ESteamAPICallFailureNone;
-    //    }
-    //
-    //    return original(hSteamAPICall);
-    //}
+    ESteamAPICallFailure GetAPICallFailureReason(auto original, SteamAPICall_t hSteamAPICall)
+    {
+        if (hSteamAPICall == CheckSignatureCall
+            || SavedItemShuffles::IsWriteCall(hSteamAPICall))
+        {
+            return k_ESteamAPICallFailureNone;
+        }
+
+        return original(hSteamAPICall);
+    }
 
     bool GetAPICallResult(auto original, SteamAPICall_t hSteamAPICall, void *pCallback, int cubCallback, int iCallbackExpected, bool *pbFailed)
     {
@@ -668,6 +677,12 @@ public:
             return true;
         }
 
+        if (SavedItemShuffles::IsWriteCall(hSteamAPICall))
+        {
+            return SavedItemShuffles::GetWriteCallResult(hSteamAPICall,
+                pCallback, cubCallback, iCallbackExpected, pbFailed);
+        }
+
         return original(hSteamAPICall, pCallback, cubCallback, iCallbackExpected, pbFailed);
     }
 
@@ -675,6 +690,71 @@ public:
     {
         // handle this
         return CheckSignatureCall;
+    }
+};
+
+class SteamRemoteStorageProxy final
+{
+    bool UseLocalStorage(const char *path) const
+    {
+        return SavedItemShuffles::ShouldUseLocalStorage(AppId::GetOverride(), path);
+    }
+
+public:
+    bool FileWrite(auto original, const char *pchFile, const void *pvData, int32 cubData)
+    {
+        if (!UseLocalStorage(pchFile))
+        {
+            return original(pchFile, pvData, cubData);
+        }
+
+        if (cubData < 0)
+        {
+            return false;
+        }
+
+        return SavedItemShuffles::FileWrite(pvData, static_cast<uint32_t>(cubData));
+    }
+
+    int32 FileRead(auto original, const char *pchFile, void *pvData, int32 cubDataToRead)
+    {
+        if (!UseLocalStorage(pchFile))
+        {
+            return original(pchFile, pvData, cubDataToRead);
+        }
+
+        return SavedItemShuffles::FileRead(pvData, cubDataToRead);
+    }
+
+    SteamAPICall_t FileWriteAsync(auto original, const char *pchFile, const void *pvData, uint32 cubData)
+    {
+        if (!UseLocalStorage(pchFile))
+        {
+            return original(pchFile, pvData, cubData);
+        }
+
+        return SavedItemShuffles::MakeWriteCall(
+            SavedItemShuffles::FileWrite(pvData, cubData));
+    }
+
+    bool FileExists(auto original, const char *pchFile)
+    {
+        if (!UseLocalStorage(pchFile))
+        {
+            return original(pchFile);
+        }
+
+        return SavedItemShuffles::FileExists();
+    }
+
+    int32 GetFileSize(auto original, const char *pchFile)
+    {
+        if (!UseLocalStorage(pchFile))
+        {
+            return original(pchFile);
+        }
+
+        return SavedItemShuffles::GetFileSize();
     }
 };
 
@@ -915,6 +995,7 @@ public:
 #include <proxy/steamgameserverproxy013.h>
 #include <proxy/steamgameserverproxy014.h>
 #include <proxy/steammatchmakingserversproxy002.h>
+#include <proxy/steamremotestorageproxy014.h>
 #include <proxy/steamuserproxy014.h>
 #include <proxy/steamuserproxy015.h>
 #include <proxy/steamuserproxy016.h>
@@ -1043,6 +1124,13 @@ public:
             return nullptr;
         }
 
+        if (VersionNameIs(version, "STEAMREMOTESTORAGE_INTERFACE_VERSION"))
+        {
+            PROXY_INTERFACE(SteamRemoteStorage, 014);
+            Platform::Print("Can't hook %s\n", version);
+            return nullptr;
+        }
+
         if (VersionNameIs(version, "SteamUtils"))
         {
             // old csgo builds fetch SteamUtils with a stale version...
@@ -1084,6 +1172,7 @@ private:
     std::unique_ptr<SteamGameServerProxy> m_proxySteamGameServer;
     std::unique_ptr<SteamUserProxy> m_proxySteamUser;
     std::unique_ptr<SteamMatchmakingServersProxy> m_proxySteamMatchmakingServers;
+    std::unique_ptr<SteamRemoteStorageProxy> m_proxySteamRemoteStorage;
 };
 
 class SteamClientProxy final
@@ -1177,6 +1266,11 @@ public:
     void *GetISteamGenericInterface(auto original, HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion)
     {
         return ProxyInterface(original(hSteamUser, hSteamPipe, pchVersion), hSteamUser, hSteamPipe, pchVersion, true);
+    }
+
+    ISteamRemoteStorage *GetISteamRemoteStorage(auto original, HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion)
+    {
+        return ProxyInterface(original(hSteamUser, hSteamPipe, pchVersion), hSteamUser, hSteamPipe, pchVersion);
     }
 
     ISteamUserStats *GetISteamUserStats(auto original, HSteamUser hSteamUser, HSteamPipe hSteamPipe, const char *pchVersion)

--- a/steamworks/sdk/public/proxy/steamremotestorageproxy014.h
+++ b/steamworks/sdk/public/proxy/steamremotestorageproxy014.h
@@ -1,0 +1,92 @@
+// Automatically generated interface forwarding glue. Do not modify by hand.
+#ifndef STEAMREMOTESTORAGEPROXY014_H
+#define STEAMREMOTESTORAGEPROXY014_H
+
+#include "steamproxy.h"
+#include <steam_old/isteamremotestorage014.h>
+
+class SteamRemoteStorageProxy014 final : public ISteamRemoteStorage014
+{
+    ISteamRemoteStorage014 *m_original;
+    SteamRemoteStorageProxy *m_proxy;
+
+public:
+    SteamRemoteStorageProxy014(ISteamRemoteStorage014 *original, SteamRemoteStorageProxy *proxy)
+        : m_original{ original }
+        , m_proxy{ proxy }
+    {
+    }
+
+#define STEAM_REMOTE_STORAGE_PROXY_METHOD(returnType, name, parameters, ...) \
+    returnType name parameters override \
+    { \
+        return [&](auto p) -> returnType \
+        { \
+            auto o = MakeOrig<&ISteamRemoteStorage014::name>(m_original); \
+            if constexpr (requires { p->name(o __VA_OPT__(,) __VA_ARGS__); }) \
+                return p->name(o __VA_OPT__(,) __VA_ARGS__); \
+            else \
+                return o(__VA_ARGS__); \
+        }(m_proxy); \
+    }
+
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(bool, FileWrite, (const char *pchFile, const void *pvData, int32 cubData), pchFile, pvData, cubData)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(int32, FileRead, (const char *pchFile, void *pvData, int32 cubDataToRead), pchFile, pvData, cubDataToRead)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(SteamAPICall_t, FileWriteAsync, (const char *pchFile, const void *pvData, uint32 cubData), pchFile, pvData, cubData)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(SteamAPICall_t, FileReadAsync, (const char *pchFile, uint32 nOffset, uint32 cubToRead), pchFile, nOffset, cubToRead)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(bool, FileReadAsyncComplete, (SteamAPICall_t hReadCall, void *pvBuffer, uint32 cubToRead), hReadCall, pvBuffer, cubToRead)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(bool, FileForget, (const char *pchFile), pchFile)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(bool, FileDelete, (const char *pchFile), pchFile)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(SteamAPICall_t, FileShare, (const char *pchFile), pchFile)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(bool, SetSyncPlatforms, (const char *pchFile, ERemoteStoragePlatform eRemoteStoragePlatform), pchFile, eRemoteStoragePlatform)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(UGCFileWriteStreamHandle_t, FileWriteStreamOpen, (const char *pchFile), pchFile)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(bool, FileWriteStreamWriteChunk, (UGCFileWriteStreamHandle_t writeHandle, const void *pvData, int32 cubData), writeHandle, pvData, cubData)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(bool, FileWriteStreamClose, (UGCFileWriteStreamHandle_t writeHandle), writeHandle)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(bool, FileWriteStreamCancel, (UGCFileWriteStreamHandle_t writeHandle), writeHandle)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(bool, FileExists, (const char *pchFile), pchFile)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(bool, FilePersisted, (const char *pchFile), pchFile)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(int32, GetFileSize, (const char *pchFile), pchFile)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(int64, GetFileTimestamp, (const char *pchFile), pchFile)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(ERemoteStoragePlatform, GetSyncPlatforms, (const char *pchFile), pchFile)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(int32, GetFileCount, ())
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(const char *, GetFileNameAndSize, (int iFile, int32 *pnFileSizeInBytes), iFile, pnFileSizeInBytes)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(bool, GetQuota, (uint64 *pnTotalBytes, uint64 *puAvailableBytes), pnTotalBytes, puAvailableBytes)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(bool, IsCloudEnabledForAccount, ())
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(bool, IsCloudEnabledForApp, ())
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(void, SetCloudEnabledForApp, (bool bEnabled), bEnabled)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(SteamAPICall_t, UGCDownload, (UGCHandle_t hContent, uint32 unPriority), hContent, unPriority)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(bool, GetUGCDownloadProgress, (UGCHandle_t hContent, int32 *pnBytesDownloaded, int32 *pnBytesExpected), hContent, pnBytesDownloaded, pnBytesExpected)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(bool, GetUGCDetails, (UGCHandle_t hContent, AppId_t *pnAppID, char **ppchName, int32 *pnFileSizeInBytes, CSteamID *pSteamIDOwner), hContent, pnAppID, ppchName, pnFileSizeInBytes, pSteamIDOwner)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(int32, UGCRead, (UGCHandle_t hContent, void *pvData, int32 cubDataToRead, uint32 cOffset, EUGCReadAction eAction), hContent, pvData, cubDataToRead, cOffset, eAction)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(int32, GetCachedUGCCount, ())
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(UGCHandle_t, GetCachedUGCHandle, (int32 iCachedContent), iCachedContent)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(SteamAPICall_t, PublishWorkshopFile, (const char *pchFile, const char *pchPreviewFile, AppId_t nConsumerAppId, const char *pchTitle, const char *pchDescription, ERemoteStoragePublishedFileVisibility eVisibility, SteamParamStringArray_t *pTags, EWorkshopFileType eWorkshopFileType), pchFile, pchPreviewFile, nConsumerAppId, pchTitle, pchDescription, eVisibility, pTags, eWorkshopFileType)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(PublishedFileUpdateHandle_t, CreatePublishedFileUpdateRequest, (PublishedFileId_t unPublishedFileId), unPublishedFileId)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(bool, UpdatePublishedFileFile, (PublishedFileUpdateHandle_t updateHandle, const char *pchFile), updateHandle, pchFile)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(bool, UpdatePublishedFilePreviewFile, (PublishedFileUpdateHandle_t updateHandle, const char *pchPreviewFile), updateHandle, pchPreviewFile)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(bool, UpdatePublishedFileTitle, (PublishedFileUpdateHandle_t updateHandle, const char *pchTitle), updateHandle, pchTitle)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(bool, UpdatePublishedFileDescription, (PublishedFileUpdateHandle_t updateHandle, const char *pchDescription), updateHandle, pchDescription)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(bool, UpdatePublishedFileVisibility, (PublishedFileUpdateHandle_t updateHandle, ERemoteStoragePublishedFileVisibility eVisibility), updateHandle, eVisibility)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(bool, UpdatePublishedFileTags, (PublishedFileUpdateHandle_t updateHandle, SteamParamStringArray_t *pTags), updateHandle, pTags)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(SteamAPICall_t, CommitPublishedFileUpdate, (PublishedFileUpdateHandle_t updateHandle), updateHandle)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(SteamAPICall_t, GetPublishedFileDetails, (PublishedFileId_t unPublishedFileId, uint32 unMaxSecondsOld), unPublishedFileId, unMaxSecondsOld)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(SteamAPICall_t, DeletePublishedFile, (PublishedFileId_t unPublishedFileId), unPublishedFileId)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(SteamAPICall_t, EnumerateUserPublishedFiles, (uint32 unStartIndex), unStartIndex)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(SteamAPICall_t, SubscribePublishedFile, (PublishedFileId_t unPublishedFileId), unPublishedFileId)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(SteamAPICall_t, EnumerateUserSubscribedFiles, (uint32 unStartIndex), unStartIndex)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(SteamAPICall_t, UnsubscribePublishedFile, (PublishedFileId_t unPublishedFileId), unPublishedFileId)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(bool, UpdatePublishedFileSetChangeDescription, (PublishedFileUpdateHandle_t updateHandle, const char *pchChangeDescription), updateHandle, pchChangeDescription)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(SteamAPICall_t, GetPublishedItemVoteDetails, (PublishedFileId_t unPublishedFileId), unPublishedFileId)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(SteamAPICall_t, UpdateUserPublishedItemVote, (PublishedFileId_t unPublishedFileId, bool bVoteUp), unPublishedFileId, bVoteUp)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(SteamAPICall_t, GetUserPublishedItemVoteDetails, (PublishedFileId_t unPublishedFileId), unPublishedFileId)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(SteamAPICall_t, EnumerateUserSharedWorkshopFiles, (CSteamID steamId, uint32 unStartIndex, SteamParamStringArray_t *pRequiredTags, SteamParamStringArray_t *pExcludedTags), steamId, unStartIndex, pRequiredTags, pExcludedTags)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(SteamAPICall_t, PublishVideo, (EWorkshopVideoProvider eVideoProvider, const char *pchVideoAccount, const char *pchVideoIdentifier, const char *pchPreviewFile, AppId_t nConsumerAppId, const char *pchTitle, const char *pchDescription, ERemoteStoragePublishedFileVisibility eVisibility, SteamParamStringArray_t *pTags), eVideoProvider, pchVideoAccount, pchVideoIdentifier, pchPreviewFile, nConsumerAppId, pchTitle, pchDescription, eVisibility, pTags)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(SteamAPICall_t, SetUserPublishedFileAction, (PublishedFileId_t unPublishedFileId, EWorkshopFileAction eAction), unPublishedFileId, eAction)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(SteamAPICall_t, EnumeratePublishedFilesByUserAction, (EWorkshopFileAction eAction, uint32 unStartIndex), eAction, unStartIndex)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(SteamAPICall_t, EnumeratePublishedWorkshopFiles, (EWorkshopEnumerationType eEnumerationType, uint32 unStartIndex, uint32 unCount, uint32 unDays, SteamParamStringArray_t *pTags, SteamParamStringArray_t *pUserTags), eEnumerationType, unStartIndex, unCount, unDays, pTags, pUserTags)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(SteamAPICall_t, UGCDownloadToLocation, (UGCHandle_t hContent, const char *pchLocation, uint32 unPriority), hContent, pchLocation, unPriority)
+
+#undef STEAM_REMOTE_STORAGE_PROXY_METHOD
+};
+
+#endif // STEAMREMOTESTORAGEPROXY014_H

--- a/steamworks/sdk/public/proxy/steamremotestorageproxy016.h
+++ b/steamworks/sdk/public/proxy/steamremotestorageproxy016.h
@@ -1,0 +1,96 @@
+// Automatically generated interface forwarding glue. Do not modify by hand.
+#ifndef STEAMREMOTESTORAGEPROXY016_H
+#define STEAMREMOTESTORAGEPROXY016_H
+
+#include "steamproxy.h"
+#include <steam_old/isteamremotestorage016.h>
+
+class SteamRemoteStorageProxy016 final : public ISteamRemoteStorage016
+{
+    ISteamRemoteStorage016 *m_original;
+    SteamRemoteStorageProxy *m_proxy;
+
+public:
+    SteamRemoteStorageProxy016(ISteamRemoteStorage016 *original, SteamRemoteStorageProxy *proxy)
+        : m_original{ original }
+        , m_proxy{ proxy }
+    {
+    }
+
+#define STEAM_REMOTE_STORAGE_PROXY_METHOD(returnType, name, parameters, ...) \
+    returnType name parameters override \
+    { \
+        return [&](auto p) -> returnType \
+        { \
+            auto o = MakeOrig<&ISteamRemoteStorage016::name>(m_original); \
+            if constexpr (requires { p->name(o __VA_OPT__(,) __VA_ARGS__); }) \
+                return p->name(o __VA_OPT__(,) __VA_ARGS__); \
+            else \
+                return o(__VA_ARGS__); \
+        }(m_proxy); \
+    }
+
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(bool, FileWrite, (const char *pchFile, const void *pvData, int32 cubData), pchFile, pvData, cubData)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(int32, FileRead, (const char *pchFile, void *pvData, int32 cubDataToRead), pchFile, pvData, cubDataToRead)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(SteamAPICall_t, FileWriteAsync, (const char *pchFile, const void *pvData, uint32 cubData), pchFile, pvData, cubData)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(SteamAPICall_t, FileReadAsync, (const char *pchFile, uint32 nOffset, uint32 cubToRead), pchFile, nOffset, cubToRead)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(bool, FileReadAsyncComplete, (SteamAPICall_t hReadCall, void *pvBuffer, uint32 cubToRead), hReadCall, pvBuffer, cubToRead)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(bool, FileForget, (const char *pchFile), pchFile)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(bool, FileDelete, (const char *pchFile), pchFile)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(SteamAPICall_t, FileShare, (const char *pchFile), pchFile)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(bool, SetSyncPlatforms, (const char *pchFile, ERemoteStoragePlatform eRemoteStoragePlatform), pchFile, eRemoteStoragePlatform)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(UGCFileWriteStreamHandle_t, FileWriteStreamOpen, (const char *pchFile), pchFile)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(bool, FileWriteStreamWriteChunk, (UGCFileWriteStreamHandle_t writeHandle, const void *pvData, int32 cubData), writeHandle, pvData, cubData)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(bool, FileWriteStreamClose, (UGCFileWriteStreamHandle_t writeHandle), writeHandle)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(bool, FileWriteStreamCancel, (UGCFileWriteStreamHandle_t writeHandle), writeHandle)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(bool, FileExists, (const char *pchFile), pchFile)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(bool, FilePersisted, (const char *pchFile), pchFile)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(int32, GetFileSize, (const char *pchFile), pchFile)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(int64, GetFileTimestamp, (const char *pchFile), pchFile)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(ERemoteStoragePlatform, GetSyncPlatforms, (const char *pchFile), pchFile)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(int32, GetFileCount, ())
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(const char *, GetFileNameAndSize, (int iFile, int32 *pnFileSizeInBytes), iFile, pnFileSizeInBytes)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(bool, GetQuota, (uint64 *pnTotalBytes, uint64 *puAvailableBytes), pnTotalBytes, puAvailableBytes)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(bool, IsCloudEnabledForAccount, ())
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(bool, IsCloudEnabledForApp, ())
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(void, SetCloudEnabledForApp, (bool bEnabled), bEnabled)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(SteamAPICall_t, UGCDownload, (UGCHandle_t hContent, uint32 unPriority), hContent, unPriority)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(bool, GetUGCDownloadProgress, (UGCHandle_t hContent, int32 *pnBytesDownloaded, int32 *pnBytesExpected), hContent, pnBytesDownloaded, pnBytesExpected)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(bool, GetUGCDetails, (UGCHandle_t hContent, AppId_t *pnAppID, char **ppchName, int32 *pnFileSizeInBytes, CSteamID *pSteamIDOwner), hContent, pnAppID, ppchName, pnFileSizeInBytes, pSteamIDOwner)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(int32, UGCRead, (UGCHandle_t hContent, void *pvData, int32 cubDataToRead, uint32 cOffset, EUGCReadAction eAction), hContent, pvData, cubDataToRead, cOffset, eAction)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(int32, GetCachedUGCCount, ())
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(UGCHandle_t, GetCachedUGCHandle, (int32 iCachedContent), iCachedContent)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(SteamAPICall_t, PublishWorkshopFile, (const char *pchFile, const char *pchPreviewFile, AppId_t nConsumerAppId, const char *pchTitle, const char *pchDescription, ERemoteStoragePublishedFileVisibility eVisibility, SteamParamStringArray_t *pTags, EWorkshopFileType eWorkshopFileType), pchFile, pchPreviewFile, nConsumerAppId, pchTitle, pchDescription, eVisibility, pTags, eWorkshopFileType)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(PublishedFileUpdateHandle_t, CreatePublishedFileUpdateRequest, (PublishedFileId_t unPublishedFileId), unPublishedFileId)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(bool, UpdatePublishedFileFile, (PublishedFileUpdateHandle_t updateHandle, const char *pchFile), updateHandle, pchFile)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(bool, UpdatePublishedFilePreviewFile, (PublishedFileUpdateHandle_t updateHandle, const char *pchPreviewFile), updateHandle, pchPreviewFile)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(bool, UpdatePublishedFileTitle, (PublishedFileUpdateHandle_t updateHandle, const char *pchTitle), updateHandle, pchTitle)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(bool, UpdatePublishedFileDescription, (PublishedFileUpdateHandle_t updateHandle, const char *pchDescription), updateHandle, pchDescription)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(bool, UpdatePublishedFileVisibility, (PublishedFileUpdateHandle_t updateHandle, ERemoteStoragePublishedFileVisibility eVisibility), updateHandle, eVisibility)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(bool, UpdatePublishedFileTags, (PublishedFileUpdateHandle_t updateHandle, SteamParamStringArray_t *pTags), updateHandle, pTags)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(SteamAPICall_t, CommitPublishedFileUpdate, (PublishedFileUpdateHandle_t updateHandle), updateHandle)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(SteamAPICall_t, GetPublishedFileDetails, (PublishedFileId_t unPublishedFileId, uint32 unMaxSecondsOld), unPublishedFileId, unMaxSecondsOld)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(SteamAPICall_t, DeletePublishedFile, (PublishedFileId_t unPublishedFileId), unPublishedFileId)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(SteamAPICall_t, EnumerateUserPublishedFiles, (uint32 unStartIndex), unStartIndex)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(SteamAPICall_t, SubscribePublishedFile, (PublishedFileId_t unPublishedFileId), unPublishedFileId)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(SteamAPICall_t, EnumerateUserSubscribedFiles, (uint32 unStartIndex), unStartIndex)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(SteamAPICall_t, UnsubscribePublishedFile, (PublishedFileId_t unPublishedFileId), unPublishedFileId)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(bool, UpdatePublishedFileSetChangeDescription, (PublishedFileUpdateHandle_t updateHandle, const char *pchChangeDescription), updateHandle, pchChangeDescription)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(SteamAPICall_t, GetPublishedItemVoteDetails, (PublishedFileId_t unPublishedFileId), unPublishedFileId)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(SteamAPICall_t, UpdateUserPublishedItemVote, (PublishedFileId_t unPublishedFileId, bool bVoteUp), unPublishedFileId, bVoteUp)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(SteamAPICall_t, GetUserPublishedItemVoteDetails, (PublishedFileId_t unPublishedFileId), unPublishedFileId)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(SteamAPICall_t, EnumerateUserSharedWorkshopFiles, (CSteamID steamId, uint32 unStartIndex, SteamParamStringArray_t *pRequiredTags, SteamParamStringArray_t *pExcludedTags), steamId, unStartIndex, pRequiredTags, pExcludedTags)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(SteamAPICall_t, PublishVideo, (EWorkshopVideoProvider eVideoProvider, const char *pchVideoAccount, const char *pchVideoIdentifier, const char *pchPreviewFile, AppId_t nConsumerAppId, const char *pchTitle, const char *pchDescription, ERemoteStoragePublishedFileVisibility eVisibility, SteamParamStringArray_t *pTags), eVideoProvider, pchVideoAccount, pchVideoIdentifier, pchPreviewFile, nConsumerAppId, pchTitle, pchDescription, eVisibility, pTags)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(SteamAPICall_t, SetUserPublishedFileAction, (PublishedFileId_t unPublishedFileId, EWorkshopFileAction eAction), unPublishedFileId, eAction)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(SteamAPICall_t, EnumeratePublishedFilesByUserAction, (EWorkshopFileAction eAction, uint32 unStartIndex), eAction, unStartIndex)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(SteamAPICall_t, EnumeratePublishedWorkshopFiles, (EWorkshopEnumerationType eEnumerationType, uint32 unStartIndex, uint32 unCount, uint32 unDays, SteamParamStringArray_t *pTags, SteamParamStringArray_t *pUserTags), eEnumerationType, unStartIndex, unCount, unDays, pTags, pUserTags)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(SteamAPICall_t, UGCDownloadToLocation, (UGCHandle_t hContent, const char *pchLocation, uint32 unPriority), hContent, pchLocation, unPriority)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(int32, GetLocalFileChangeCount, ())
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(const char *, GetLocalFileChange, (int iFile, ERemoteStorageLocalFileChange *pEChangeType, ERemoteStorageFilePathType *pEFilePathType), iFile, pEChangeType, pEFilePathType)
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(bool, BeginFileWriteBatch, ())
+    STEAM_REMOTE_STORAGE_PROXY_METHOD(bool, EndFileWriteBatch, ())
+
+#undef STEAM_REMOTE_STORAGE_PROXY_METHOD
+};
+
+#endif // STEAMREMOTESTORAGEPROXY016_H

--- a/steamworks/sdk/public/steam_old/isteamremotestorage014.h
+++ b/steamworks/sdk/public/steam_old/isteamremotestorage014.h
@@ -1,0 +1,65 @@
+// Extracted from steamworks_sdk_142
+#ifndef ISTEAMREMOTESTORAGE014_H
+#define ISTEAMREMOTESTORAGE014_H
+
+class ISteamRemoteStorage014
+{
+public:
+    virtual bool FileWrite(const char *pchFile, const void *pvData, int32 cubData) = 0;
+    virtual int32 FileRead(const char *pchFile, void *pvData, int32 cubDataToRead) = 0;
+    virtual SteamAPICall_t FileWriteAsync(const char *pchFile, const void *pvData, uint32 cubData) = 0;
+    virtual SteamAPICall_t FileReadAsync(const char *pchFile, uint32 nOffset, uint32 cubToRead) = 0;
+    virtual bool FileReadAsyncComplete(SteamAPICall_t hReadCall, void *pvBuffer, uint32 cubToRead) = 0;
+    virtual bool FileForget(const char *pchFile) = 0;
+    virtual bool FileDelete(const char *pchFile) = 0;
+    virtual SteamAPICall_t FileShare(const char *pchFile) = 0;
+    virtual bool SetSyncPlatforms(const char *pchFile, ERemoteStoragePlatform eRemoteStoragePlatform) = 0;
+    virtual UGCFileWriteStreamHandle_t FileWriteStreamOpen(const char *pchFile) = 0;
+    virtual bool FileWriteStreamWriteChunk(UGCFileWriteStreamHandle_t writeHandle, const void *pvData, int32 cubData) = 0;
+    virtual bool FileWriteStreamClose(UGCFileWriteStreamHandle_t writeHandle) = 0;
+    virtual bool FileWriteStreamCancel(UGCFileWriteStreamHandle_t writeHandle) = 0;
+    virtual bool FileExists(const char *pchFile) = 0;
+    virtual bool FilePersisted(const char *pchFile) = 0;
+    virtual int32 GetFileSize(const char *pchFile) = 0;
+    virtual int64 GetFileTimestamp(const char *pchFile) = 0;
+    virtual ERemoteStoragePlatform GetSyncPlatforms(const char *pchFile) = 0;
+    virtual int32 GetFileCount() = 0;
+    virtual const char *GetFileNameAndSize(int iFile, int32 *pnFileSizeInBytes) = 0;
+    virtual bool GetQuota(uint64 *pnTotalBytes, uint64 *puAvailableBytes) = 0;
+    virtual bool IsCloudEnabledForAccount() = 0;
+    virtual bool IsCloudEnabledForApp() = 0;
+    virtual void SetCloudEnabledForApp(bool bEnabled) = 0;
+    virtual SteamAPICall_t UGCDownload(UGCHandle_t hContent, uint32 unPriority) = 0;
+    virtual bool GetUGCDownloadProgress(UGCHandle_t hContent, int32 *pnBytesDownloaded, int32 *pnBytesExpected) = 0;
+    virtual bool GetUGCDetails(UGCHandle_t hContent, AppId_t *pnAppID, STEAM_OUT_STRING() char **ppchName, int32 *pnFileSizeInBytes, STEAM_OUT_STRUCT() CSteamID *pSteamIDOwner) = 0;
+    virtual int32 UGCRead(UGCHandle_t hContent, void *pvData, int32 cubDataToRead, uint32 cOffset, EUGCReadAction eAction) = 0;
+    virtual int32 GetCachedUGCCount() = 0;
+    virtual UGCHandle_t GetCachedUGCHandle(int32 iCachedContent) = 0;
+    virtual SteamAPICall_t PublishWorkshopFile(const char *pchFile, const char *pchPreviewFile, AppId_t nConsumerAppId, const char *pchTitle, const char *pchDescription, ERemoteStoragePublishedFileVisibility eVisibility, SteamParamStringArray_t *pTags, EWorkshopFileType eWorkshopFileType) = 0;
+    virtual PublishedFileUpdateHandle_t CreatePublishedFileUpdateRequest(PublishedFileId_t unPublishedFileId) = 0;
+    virtual bool UpdatePublishedFileFile(PublishedFileUpdateHandle_t updateHandle, const char *pchFile) = 0;
+    virtual bool UpdatePublishedFilePreviewFile(PublishedFileUpdateHandle_t updateHandle, const char *pchPreviewFile) = 0;
+    virtual bool UpdatePublishedFileTitle(PublishedFileUpdateHandle_t updateHandle, const char *pchTitle) = 0;
+    virtual bool UpdatePublishedFileDescription(PublishedFileUpdateHandle_t updateHandle, const char *pchDescription) = 0;
+    virtual bool UpdatePublishedFileVisibility(PublishedFileUpdateHandle_t updateHandle, ERemoteStoragePublishedFileVisibility eVisibility) = 0;
+    virtual bool UpdatePublishedFileTags(PublishedFileUpdateHandle_t updateHandle, SteamParamStringArray_t *pTags) = 0;
+    virtual SteamAPICall_t CommitPublishedFileUpdate(PublishedFileUpdateHandle_t updateHandle) = 0;
+    virtual SteamAPICall_t GetPublishedFileDetails(PublishedFileId_t unPublishedFileId, uint32 unMaxSecondsOld) = 0;
+    virtual SteamAPICall_t DeletePublishedFile(PublishedFileId_t unPublishedFileId) = 0;
+    virtual SteamAPICall_t EnumerateUserPublishedFiles(uint32 unStartIndex) = 0;
+    virtual SteamAPICall_t SubscribePublishedFile(PublishedFileId_t unPublishedFileId) = 0;
+    virtual SteamAPICall_t EnumerateUserSubscribedFiles(uint32 unStartIndex) = 0;
+    virtual SteamAPICall_t UnsubscribePublishedFile(PublishedFileId_t unPublishedFileId) = 0;
+    virtual bool UpdatePublishedFileSetChangeDescription(PublishedFileUpdateHandle_t updateHandle, const char *pchChangeDescription) = 0;
+    virtual SteamAPICall_t GetPublishedItemVoteDetails(PublishedFileId_t unPublishedFileId) = 0;
+    virtual SteamAPICall_t UpdateUserPublishedItemVote(PublishedFileId_t unPublishedFileId, bool bVoteUp) = 0;
+    virtual SteamAPICall_t GetUserPublishedItemVoteDetails(PublishedFileId_t unPublishedFileId) = 0;
+    virtual SteamAPICall_t EnumerateUserSharedWorkshopFiles(CSteamID steamId, uint32 unStartIndex, SteamParamStringArray_t *pRequiredTags, SteamParamStringArray_t *pExcludedTags) = 0;
+    virtual SteamAPICall_t PublishVideo(EWorkshopVideoProvider eVideoProvider, const char *pchVideoAccount, const char *pchVideoIdentifier, const char *pchPreviewFile, AppId_t nConsumerAppId, const char *pchTitle, const char *pchDescription, ERemoteStoragePublishedFileVisibility eVisibility, SteamParamStringArray_t *pTags) = 0;
+    virtual SteamAPICall_t SetUserPublishedFileAction(PublishedFileId_t unPublishedFileId, EWorkshopFileAction eAction) = 0;
+    virtual SteamAPICall_t EnumeratePublishedFilesByUserAction(EWorkshopFileAction eAction, uint32 unStartIndex) = 0;
+    virtual SteamAPICall_t EnumeratePublishedWorkshopFiles(EWorkshopEnumerationType eEnumerationType, uint32 unStartIndex, uint32 unCount, uint32 unDays, SteamParamStringArray_t *pTags, SteamParamStringArray_t *pUserTags) = 0;
+    virtual SteamAPICall_t UGCDownloadToLocation(UGCHandle_t hContent, const char *pchLocation, uint32 unPriority) = 0;
+};
+
+#endif // ISTEAMREMOTESTORAGE014_H

--- a/steamworks/sdk/public/steam_old/isteamremotestorage016.h
+++ b/steamworks/sdk/public/steam_old/isteamremotestorage016.h
@@ -1,0 +1,9 @@
+// ISteamRemoteStorage in the bundled SDK is interface version 016.
+#ifndef ISTEAMREMOTESTORAGE016_H
+#define ISTEAMREMOTESTORAGE016_H
+
+#include <steam/isteamremotestorage.h>
+
+using ISteamRemoteStorage016 = ISteamRemoteStorage;
+
+#endif // ISTEAMREMOTESTORAGE016_H


### PR DESCRIPTION
## Summary

- Persist `cfg/csgo_saved_item_shuffles.txt` locally for non-730 AppIDs.
- Keep AppID 730 and all unrelated Remote Storage, Workshop, and UGC calls forwarded to Steam.
- Proxy Steam Remote Storage interfaces 014 and 016, including synthetic async write completion results.
- Use flushed atomic replacement for `csgo_gc/saved_item_shuffles.txt`.

## Testing

- Windows x86 MSVC build via `.idea/build-windows.ps1`
- `ctest --test-dir build --output-on-failure` (6/6 passed)
- Runtime verified with AppID 4465480

Fixes #54

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added local file storage for saved item data when remote storage is unavailable or unsuitable.
  * Added reliable file writing, reading, deletion, existence checks, size reporting, and timestamps.
  * Added asynchronous read and write support with result reporting.
  * Added compatibility across supported Steam Remote Storage interface versions.
  * Preserved existing remote-storage behavior for other files and operations.

* **Bug Fixes**
  * Improved handling of failed writes, invalid inputs, temporary files, and interrupted file replacement.

* **Tests**
  * Added comprehensive coverage for storage routing, file operations, failure handling, and asynchronous results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->