### PR TITLE
Enable offline store purchases for market crates

### DIFF
--- a/csgo_gc/gc_client.cpp
+++ b/csgo_gc/gc_client.cpp
@@ -1182,7 +1182,13 @@ static void EnableOfflineStoreCrates(KeyValue &priceSheet, const ItemSchema &ite
             continue;
         }
 
-        const ItemInfo *item = itemSchema.ItemInfoByDefIndex(FromString<uint32_t>(bannerEntry.Name()));
+        uint32_t defIndex{};
+        if (!TryParseNumber(bannerEntry.Name(), defIndex))
+        {
+            continue;
+        }
+
+        const ItemInfo *item = itemSchema.ItemInfoByDefIndex(defIndex);
         if (!item || !IsStoreCrate(*item))
         {
             continue;

--- a/csgo_gc/gc_client.cpp
+++ b/csgo_gc/gc_client.cpp
@@ -1129,10 +1129,89 @@ constexpr uint32_t MakeAddress(uint32_t v1, uint32_t v2, uint32_t v3, uint32_t v
     return v4 | (v3 << 8) | (v2 << 16) | (v1 << 24);
 }
 
-constexpr uint32_t PriceSheetVersion = 1680057676;
+constexpr uint32_t PriceSheetVersion = 1680057677;
 constexpr int32_t StoreResultOK = 1;
 constexpr int32_t StoreResultInvalid = 2;
 constexpr uint32_t MaxStorePurchaseItems = 1024;
+
+static bool IsStoreCrate(const ItemInfo &item)
+{
+    return item.m_supplyCrateSeries || !item.m_lootListName.empty();
+}
+
+static void EnableOfflineStoreCrates(KeyValue &priceSheet, const ItemSchema &itemSchema)
+{
+    KeyValue *store = priceSheet.GetSubkey("store");
+    if (!store)
+    {
+        return;
+    }
+
+    KeyValue *bannerLayout = store->GetSubkey("store_banner_layout");
+    KeyValue *entries = store->GetSubkey("entries");
+    if (!bannerLayout || !entries)
+    {
+        return;
+    }
+
+    const KeyValue *templatePrices = nullptr;
+    for (const KeyValue &entry : *entries)
+    {
+        const KeyValue *prices = entry.GetSubkey("prices");
+        if (prices && prices->SubkeyCount())
+        {
+            templatePrices = prices;
+            break;
+        }
+    }
+
+    if (!templatePrices)
+    {
+        Platform::Print("Store price sheet has no price template for offline crates\n");
+        return;
+    }
+
+    // Adding entries can reallocate the entries vector, so preserve the price
+    // tree before iterating the banner layout.
+    KeyValue priceTemplate{ *templatePrices };
+    size_t enabledCount = 0;
+    for (KeyValue &bannerEntry : *bannerLayout)
+    {
+        if (!bannerEntry.GetNumber("market_link", false))
+        {
+            continue;
+        }
+
+        const ItemInfo *item = itemSchema.ItemInfoByDefIndex(FromString<uint32_t>(bannerEntry.Name()));
+        if (!item || !IsStoreCrate(*item))
+        {
+            continue;
+        }
+
+        bannerEntry.SetString("market_link", "0");
+
+        KeyValue *entry = entries->GetSubkey(item->m_name);
+        if (!entry)
+        {
+            entry = &entries->AddSubkey(item->m_name);
+            entry->AddString("item_link", item->m_name);
+            entry->AddString("category_tags", "Misc");
+        }
+
+        if (!entry->GetSubkey("prices"))
+        {
+            entry->AddSubkey("prices") = priceTemplate;
+        }
+
+        ++enabledCount;
+    }
+
+    if (enabledCount)
+    {
+        Platform::Print("Enabled %zu market crate%s for offline store purchase\n", enabledCount,
+            enabledCount == 1 ? "" : "s");
+    }
+}
 
 static void BuildCSWelcome(CMsgCStrike15Welcome &message)
 {
@@ -1537,6 +1616,8 @@ void ClientGC::StoreGetUserData(GCMessageRead &messageRead)
         SendMessageToGame(false, k_EMsgGCStoreGetUserDataResponse, response, messageRead.JobId());
         return;
     }
+
+    EnableOfflineStoreCrates(priceSheet, m_inventory.GetItemSchema());
 
     std::string binaryString;
     binaryString.reserve(1 << 17);

--- a/csgo_gc/gc_message_tests.cpp
+++ b/csgo_gc/gc_message_tests.cpp
@@ -1251,17 +1251,34 @@ static bool StorePurchasesFinalizeTransactionally()
         constexpr std::string_view DisabledMarketLink{
             "market_link\0" "0\0", sizeof("market_link\0" "0\0") - 1
         };
+        constexpr std::string_view CrateEntryWithPrices{
+            "\0" "crate_test\0"
+            "\1" "item_link\0" "crate_test\0"
+            "\1" "category_tags\0" "Misc\0"
+            "\0" "prices\0"
+            "\1" "USD\0" "99\0"
+            "\1" "CNY\0" "700\0"
+            "\x0b" "\x0b",
+            sizeof("\0" "crate_test\0"
+                "\1" "item_link\0" "crate_test\0"
+                "\1" "category_tags\0" "Misc\0"
+                "\0" "prices\0"
+                "\1" "USD\0" "99\0"
+                "\1" "CNY\0" "700\0"
+                "\x0b" "\x0b") - 1
+        };
         valid &= WaitForHostMessage(gc, k_EMsgGCStoreGetUserDataResponse, event)
             && ParseHostProtobuf(event, storeDataResponse)
             && storeDataResponse.result() == 1
             && storeDataResponse.price_sheet_version() == priceSheetVersion
             && !storeDataResponse.price_sheet().empty()
             && storeDataResponse.price_sheet().find("crate_test") != std::string::npos
-            && storeDataResponse.price_sheet().find(DisabledMarketLink) != std::string::npos;
+            && storeDataResponse.price_sheet().find(DisabledMarketLink) != std::string::npos
+            && storeDataResponse.price_sheet().find(CrateEntryWithPrices) != std::string::npos;
 
         CMsgGCStorePurchaseInit purchaseInit;
         CGCStorePurchaseInit_LineItem *lineItem = purchaseInit.add_line_items();
-        lineItem->set_item_def_id(7);
+        lineItem->set_item_def_id(8);
         lineItem->set_quantity(2);
         SendGCProtobuf(gc, k_EMsgGCStorePurchaseInit, purchaseInit);
         event = {};
@@ -1318,7 +1335,7 @@ static bool StorePurchasesFinalizeTransactionally()
             const CMsgSOCacheSubscribed &subscription = welcome.outofdate_subscribed_caches(0);
             valid &= subscription.version() != initialCacheVersion;
 
-            std::unordered_set<uint64_t> snapshotItemIds;
+            std::unordered_map<uint64_t, uint32_t> snapshotItems;
             for (const CMsgSOCacheSubscribed_SubscribedType &type : subscription.objects())
             {
                 if (type.type_id() != SOTypeItem)
@@ -1330,15 +1347,16 @@ static bool StorePurchasesFinalizeTransactionally()
                     CSOEconItem item;
                     if (item.ParseFromString(objectData))
                     {
-                        snapshotItemIds.insert(item.id());
+                        snapshotItems.emplace(item.id(), item.def_index());
                     }
                 }
             }
 
-            valid &= snapshotItemIds.size() == 2;
+            valid &= snapshotItems.size() == 2;
             for (uint64_t itemId : finalizeResponse.item_ids())
             {
-                valid &= snapshotItemIds.contains(itemId);
+                auto item = snapshotItems.find(itemId);
+                valid &= item != snapshotItems.end() && item->second == 8;
             }
         }
 

--- a/csgo_gc/gc_message_tests.cpp
+++ b/csgo_gc/gc_message_tests.cpp
@@ -1179,6 +1179,9 @@ static bool WriteStoreFixtures()
     KeyValue &itemsGame = schema.AddSubkey("items_game");
     KeyValue &items = itemsGame.AddSubkey("items");
     items.AddSubkey("7").AddString("name", "weapon_ak47");
+    KeyValue &crate = items.AddSubkey("8");
+    crate.AddString("name", "crate_test");
+    crate.AddString("loot_list_name", "crate_test");
 
     KeyValue unusualLootLists{ "unusual_loot_lists" };
     unusualLootLists.AddSubkey("empty");
@@ -1186,6 +1189,14 @@ static bool WriteStoreFixtures()
     KeyValue priceSheet{ "price_sheet" };
     KeyValue &store = priceSheet.AddSubkey("store");
     store.AddNumber("featured_item_index", 7);
+    KeyValue &bannerLayout = store.AddSubkey("store_banner_layout");
+    bannerLayout.AddSubkey("8").AddNumber("market_link", 1);
+    KeyValue &entries = store.AddSubkey("entries");
+    KeyValue &priceTemplate = entries.AddSubkey("offline_price_template");
+    priceTemplate.AddString("item_link", "weapon_ak47");
+    KeyValue &prices = priceTemplate.AddSubkey("prices");
+    prices.AddNumber("USD", 99);
+    prices.AddNumber("CNY", 700);
 
     return schema.WriteToFile("csgo/scripts/items/items_game.txt")
         && unusualLootLists.WriteToFile("csgo_gc/unusual_loot_lists.txt")
@@ -1237,11 +1248,16 @@ static bool StorePurchasesFinalizeTransactionally()
         SendGCProtobuf(gc, k_EMsgGCStoreGetUserData, storeData);
         event = {};
         CMsgStoreGetUserDataResponse storeDataResponse;
+        constexpr std::string_view DisabledMarketLink{
+            "market_link\0" "0\0", sizeof("market_link\0" "0\0") - 1
+        };
         valid &= WaitForHostMessage(gc, k_EMsgGCStoreGetUserDataResponse, event)
             && ParseHostProtobuf(event, storeDataResponse)
             && storeDataResponse.result() == 1
             && storeDataResponse.price_sheet_version() == priceSheetVersion
-            && !storeDataResponse.price_sheet().empty();
+            && !storeDataResponse.price_sheet().empty()
+            && storeDataResponse.price_sheet().find("crate_test") != std::string::npos
+            && storeDataResponse.price_sheet().find(DisabledMarketLink) != std::string::npos;
 
         CMsgGCStorePurchaseInit purchaseInit;
         CGCStorePurchaseInit_LineItem *lineItem = purchaseInit.add_line_items();

--- a/csgo_gc/keyvalue.cpp
+++ b/csgo_gc/keyvalue.cpp
@@ -453,6 +453,19 @@ void KeyValue::WriteToFile(FILE *f, int indent)
     }
 }
 
+KeyValue *KeyValue::GetSubkey(std::string_view name)
+{
+    for (KeyValue &subkey : m_subkeys)
+    {
+        if (subkey.m_name == name)
+        {
+            return &subkey;
+        }
+    }
+
+    return nullptr;
+}
+
 const KeyValue *KeyValue::GetSubkey(std::string_view name) const
 {
     for (const KeyValue &subkey : m_subkeys)
@@ -486,4 +499,15 @@ void KeyValue::AddString(std::string_view name, std::string_view value)
 {
     KeyValue &subkey = AddSubkey(name);
     subkey.m_string = value;
+}
+
+void KeyValue::SetString(std::string_view name, std::string_view value)
+{
+    KeyValue *subkey = GetSubkey(name);
+    if (!subkey)
+    {
+        subkey = &AddSubkey(name);
+    }
+
+    subkey->m_string = value;
 }

--- a/csgo_gc/keyvalue.h
+++ b/csgo_gc/keyvalue.h
@@ -58,16 +58,20 @@ public:
     std::string_view String() const { return m_string; }
 
     // range based for loops for subkeys
+    KeyValue *begin() { return m_subkeys.data(); }
+    KeyValue *end() { return m_subkeys.data() + m_subkeys.size(); }
     const KeyValue *begin() const { return m_subkeys.data(); }
     const KeyValue *end() const { return m_subkeys.data() + m_subkeys.size(); }
 
     // parsing helpers
+    KeyValue *GetSubkey(std::string_view name);
     const KeyValue *GetSubkey(std::string_view name) const;
     std::string_view GetString(std::string_view name, std::string_view fallback = {}) const;
 
     // writing helpers
     KeyValue &AddSubkey(std::string_view name);
     void AddString(std::string_view name, std::string_view value);
+    void SetString(std::string_view name, std::string_view value);
 
     // template helpers for parsing/writing integers/floats
 


### PR DESCRIPTION
Resolve #65 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled eligible offline store crates to appear as local store entries.
  * Added offline pricing support using available price templates.
  * Updated store price-sheet versioning.

* **Bug Fixes**
  * Market links are disabled when items are converted to offline store entries.

* **Tests**
  * Expanded store coverage to verify offline crate listings, pricing, and disabled market links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->