### PR TITLE
Fix paint wear defaults and base item customization cleanup

### DIFF
--- a/csgo_gc/gc_message_tests.cpp
+++ b/csgo_gc/gc_message_tests.cpp
@@ -607,6 +607,242 @@ static bool SOCacheVersionNegotiationAndRefresh()
     return valid;
 }
 
+static void RemoveCustomizationFixtures()
+{
+    TestFilesystem::RemoveFile("csgo_gc/inventory.txt");
+    TestFilesystem::RemoveFile("csgo_gc/unusual_loot_lists.txt");
+    TestFilesystem::RemoveFile("csgo_gc/gc_loot_lists.txt");
+    TestFilesystem::RemoveFile("csgo/scripts/items/items_game.txt");
+    TestFilesystem::RemoveDirectory("csgo/scripts/items");
+    TestFilesystem::RemoveDirectory("csgo/scripts");
+    TestFilesystem::RemoveDirectory("csgo");
+    TestFilesystem::RemoveDirectory("csgo_gc");
+}
+
+static bool WriteCustomizationFixtures()
+{
+    if (!TestFilesystem::MakeDirectory("csgo")
+        || !TestFilesystem::MakeDirectory("csgo/scripts")
+        || !TestFilesystem::MakeDirectory("csgo/scripts/items")
+        || !TestFilesystem::MakeDirectory("csgo_gc"))
+    {
+        return false;
+    }
+
+    KeyValue schema{ "root" };
+    KeyValue &itemsGame = schema.AddSubkey("items_game");
+
+    KeyValue &attributes = itemsGame.AddSubkey("attributes");
+    attributes.AddSubkey(std::to_string(ItemSchema::AttributeStickerId0))
+        .AddNumber("stored_as_integer", 1);
+    attributes.AddSubkey(std::to_string(ItemSchema::AttributeStickerWear0))
+        .AddString("attribute_type", "float");
+    attributes.AddSubkey(std::to_string(ItemSchema::AttributeStickerScale0))
+        .AddString("attribute_type", "float");
+    attributes.AddSubkey(std::to_string(ItemSchema::AttributeStickerRotation0))
+        .AddString("attribute_type", "float");
+
+    KeyValue &items = itemsGame.AddSubkey("items");
+    KeyValue &weapon = items.AddSubkey("7");
+    weapon.AddString("name", "weapon_ak47");
+    weapon.AddString("item_rarity", "uncommon");
+    KeyValue &weaponCapabilities = weapon.AddSubkey("capabilities");
+    weaponCapabilities.AddNumber("can_sticker", 1);
+    weaponCapabilities.AddNumber("nameable", 1);
+
+    items.AddSubkey(std::to_string(ItemSchema::ItemSticker)).AddString("name", "sticker");
+    items.AddSubkey("999").AddString("name", "name_tag");
+
+    KeyValue inventory{ "inventory" };
+    inventory.AddNumber("format_version", 1);
+    KeyValue &inventoryItems = inventory.AddSubkey("items");
+
+    auto addSticker = [&](const char *highItemId, uint32_t stickerKit)
+    {
+        KeyValue &item = inventoryItems.AddSubkey(highItemId);
+        item.AddNumber("def_index", ItemSchema::ItemSticker);
+        item.AddNumber("origin", ItemOriginTraded);
+        item.AddNumber("rarity", ItemSchema::RarityCommon);
+        item.AddSubkey("attributes")
+            .AddNumber(std::to_string(ItemSchema::AttributeStickerId0), stickerKit);
+    };
+    auto addNameTag = [&](const char *highItemId)
+    {
+        KeyValue &item = inventoryItems.AddSubkey(highItemId);
+        item.AddNumber("def_index", 999);
+        item.AddNumber("origin", ItemOriginTraded);
+        item.AddNumber("rarity", ItemSchema::RarityCommon);
+    };
+
+    addSticker("1", 101);
+    addSticker("2", 102);
+    addNameTag("3");
+    addNameTag("4");
+
+    KeyValue unusualLootLists{ "unusual_loot_lists" };
+    KeyValue gcLootLists{ "gc_loot_lists" };
+    return schema.WriteToFile("csgo/scripts/items/items_game.txt")
+        && inventory.WriteToFile("csgo_gc/inventory.txt")
+        && unusualLootLists.WriteToFile("csgo_gc/unusual_loot_lists.txt")
+        && gcLootLists.WriteToFile("csgo_gc/gc_loot_lists.txt");
+}
+
+static bool ParseItemObject(const CMsgSOSingleObject &object, CSOEconItem &item)
+{
+    return object.type_id() == SOTypeItem && item.ParseFromString(object.object_data());
+}
+
+static bool HasAttribute(const CSOEconItem &item, uint32_t defIndex)
+{
+    for (const CSOEconItemAttribute &attribute : item.attribute())
+    {
+        if (attribute.def_index() == defIndex)
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+static bool ScrapeStickerUntilRemoved(Inventory &inventory, uint64_t itemId,
+    bool expectDestroyed, std::string_view expectedName)
+{
+    CMsgApplySticker scrape;
+    scrape.set_item_item_id(itemId);
+    scrape.set_sticker_slot(0);
+
+    for (int i = 0; i < 12; i++)
+    {
+        CMsgSOSingleObject update;
+        CMsgSOSingleObject destroy;
+        CMsgGCItemCustomizationNotification notification;
+        if (!inventory.ScrapeSticker(scrape, update, destroy, notification))
+        {
+            return false;
+        }
+
+        const CSOEconItem *item = inventory.GetItem(itemId);
+        if (!item)
+        {
+            CSOEconItem destroyedItem;
+            return expectDestroyed
+                && !update.has_object_data()
+                && ParseItemObject(destroy, destroyedItem)
+                && destroyedItem.id() == itemId
+                && notification.item_id_size() == 1
+                && notification.item_id(0) == (ItemIdDefaultItemMask | 7);
+        }
+
+        if (!HasAttribute(*item, ItemSchema::AttributeStickerId0))
+        {
+            CSOEconItem updatedItem;
+            return !expectDestroyed
+                && ParseItemObject(update, updatedItem)
+                && !destroy.has_object_data()
+                && updatedItem.id() == itemId
+                && updatedItem.custom_name() == expectedName
+                && updatedItem.attribute_size() == 0
+                && notification.item_id_size() == 1
+                && notification.item_id(0) == itemId;
+        }
+    }
+
+    return false;
+}
+
+static bool BaseItemCustomizationsPreserveRemainingState()
+{
+    constexpr uint64_t SteamId = 76561197960265729ull;
+    auto itemId = [&](uint32_t highItemId)
+    {
+        return (static_cast<uint64_t>(highItemId) << 32) | (SteamId & UINT32_MAX);
+    };
+
+    RemoveCustomizationFixtures();
+    if (!WriteCustomizationFixtures())
+    {
+        RemoveCustomizationFixtures();
+        return false;
+    }
+
+    bool valid = true;
+    {
+        Inventory inventory{ SteamId };
+
+        CMsgApplySticker applyToBase;
+        applyToBase.set_sticker_item_id(itemId(1));
+        applyToBase.set_sticker_slot(0);
+        applyToBase.set_baseitem_defidx(7);
+        CMsgSOSingleObject stickerCreate;
+        CMsgSOSingleObject stickerDestroy;
+        CMsgGCItemCustomizationNotification stickerNotification;
+        valid &= inventory.ApplySticker(applyToBase, stickerCreate, stickerDestroy,
+            stickerNotification);
+
+        CSOEconItem stickerClone;
+        valid &= ParseItemObject(stickerCreate, stickerClone)
+            && stickerClone.origin() == ItemOriginBaseItem
+            && stickerClone.rarity() == ItemSchema::RarityDefault;
+
+        CMsgSOSingleObject nameUpdate;
+        CMsgSOSingleObject nameTagDestroy;
+        CMsgGCItemCustomizationNotification nameNotification;
+        valid &= inventory.NameItem(itemId(3), stickerClone.id(), "named",
+            nameUpdate, nameTagDestroy, nameNotification);
+        valid &= ScrapeStickerUntilRemoved(inventory, stickerClone.id(), false, "named");
+
+        CMsgSOSingleObject removeNameUpdate;
+        CMsgSOSingleObject removeNameDestroy;
+        CMsgGCItemCustomizationNotification removeNameNotification;
+        valid &= inventory.RemoveItemName(stickerClone.id(), removeNameUpdate,
+            removeNameDestroy, removeNameNotification);
+        CSOEconItem destroyedStickerClone;
+        valid &= !inventory.GetItem(stickerClone.id())
+            && !removeNameUpdate.has_object_data()
+            && ParseItemObject(removeNameDestroy, destroyedStickerClone)
+            && destroyedStickerClone.id() == stickerClone.id();
+
+        CMsgSOSingleObject nameCreate;
+        CMsgSOSingleObject secondNameTagDestroy;
+        CMsgGCItemCustomizationNotification secondNameNotification;
+        valid &= inventory.NameBaseItem(itemId(4), 7, "named", nameCreate,
+            secondNameTagDestroy, secondNameNotification);
+
+        CSOEconItem nameClone;
+        valid &= ParseItemObject(nameCreate, nameClone)
+            && nameClone.origin() == ItemOriginBaseItem
+            && nameClone.rarity() == ItemSchema::RarityDefault;
+
+        CMsgApplySticker applyToNamedClone;
+        applyToNamedClone.set_sticker_item_id(itemId(2));
+        applyToNamedClone.set_sticker_slot(0);
+        applyToNamedClone.set_item_item_id(nameClone.id());
+        CMsgSOSingleObject secondStickerUpdate;
+        CMsgSOSingleObject secondStickerDestroy;
+        CMsgGCItemCustomizationNotification secondStickerNotification;
+        valid &= inventory.ApplySticker(applyToNamedClone, secondStickerUpdate,
+            secondStickerDestroy, secondStickerNotification);
+
+        CMsgSOSingleObject secondRemoveNameUpdate;
+        CMsgSOSingleObject secondRemoveNameDestroy;
+        CMsgGCItemCustomizationNotification secondRemoveNameNotification;
+        valid &= inventory.RemoveItemName(nameClone.id(), secondRemoveNameUpdate,
+            secondRemoveNameDestroy, secondRemoveNameNotification);
+        const CSOEconItem *unnamedClone = inventory.GetItem(nameClone.id());
+        CSOEconItem updatedUnnamedClone;
+        valid &= unnamedClone
+            && unnamedClone->custom_name().empty()
+            && HasAttribute(*unnamedClone, ItemSchema::AttributeStickerId0)
+            && ParseItemObject(secondRemoveNameUpdate, updatedUnnamedClone)
+            && !secondRemoveNameDestroy.has_object_data();
+
+        valid &= ScrapeStickerUntilRemoved(inventory, nameClone.id(), true, {});
+    }
+
+    RemoveCustomizationFixtures();
+    return valid;
+}
+
 static bool WriteStoreFixtures()
 {
     if (!TestFilesystem::MakeDirectory("csgo")
@@ -798,6 +1034,8 @@ int main()
         { "LoadoutStateTransitionsPreserveClassesAndSwapSlots",
             LoadoutStateTransitionsPreserveClassesAndSwapSlots },
         { "SOCacheVersionNegotiationAndRefresh", SOCacheVersionNegotiationAndRefresh },
+        { "BaseItemCustomizationsPreserveRemainingState",
+            BaseItemCustomizationsPreserveRemainingState },
         { "StorePurchasesFinalizeTransactionally", StorePurchasesFinalizeTransactionally },
     };
 

--- a/csgo_gc/gc_message_tests.cpp
+++ b/csgo_gc/gc_message_tests.cpp
@@ -729,6 +729,7 @@ static bool ScrapeStickerUntilRemoved(Inventory &inventory, uint64_t itemId,
                 && !update.has_object_data()
                 && ParseItemObject(destroy, destroyedItem)
                 && destroyedItem.id() == itemId
+                && notification.request() == k_EGCItemCustomizationNotification_RemoveSticker
                 && notification.item_id_size() == 1
                 && notification.item_id(0) == (ItemIdDefaultItemMask | 7);
         }
@@ -742,6 +743,7 @@ static bool ScrapeStickerUntilRemoved(Inventory &inventory, uint64_t itemId,
                 && updatedItem.id() == itemId
                 && updatedItem.custom_name() == expectedName
                 && updatedItem.attribute_size() == 0
+                && notification.request() == k_EGCItemCustomizationNotification_RemoveSticker
                 && notification.item_id_size() == 1
                 && notification.item_id(0) == itemId;
         }

--- a/csgo_gc/inventory.cpp
+++ b/csgo_gc/inventory.cpp
@@ -96,6 +96,16 @@ uint32_t StickerRotationAttribute(size_t slot)
     return ItemSchema::AttributeStickerRotation0 + static_cast<uint32_t>(slot) * 4;
 }
 
+static bool IsBaseItemClone(const CSOEconItem &item)
+{
+    return item.origin() == ItemOriginBaseItem;
+}
+
+static bool IsUncustomizedBaseItemClone(const CSOEconItem &item)
+{
+    return IsBaseItemClone(item) && item.custom_name().empty() && item.attribute_size() == 0;
+}
+
 Inventory::Inventory(uint64_t steamId)
     : m_steamId{ steamId }
     , m_version{ InitialInventoryVersion() }
@@ -1109,6 +1119,7 @@ bool Inventory::ApplySticker(const CMsgApplySticker &message,
     if (message.baseitem_defidx())
     {
         item = &CreateItem(message.baseitem_defidx(), ItemOriginBaseItem, UnacknowledgedInvalid);
+        item->set_rarity(ItemSchema::RarityDefault);
     }
 
     assert(item);
@@ -1166,15 +1177,17 @@ bool Inventory::ApplySticker(const CMsgApplySticker &message,
 
 static void RemoveStickerAttributes(CSOEconItem &item, uint32_t slot)
 {
-    // mikkotodo lookup table instead of this crap...
-    // mikkotodo rest of attribs???
-    uint32_t attributeStickerId = ItemSchema::AttributeStickerId0 + (slot * 4);
-    uint32_t attributeStickerWear = ItemSchema::AttributeStickerWear0 + (slot * 4);
+    const uint32_t attributeStickerId = StickerIdAttribute(slot);
+    const uint32_t attributeStickerWear = StickerWearAttribute(slot);
+    const uint32_t attributeStickerScale = StickerScaleAttribute(slot);
+    const uint32_t attributeStickerRotation = StickerRotationAttribute(slot);
 
     for (auto attrib = item.mutable_attribute()->begin(); attrib != item.mutable_attribute()->end();)
     {
         if (attrib->def_index() == attributeStickerId
-            || attrib->def_index() == attributeStickerWear)
+            || attrib->def_index() == attributeStickerWear
+            || attrib->def_index() == attributeStickerScale
+            || attrib->def_index() == attributeStickerRotation)
         {
             attrib = item.mutable_attribute()->erase(attrib);
         }
@@ -1233,13 +1246,15 @@ bool Inventory::ScrapeSticker(const CMsgApplySticker &message,
             request = k_EGCItemCustomizationNotification_RemovePatch;
         }
 
-        if (item.rarity() == ItemSchema::RarityDefault)
+        RemoveStickerAttributes(item, message.sticker_slot());
+
+        if (IsUncustomizedBaseItemClone(item))
         {
             // sticker removal notification with a fake item id
             notification.add_item_id(item.def_index() | ItemIdDefaultItemMask);
             notification.set_request(request);
 
-            // this was a default weapon clone with a sticker so destroy the entire item
+            // this was a default weapon clone whose last customization was removed
             DestroyItem(it, destroy);
         }
         else
@@ -1247,9 +1262,6 @@ bool Inventory::ScrapeSticker(const CMsgApplySticker &message,
             // sticker removal notification
             notification.add_item_id(item.id());
             notification.set_request(request);
-
-            // remove the sticker
-            RemoveStickerAttributes(item, message.sticker_slot());
 
             ToSingleObject(update, item);
         }
@@ -1503,6 +1515,7 @@ bool Inventory::NameBaseItem(uint64_t nameTagId,
     }
 
     CSOEconItem &item = CreateItem(defIndex, ItemOriginBaseItem, UnacknowledgedInvalid);
+    item.set_rarity(ItemSchema::RarityDefault);
 
     item.mutable_custom_name()->assign(name);
 
@@ -1531,7 +1544,9 @@ bool Inventory::RemoveItemName(uint64_t itemId,
         return false;
     }
 
-    if (it->second.rarity() == ItemSchema::RarityDefault)
+    it->second.mutable_custom_name()->clear();
+
+    if (IsUncustomizedBaseItemClone(it->second))
     {
         notification.add_item_id(it->second.def_index() | ItemIdDefaultItemMask);
         notification.set_request(k_EGCItemCustomizationNotification_RemoveItemName);
@@ -1540,8 +1555,6 @@ bool Inventory::RemoveItemName(uint64_t itemId,
     }
     else
     {
-        it->second.mutable_custom_name()->clear();
-
         notification.add_item_id(it->second.id());
         notification.set_request(k_EGCItemCustomizationNotification_RemoveItemName);
 

--- a/csgo_gc/item_schema.cpp
+++ b/csgo_gc/item_schema.cpp
@@ -79,12 +79,12 @@ ItemInfo::ItemInfo(uint32_t defIndex)
     // RecursiveParseItem parses the rest
 }
 
-PaintKitInfo::PaintKitInfo(const KeyValue &key)
+PaintKitInfo::PaintKitInfo(const KeyValue &key, float defaultMinFloat, float defaultMaxFloat)
     : m_defIndex{ FromString<uint32_t>(key.Name()) }
     , m_rarity{ ItemSchema::RarityCommon } // rarity is not set here, done in ParsePaintKitRarities
 {
-    m_minFloat = key.GetNumber<float>("wear_remap_min", 0.0f);
-    m_maxFloat = key.GetNumber<float>("wear_remap_max", 1.0f);
+    m_minFloat = key.GetNumber<float>("wear_remap_min", defaultMinFloat);
+    m_maxFloat = key.GetNumber<float>("wear_remap_max", defaultMaxFloat);
 }
 
 StickerKitInfo::StickerKitInfo(const KeyValue &key)
@@ -953,13 +953,21 @@ void ItemSchema::ParsePaintKits(const KeyValue *paintKitsKey)
 {
     m_paintKitInfo.reserve(paintKitsKey->SubkeyCount());
 
+    float defaultMinFloat = 0.0f;
+    float defaultMaxFloat = 1.0f;
+    if (const KeyValue *defaultPaintKitKey = paintKitsKey->GetSubkey("0"))
+    {
+        defaultMinFloat = defaultPaintKitKey->GetNumber<float>("wear_remap_min", defaultMinFloat);
+        defaultMaxFloat = defaultPaintKitKey->GetNumber<float>("wear_remap_max", defaultMaxFloat);
+    }
+
     for (const KeyValue &paintKitKey : *paintKitsKey)
     {
         std::string_view name = paintKitKey.GetString("name");
 
         m_paintKitInfo.emplace(std::piecewise_construct,
             std::forward_as_tuple(name),
-            std::forward_as_tuple(paintKitKey));
+            std::forward_as_tuple(paintKitKey, defaultMinFloat, defaultMaxFloat));
     }
 }
 

--- a/csgo_gc/item_schema.h
+++ b/csgo_gc/item_schema.h
@@ -59,7 +59,7 @@ public:
 class PaintKitInfo
 {
 public:
-    explicit PaintKitInfo(const KeyValue &key);
+    PaintKitInfo(const KeyValue &key, float defaultMinFloat, float defaultMaxFloat);
 
     uint32_t m_defIndex;
     uint32_t m_rarity;

--- a/csgo_gc/item_schema_tests.cpp
+++ b/csgo_gc/item_schema_tests.cpp
@@ -82,6 +82,40 @@ public:
             && fiveSlotItem->m_stickerSlotCount == 5;
     }
 
+    bool ParsePaintKitWearRanges()
+    {
+        KeyValue paintKits{ "paint_kits" };
+
+        KeyValue &defaultPaintKit = paintKits.AddSubkey("0");
+        defaultPaintKit.AddString("name", "default");
+        defaultPaintKit.AddNumber("wear_remap_min", 0.06f);
+        defaultPaintKit.AddNumber("wear_remap_max", 0.8f);
+
+        paintKits.AddSubkey("1").AddString("name", "inherited");
+
+        KeyValue &overriddenPaintKit = paintKits.AddSubkey("2");
+        overriddenPaintKit.AddString("name", "overridden");
+        overriddenPaintKit.AddNumber("wear_remap_min", 0.2f);
+        overriddenPaintKit.AddNumber("wear_remap_max", 0.4f);
+
+        KeyValue &partiallyOverriddenPaintKit = paintKits.AddSubkey("3");
+        partiallyOverriddenPaintKit.AddString("name", "partially_overridden");
+        partiallyOverriddenPaintKit.AddNumber("wear_remap_max", 0.5f);
+
+        schema.ParsePaintKits(&paintKits);
+
+        const PaintKitInfo *inherited = schema.PaintKitInfoByDefIndex(1);
+        const PaintKitInfo *overridden = schema.PaintKitInfoByDefIndex(2);
+        const PaintKitInfo *partiallyOverridden = schema.PaintKitInfoByDefIndex(3);
+        return inherited && overridden && partiallyOverridden
+            && inherited->m_minFloat == 0.06f
+            && inherited->m_maxFloat == 0.8f
+            && overridden->m_minFloat == 0.2f
+            && overridden->m_maxFloat == 0.4f
+            && partiallyOverridden->m_minFloat == 0.06f
+            && partiallyOverridden->m_maxFloat == 0.5f;
+    }
+
     ItemSchema schema;
 };
 
@@ -119,6 +153,12 @@ static bool StickerSlotCountsFollowPrefabData()
     return fixture.ParseStickerSlotCounts();
 }
 
+static bool PaintKitWearRangesInheritDefaults()
+{
+    ItemSchemaTestFixture fixture;
+    return fixture.ParsePaintKitWearRanges();
+}
+
 int main()
 {
     if (!TournamentStickerCapsuleIsNotSouvenir())
@@ -134,6 +174,11 @@ int main()
     if (!StickerSlotCountsFollowPrefabData())
     {
         return 3;
+    }
+
+    if (!PaintKitWearRangesInheritDefaults())
+    {
+        return 4;
     }
 
     return 0;


### PR DESCRIPTION
Closes #59 and #60. Paint kits now inherit omitted wear ranges from the default paint kit. Customized default-item clones now use default rarity and are removed only after their final customization is cleared, preserving remaining names, stickers, and other attributes. Verified with the Windows x86 build and the full CTest suite (6/6).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved customization handling for item names and stickers, including applying, scraping, preserving, and removing customizations.
  * Paint kits now correctly inherit default wear ranges when specific values are not provided.

* **Bug Fixes**
  * Fully removing customizations now correctly cleans up temporary item copies and related sticker data.

* **Tests**
  * Added coverage for item customization workflows and paint-kit wear-range inheritance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->