### PR TITLE
Support service medal prestige requests

### DIFF
--- a/csgo_gc/CMakeLists.txt
+++ b/csgo_gc/CMakeLists.txt
@@ -102,6 +102,7 @@ endif()
 
 if (BUILD_TESTING)
     add_executable(gc_message_tests
+        appid.cpp
         case_opening.cpp
         config.cpp
         gc_client.cpp

--- a/csgo_gc/appid.cpp
+++ b/csgo_gc/appid.cpp
@@ -6,6 +6,8 @@
 namespace AppId
 {
 
+constexpr uint32_t DefaultBuildYear = 2023;
+
 static size_t ifind(std::string_view haystack, std::string_view needle)
 {
     // not needed here but keep it
@@ -57,6 +59,55 @@ static SteamInfResult ReplaceSteamInfAppId(std::string &buf, uint32_t appId)
     return SteamInfResult::Ok;
 }
 
+static uint32_t ParseSteamInfBuildYear(std::string_view buf)
+{
+    size_t keyPos = ifind(buf, "VersionDate=");
+    if (keyPos == std::string::npos)
+    {
+        return 0;
+    }
+
+    size_t valuePos = keyPos + sizeof("VersionDate=") - 1;
+    size_t valueEnd = buf.find_first_of("\r\n", valuePos);
+    if (valueEnd == std::string_view::npos)
+    {
+        valueEnd = buf.size();
+    }
+
+    std::string_view value = buf.substr(valuePos, valueEnd - valuePos);
+    for (size_t i = 0; i + 4 <= value.size(); i++)
+    {
+        bool fourDigits = true;
+        for (size_t digit = 0; digit < 4; digit++)
+        {
+            fourDigits &= value[i + digit] >= '0' && value[i + digit] <= '9';
+        }
+
+        if (!fourDigits)
+        {
+            continue;
+        }
+
+        const bool startsAtBoundary = i == 0 || value[i - 1] < '0' || value[i - 1] > '9';
+        const bool endsAtBoundary = i + 4 == value.size()
+            || value[i + 4] < '0' || value[i + 4] > '9';
+        if (!startsAtBoundary || !endsAtBoundary)
+        {
+            continue;
+        }
+
+        uint32_t year = 0;
+        auto [ptr, ec] = std::from_chars(value.data() + i, value.data() + i + 4, year);
+        if (ec == std::errc{} && ptr == value.data() + i + 4
+            && year >= 2012 && year <= DefaultBuildYear)
+        {
+            return year;
+        }
+    }
+
+    return 0;
+}
+
 static void WriteFile(const char *path, const std::string &buffer)
 {
     FILE *f = fopen(path, "wb");
@@ -98,6 +149,19 @@ void Init()
 uint32_t GetOverride()
 {
     return GetConfig().AppIdOverride();
+}
+
+uint32_t GetBuildYear()
+{
+    uint32_t buildYear = ParseSteamInfBuildYear(LoadFile("csgo/steam.inf"));
+    if (!buildYear)
+    {
+        Platform::Print("Could not read the client build year from steam.inf; using %u\n",
+            DefaultBuildYear);
+        return DefaultBuildYear;
+    }
+
+    return buildYear;
 }
 
 bool IsOriginal()

--- a/csgo_gc/appid.h
+++ b/csgo_gc/appid.h
@@ -10,6 +10,9 @@ void Init();
 // returns the appid provided in appid_override.txt, fallback to 730
 uint32_t GetOverride();
 
+// returns the build year reported by csgo/steam.inf, fallback to 2023
+uint32_t GetBuildYear();
+
 // if false, the game is running on a "non-valve" app id and we
 // should patch serverbrowser and spoof steam stats callbacks
 bool IsOriginal();

--- a/csgo_gc/gc_client.cpp
+++ b/csgo_gc/gc_client.cpp
@@ -1655,10 +1655,25 @@ void ClientGC::ApplySticker(GCMessageRead &messageRead)
 
 void ClientGC::RequestPrestigeCoin(GCMessageRead &messageRead)
 {
+    auto sendRejectedResponse = [&]()
+    {
+        if (messageRead.JobId() == JobIdInvalid)
+        {
+            return;
+        }
+
+        CMsgGCCStrike15_v2_Client2GCRequestPrestigeCoin response;
+        SendMessageToGame(false,
+            k_EMsgGCCStrike15_v2_Client2GCRequestPrestigeCoin,
+            response,
+            messageRead.JobId());
+    };
+
     CMsgGCCStrike15_v2_Client2GCRequestPrestigeCoin request;
     if (!messageRead.ReadProtobuf(request))
     {
         Platform::Print("Parsing CMsgGCCStrike15_v2_Client2GCRequestPrestigeCoin failed, ignoring\n");
+        sendRejectedResponse();
         return;
     }
 
@@ -1666,6 +1681,7 @@ void ClientGC::RequestPrestigeCoin(GCMessageRead &messageRead)
     {
         Platform::Print("RequestPrestigeCoin: player level %d is below %d\n",
             m_inventory.PlayerLevel(), CSGOMaxPlayerLevel);
+        sendRejectedResponse();
         return;
     }
 
@@ -1675,6 +1691,7 @@ void ClientGC::RequestPrestigeCoin(GCMessageRead &messageRead)
     {
         Platform::Print("RequestPrestigeCoin: no service medal is available for build year %u\n",
             m_buildYear);
+        sendRejectedResponse();
         return;
     }
 
@@ -1699,6 +1716,7 @@ void ClientGC::RequestPrestigeCoin(GCMessageRead &messageRead)
     {
         Platform::Print("RequestPrestigeCoin: rejected stale or invalid defindex %u for year %u\n",
             request.defindex(), m_buildYear);
+        sendRejectedResponse();
         return;
     }
 

--- a/csgo_gc/gc_client.cpp
+++ b/csgo_gc/gc_client.cpp
@@ -1,5 +1,6 @@
 #include "stdafx.h"
 #include "gc_client.h"
+#include "appid.h"
 #include "graffiti.h"
 #include "item_utils.h"
 #include "keyvalue.h"
@@ -305,6 +306,7 @@ std::string UnknownParameter(std::string_view key)
 
 ClientGC::ClientGC(uint64_t steamId)
     : m_steamId{ steamId }
+    , m_buildYear{ AppId::GetBuildYear() }
     , m_inventory{ steamId }
 {
     // also called from ServerGC's constructor
@@ -943,7 +945,7 @@ std::string ClientGC::RconRefreshInventory(const RconRequest &request)
     }
 
     CMsgSOCacheSubscribed message;
-    m_inventory.BuildCacheSubscription(message, GetConfig().Level(), false);
+    m_inventory.BuildCacheSubscription(message, false);
     SendMessageToGame(false, k_ESOMsg_CacheSubscribed, message);
     return "OK refreshed";
 }
@@ -955,8 +957,7 @@ std::string ClientGC::RconSaveInventory(const RconRequest &request)
         return Usage("save_inventory");
     }
 
-    m_inventory.Save();
-    return "OK saved";
+    return m_inventory.Save() ? "OK saved" : "ERR save failed";
 }
 
 void ClientGC::HandleMessage(uint32_t type, const void *data, uint32_t size)
@@ -1006,6 +1007,10 @@ void ClientGC::HandleMessage(uint32_t type, const void *data, uint32_t size)
 
         case k_EMsgGCApplySticker:
             ApplySticker(messageRead);
+            break;
+
+        case k_EMsgGCCStrike15_v2_Client2GCRequestPrestigeCoin:
+            RequestPrestigeCoin(messageRead);
             break;
 
         case k_EMsgGCStoreGetUserData:
@@ -1109,7 +1114,7 @@ void ClientGC::HandleNetMessage(const void *data, uint32_t size)
 void ClientGC::HandleSOCacheRequest()
 {
     CMsgSOCacheSubscribed message;
-    m_inventory.BuildCacheSubscription(message, GetConfig().Level(), true);
+    m_inventory.BuildCacheSubscription(message, true);
 
     GCMessageWrite messageWrite{ k_ESOMsg_CacheSubscribed, message };
     PostToHost(HostEvent::NetMessage, 0, messageWrite.Data(), messageWrite.Size());
@@ -1299,8 +1304,8 @@ void ClientGC::BuildMatchmakingHello(CMsgGCCStrike15_v2_MatchmakingGC2ClientHell
     message.mutable_commendation()->set_cmd_friendly(GetConfig().CommendedFriendly());
     message.mutable_commendation()->set_cmd_teaching(GetConfig().CommendedTeaching());
     message.mutable_commendation()->set_cmd_leader(GetConfig().CommendedLeader());
-    message.set_player_level(GetConfig().Level());
-    message.set_player_cur_xp(GetConfig().Xp());
+    message.set_player_level(m_inventory.PlayerLevel());
+    message.set_player_cur_xp(m_inventory.PlayerXp());
 }
 
 void ClientGC::BuildClientWelcome(CMsgClientWelcome &message, const CMsgClientHello &hello,
@@ -1332,8 +1337,7 @@ void ClientGC::BuildClientWelcome(CMsgClientWelcome &message, const CMsgClientHe
     }
     else
     {
-        m_inventory.BuildCacheSubscription(*message.add_outofdate_subscribed_caches(),
-            GetConfig().Level(), false);
+        m_inventory.BuildCacheSubscription(*message.add_outofdate_subscribed_caches(), false);
     }
     message.mutable_location()->set_latitude(65.0133006f);
     message.mutable_location()->set_longitude(25.4646212f);
@@ -1417,7 +1421,7 @@ void ClientGC::SOCacheSubscriptionRefresh(GCMessageRead &messageRead)
     }
 
     CMsgSOCacheSubscribed subscription;
-    m_inventory.BuildCacheSubscription(subscription, GetConfig().Level(), false);
+    m_inventory.BuildCacheSubscription(subscription, false);
     SendMessageToGame(false, k_ESOMsg_CacheSubscribed, subscription);
 }
 
@@ -1647,6 +1651,72 @@ void ClientGC::ApplySticker(GCMessageRead &messageRead)
     {
         assert(false);
     }
+}
+
+void ClientGC::RequestPrestigeCoin(GCMessageRead &messageRead)
+{
+    CMsgGCCStrike15_v2_Client2GCRequestPrestigeCoin request;
+    if (!messageRead.ReadProtobuf(request))
+    {
+        Platform::Print("Parsing CMsgGCCStrike15_v2_Client2GCRequestPrestigeCoin failed, ignoring\n");
+        return;
+    }
+
+    if (m_inventory.PlayerLevel() < CSGOMaxPlayerLevel)
+    {
+        Platform::Print("RequestPrestigeCoin: player level %d is below %d\n",
+            m_inventory.PlayerLevel(), CSGOMaxPlayerLevel);
+        return;
+    }
+
+    std::optional<Inventory::PrestigeMedalPlan> plan
+        = m_inventory.GetPrestigeMedalPlan(m_buildYear);
+    if (!plan)
+    {
+        Platform::Print("RequestPrestigeCoin: no service medal is available for build year %u\n",
+            m_buildYear);
+        return;
+    }
+
+    if (!request.has_defindex() || !request.defindex())
+    {
+        CMsgGCCStrike15_v2_Client2GCRequestPrestigeCoin response;
+        response.set_defindex(plan->defIndex);
+        if (plan->upgradeId)
+        {
+            response.set_upgradeid(plan->upgradeId);
+        }
+
+        SendMessageToGame(false,
+            k_EMsgGCCStrike15_v2_Client2GCRequestPrestigeCoin,
+            response,
+            messageRead.JobId());
+        return;
+    }
+
+    Inventory::PrestigeMedalClaim claim;
+    if (!m_inventory.ClaimPrestigeMedal(m_buildYear, request.defindex(), claim))
+    {
+        Platform::Print("RequestPrestigeCoin: rejected stale or invalid defindex %u for year %u\n",
+            request.defindex(), m_buildYear);
+        return;
+    }
+
+    SendMessageToGame(true, claim.created ? k_ESOMsg_Create : k_ESOMsg_Update, claim.itemData);
+    SendMessageToGame(true, k_ESOMsg_Update, claim.personaData);
+
+    CMsgGCCStrike15_v2_MatchmakingGC2ClientHello matchmakingHello;
+    BuildMatchmakingHello(matchmakingHello);
+    SendMessageToGame(false, k_EMsgGCCStrike15_v2_MatchmakingGC2ClientHello, matchmakingHello);
+
+    CMsgGCCStrike15_v2_Client2GCRequestPrestigeCoin response;
+    response.set_defindex(request.defindex());
+    response.set_upgradeid(claim.itemId);
+    response.set_prestigetime(static_cast<uint32_t>(time(nullptr)));
+    SendMessageToGame(false,
+        k_EMsgGCCStrike15_v2_Client2GCRequestPrestigeCoin,
+        response,
+        messageRead.JobId());
 }
 
 void ClientGC::StoreGetUserData(GCMessageRead &messageRead)

--- a/csgo_gc/gc_client.h
+++ b/csgo_gc/gc_client.h
@@ -72,6 +72,7 @@ private:
     // Increment the equipped StatTrak music kit when the local player receives round MVP.
     void LocalPlayerRoundMVP();
     void ApplySticker(GCMessageRead &messageRead);
+    void RequestPrestigeCoin(GCMessageRead &messageRead);
     void StoreGetUserData(GCMessageRead &messageRead);
     void StorePurchaseInit(GCMessageRead &messageRead);
     void StorePurchaseFinalize(GCMessageRead &messageRead);
@@ -100,6 +101,7 @@ private:
     uint32_t AccountId() const { return m_steamId & 0xffffffff; }
 
     const uint64_t m_steamId;
+    const uint32_t m_buildYear;
 
     Inventory m_inventory;
     std::atomic<int32_t> m_localUserId{};

--- a/csgo_gc/gc_const_csgo.h
+++ b/csgo_gc/gc_const_csgo.h
@@ -14,6 +14,8 @@ constexpr uint64_t ItemIdDefaultItemMask = 0xfull << 60;
 // technically 5 but there are attributes for 6 stickers...
 constexpr int MaxStickers = 6;
 
+constexpr int CSGOMaxPlayerLevel = 40;
+
 enum RankType : uint32_t
 {
     RankTypeCompetitive = 6,
@@ -80,7 +82,8 @@ enum ItemOrigin
     ItemOriginPurchased = 2,
     ItemOriginTraded = 3,
     ItemOriginCrate = 8,
-    ItemOriginBaseItem = 22
+    ItemOriginBaseItem = 22,
+    ItemOriginLevelUpReward = 24
 };
 
 enum ElevatedState : uint32_t

--- a/csgo_gc/gc_message_tests.cpp
+++ b/csgo_gc/gc_message_tests.cpp
@@ -310,10 +310,73 @@ static bool ParseHostProtobuf(const EventData &event, T &message)
 }
 
 template<typename T>
+static bool ParseHostJobProtobuf(const EventData &event, uint64_t jobId, T &message)
+{
+    constexpr size_t HeaderPrefixSize = sizeof(uint32_t) + sizeof(uint32_t);
+    if (event.buffer.size() < HeaderPrefixSize)
+    {
+        return false;
+    }
+
+    const uint8_t *data = event.buffer.data();
+    uint32_t type = 0;
+    uint32_t headerSize = 0;
+    std::memcpy(&type, data, sizeof(type));
+    std::memcpy(&headerSize, data + sizeof(type), sizeof(headerSize));
+    if (!(type & ProtobufMask)
+        || !headerSize
+        || HeaderPrefixSize + headerSize > event.buffer.size())
+    {
+        return false;
+    }
+
+    CMsgProtoBufHeader header;
+    if (!header.ParseFromArray(data + HeaderPrefixSize, headerSize)
+        || header.job_id_target() != jobId)
+    {
+        return false;
+    }
+
+    const size_t bodyOffset = HeaderPrefixSize + headerSize;
+    return message.ParseFromArray(data + bodyOffset, event.buffer.size() - bodyOffset);
+}
+
+template<typename T>
 static void SendGCProtobuf(ClientGC &gc, uint32_t type, const T &message)
 {
     GCMessageWrite messageWrite{ type, message };
     gc.PostToGC(GCEvent::Message, messageWrite.TypeMasked(), messageWrite.Data(), messageWrite.Size());
+}
+
+static bool SendGCProtobufJobData(ClientGC &gc, uint32_t type,
+    const void *data, uint32_t size, uint64_t jobId)
+{
+    CMsgProtoBufHeader header;
+    header.set_job_id_source(jobId);
+
+    std::string headerData;
+    if (!header.SerializeToString(&headerData))
+    {
+        return false;
+    }
+
+    uint32_t maskedType = type | ProtobufMask;
+    GCMessageWrite messageWrite{ &maskedType, sizeof(maskedType) };
+    messageWrite.WriteUint32(static_cast<uint32_t>(headerData.size()));
+    messageWrite.WriteData(headerData.data(), static_cast<uint32_t>(headerData.size()));
+    messageWrite.WriteData(data, size);
+    gc.PostToGC(GCEvent::Message, messageWrite.TypeMasked(), messageWrite.Data(), messageWrite.Size());
+    return true;
+}
+
+template<typename T>
+static bool SendGCProtobufJob(ClientGC &gc, uint32_t type,
+    const T &message, uint64_t jobId)
+{
+    std::string messageData;
+    return message.SerializeToString(&messageData)
+        && SendGCProtobufJobData(gc, type, messageData.data(),
+            static_cast<uint32_t>(messageData.size()), jobId);
 }
 
 static bool IsMinimalPlayerProfile(
@@ -1590,6 +1653,22 @@ static bool RequestPrestigeInquiry(ClientGC &gc,
         && ParseHostProtobuf(event, response);
 }
 
+static bool RequestPrestigeJob(ClientGC &gc,
+    const CMsgGCCStrike15_v2_Client2GCRequestPrestigeCoin &request,
+    uint64_t jobId,
+    CMsgGCCStrike15_v2_Client2GCRequestPrestigeCoin &response)
+{
+    EventData event;
+    return SendGCProtobufJob(gc,
+        k_EMsgGCCStrike15_v2_Client2GCRequestPrestigeCoin,
+        request,
+        jobId)
+        && WaitForHostMessage(gc,
+            k_EMsgGCCStrike15_v2_Client2GCRequestPrestigeCoin,
+            event)
+        && ParseHostJobProtobuf(event, jobId, response);
+}
+
 static bool ValidatePrestigeClaimEvents(const std::vector<EventData> &events,
     bool expectedCreate, uint32_t expectedDefIndex, uint64_t expectedItemId,
     uint64_t &actualItemId)
@@ -1684,6 +1763,29 @@ static bool ServiceMedalsFollowBuildYearAndPersistPrestige()
             && response.defindex() == 1376
             && !response.has_upgradeid()
             && !response.has_prestigetime();
+
+        constexpr uint64_t InquiryJobId = 101;
+        CMsgGCCStrike15_v2_Client2GCRequestPrestigeCoin jobRequest;
+        response.Clear();
+        valid &= RequestPrestigeJob(gc, jobRequest, InquiryJobId, response)
+            && response.defindex() == 1376
+            && !response.has_upgradeid()
+            && !response.has_prestigetime();
+
+        constexpr uint64_t MalformedJobId = 102;
+        constexpr uint8_t MalformedRequest[]{ 0x80 };
+        EventData event;
+        response.Clear();
+        valid &= SendGCProtobufJobData(gc,
+            k_EMsgGCCStrike15_v2_Client2GCRequestPrestigeCoin,
+            MalformedRequest,
+            sizeof(MalformedRequest),
+            MalformedJobId)
+            && WaitForHostMessage(gc,
+                k_EMsgGCCStrike15_v2_Client2GCRequestPrestigeCoin,
+                event)
+            && ParseHostJobProtobuf(event, MalformedJobId, response)
+            && response.ByteSizeLong() == 0;
     }
 
     RemovePrestigeFixtures();
@@ -1704,6 +1806,11 @@ static bool ServiceMedalsFollowBuildYearAndPersistPrestige()
         valid &= HostMessageNotReceived(gc,
             k_EMsgGCCStrike15_v2_Client2GCRequestPrestigeCoin);
 
+        constexpr uint64_t StaleClaimJobId = 103;
+        CMsgGCCStrike15_v2_Client2GCRequestPrestigeCoin rejectedResponse;
+        valid &= RequestPrestigeJob(gc, staleClaim, StaleClaimJobId, rejectedResponse)
+            && rejectedResponse.ByteSizeLong() == 0;
+
         inquiry.Clear();
         valid &= RequestPrestigeInquiry(gc, inquiry) && inquiry.defindex() == 4873;
 
@@ -1721,6 +1828,14 @@ static bool ServiceMedalsFollowBuildYearAndPersistPrestige()
             ineligibleInquiry);
         valid &= HostMessageNotReceived(gc,
             k_EMsgGCCStrike15_v2_Client2GCRequestPrestigeCoin);
+
+        constexpr uint64_t IneligibleJobId = 104;
+        rejectedResponse.Clear();
+        valid &= RequestPrestigeJob(gc,
+            ineligibleInquiry,
+            IneligibleJobId,
+            rejectedResponse)
+            && rejectedResponse.ByteSizeLong() == 0;
     }
 
     valid &= medalItemId != 0
@@ -1779,6 +1894,14 @@ static bool ServiceMedalsFollowBuildYearAndPersistPrestige()
         SendGCProtobuf(gc, k_EMsgGCCStrike15_v2_Client2GCRequestPrestigeCoin, inquiry);
         valid &= HostMessageNotReceived(gc,
             k_EMsgGCCStrike15_v2_Client2GCRequestPrestigeCoin);
+
+        constexpr uint64_t MissingPlanJobId = 105;
+        CMsgGCCStrike15_v2_Client2GCRequestPrestigeCoin rejectedResponse;
+        valid &= RequestPrestigeJob(gc,
+            inquiry,
+            MissingPlanJobId,
+            rejectedResponse)
+            && rejectedResponse.ByteSizeLong() == 0;
     }
 
     RemovePrestigeFixtures();

--- a/csgo_gc/gc_message_tests.cpp
+++ b/csgo_gc/gc_message_tests.cpp
@@ -278,6 +278,30 @@ static bool WaitForHostMessagesUntil(ClientGC &gc, uint32_t terminalType,
     return false;
 }
 
+static bool HostMessageNotReceived(ClientGC &gc, uint32_t type,
+    std::chrono::milliseconds duration = std::chrono::milliseconds{ 100 })
+{
+    std::vector<EventData> events;
+    auto deadline = std::chrono::steady_clock::now() + duration;
+    while (std::chrono::steady_clock::now() < deadline)
+    {
+        gc.GetHostEvents(events);
+        for (const EventData &event : events)
+        {
+            if (event.type == static_cast<int>(HostEvent::Message)
+                && (event.id & ~ProtobufMask) == type)
+            {
+                return false;
+            }
+        }
+
+        events.clear();
+        std::this_thread::sleep_for(std::chrono::milliseconds{ 1 });
+    }
+
+    return true;
+}
+
 template<typename T>
 static bool ParseHostProtobuf(const EventData &event, T &message)
 {
@@ -455,7 +479,7 @@ static bool DefaultEquipMatches(const std::unordered_map<uint64_t, uint32_t> &de
 static std::unordered_map<uint64_t, uint32_t> SnapshotDefaultEquips(Inventory &inventory)
 {
     CMsgSOCacheSubscribed subscription;
-    inventory.BuildCacheSubscription(subscription, 1, false);
+    inventory.BuildCacheSubscription(subscription, false);
 
     std::unordered_map<uint64_t, uint32_t> defaultEquips;
     for (const CMsgSOCacheSubscribed_SubscribedType &type : subscription.objects())
@@ -1427,6 +1451,340 @@ static bool StorePurchasesFinalizeTransactionally()
     return valid;
 }
 
+static void RemovePrestigeFixtures()
+{
+    TestFilesystem::RemoveFile("csgo_gc/inventory.txt");
+    TestFilesystem::RemoveFile("csgo_gc/unusual_loot_lists.txt");
+    TestFilesystem::RemoveFile("csgo/scripts/items/items_game.txt");
+    TestFilesystem::RemoveFile("csgo/steam.inf");
+    TestFilesystem::RemoveDirectory("csgo/scripts/items");
+    TestFilesystem::RemoveDirectory("csgo/scripts");
+    TestFilesystem::RemoveDirectory("csgo");
+    TestFilesystem::RemoveDirectory("csgo_gc");
+}
+
+static bool WriteTextFile(const char *path, std::string_view contents)
+{
+    FILE *file = fopen(path, "wb");
+    if (!file)
+    {
+        return false;
+    }
+
+    bool written = fwrite(contents.data(), 1, contents.size(), file) == contents.size();
+    written &= fclose(file) == 0;
+    return written;
+}
+
+static bool WritePrestigeFixtures(std::string_view versionDate)
+{
+    if (!TestFilesystem::MakeDirectory("csgo")
+        || !TestFilesystem::MakeDirectory("csgo/scripts")
+        || !TestFilesystem::MakeDirectory("csgo/scripts/items")
+        || !TestFilesystem::MakeDirectory("csgo_gc"))
+    {
+        return false;
+    }
+
+    KeyValue schema{ "root" };
+    KeyValue &itemsGame = schema.AddSubkey("items_game");
+    itemsGame.AddSubkey("prefabs")
+        .AddSubkey("prestige_coin")
+        .AddString("item_type", "prestige_coin");
+
+    KeyValue &items = itemsGame.AddSubkey("items");
+    auto addMedal = [&](uint32_t defIndex, uint32_t year)
+    {
+        KeyValue &item = items.AddSubkey(std::to_string(defIndex));
+        item.AddString("name", std::string{ "prestige coin " }.append(std::to_string(year)));
+        item.AddString("prefab", "prestige_coin");
+        item.AddSubkey("attributes").AddNumber("prestige year", year);
+    };
+
+    addMedal(1376, 2019);
+    addMedal(1377, 2019);
+    addMedal(4873, 2023);
+    addMedal(4874, 2023);
+
+    KeyValue unusualLootLists{ "unusual_loot_lists" };
+    unusualLootLists.AddSubkey("empty");
+
+    KeyValue inventory{ "inventory" };
+    inventory.AddNumber("format_version", 1);
+    KeyValue &playerState = inventory.AddSubkey("player_state");
+    playerState.AddNumber("configured_level", GetConfig().Level());
+    playerState.AddNumber("configured_xp", GetConfig().Xp());
+    playerState.AddNumber("level", CSGOMaxPlayerLevel);
+    playerState.AddNumber("xp", 4999);
+    inventory.AddSubkey("items");
+
+    std::string steamInf{ "ClientVersion=1569\nVersionDate=" };
+    steamInf.append(versionDate.data(), versionDate.size());
+    steamInf.push_back('\n');
+
+    return schema.WriteToFile("csgo/scripts/items/items_game.txt")
+        && unusualLootLists.WriteToFile("csgo_gc/unusual_loot_lists.txt")
+        && inventory.WriteToFile("csgo_gc/inventory.txt")
+        && WriteTextFile("csgo/steam.inf", steamInf);
+}
+
+static bool SetPersistedPlayerProgress(int level, int xp)
+{
+    KeyValue inventory{ "inventory" };
+    if (!inventory.ParseFromFile("csgo_gc/inventory.txt"))
+    {
+        return false;
+    }
+
+    KeyValue *playerState = inventory.GetSubkey("player_state");
+    if (!playerState)
+    {
+        return false;
+    }
+
+    playerState->SetString("level", std::to_string(level));
+    playerState->SetString("xp", std::to_string(xp));
+    return inventory.WriteToFile("csgo_gc/inventory.txt");
+}
+
+static bool PersistedPlayerProgressIs(int level, int xp)
+{
+    KeyValue inventory{ "inventory" };
+    if (!inventory.ParseFromFile("csgo_gc/inventory.txt"))
+    {
+        return false;
+    }
+
+    const KeyValue *playerState = inventory.GetSubkey("player_state");
+    return playerState
+        && playerState->GetNumber<int>("level") == level
+        && playerState->GetNumber<int>("xp") == xp;
+}
+
+static bool PersistedItemHasDefIndex(uint64_t itemId, uint32_t defIndex)
+{
+    KeyValue inventory{ "inventory" };
+    if (!inventory.ParseFromFile("csgo_gc/inventory.txt"))
+    {
+        return false;
+    }
+
+    const KeyValue *items = inventory.GetSubkey("items");
+    if (!items)
+    {
+        return false;
+    }
+
+    const KeyValue *item = items->GetSubkey(std::to_string(itemId >> 32));
+    return item && item->GetNumber<uint32_t>("def_index") == defIndex;
+}
+
+static bool RequestPrestigeInquiry(ClientGC &gc,
+    CMsgGCCStrike15_v2_Client2GCRequestPrestigeCoin &response)
+{
+    CMsgGCCStrike15_v2_Client2GCRequestPrestigeCoin request;
+    SendGCProtobuf(gc, k_EMsgGCCStrike15_v2_Client2GCRequestPrestigeCoin, request);
+
+    EventData event;
+    return WaitForHostMessage(gc, k_EMsgGCCStrike15_v2_Client2GCRequestPrestigeCoin, event)
+        && ParseHostProtobuf(event, response);
+}
+
+static bool ValidatePrestigeClaimEvents(const std::vector<EventData> &events,
+    bool expectedCreate, uint32_t expectedDefIndex, uint64_t expectedItemId,
+    uint64_t &actualItemId)
+{
+    size_t itemEventIndex = events.size();
+    size_t responseEventIndex = events.size();
+    bool foundPersona = false;
+    bool foundMatchmakingHello = false;
+    bool foundResponse = false;
+    CMsgSOSingleObject itemData;
+    CMsgSOSingleObject personaData;
+    CSOEconItem item;
+    CSOPersonaDataPublic persona;
+    CMsgGCCStrike15_v2_Client2GCRequestPrestigeCoin response;
+
+    for (size_t i = 0; i < events.size(); i++)
+    {
+        uint32_t type = static_cast<uint32_t>(events[i].id) & ~ProtobufMask;
+        if (type == k_ESOMsg_Create || type == k_ESOMsg_Update)
+        {
+            CMsgSOSingleObject object;
+            if (!ParseHostProtobuf(events[i], object))
+            {
+                return false;
+            }
+
+            if (object.type_id() == SOTypeItem)
+            {
+                uint32_t expectedType = expectedCreate
+                    ? static_cast<uint32_t>(k_ESOMsg_Create)
+                    : static_cast<uint32_t>(k_ESOMsg_Update);
+                if (type != expectedType
+                    || !item.ParseFromString(object.object_data()))
+                {
+                    return false;
+                }
+                itemData = object;
+                itemEventIndex = i;
+            }
+            else if (object.type_id() == SOTypePersonaDataPublic)
+            {
+                if (!persona.ParseFromString(object.object_data()))
+                {
+                    return false;
+                }
+                personaData = object;
+                foundPersona = true;
+            }
+        }
+        else if (type == k_EMsgGCCStrike15_v2_MatchmakingGC2ClientHello)
+        {
+            CMsgGCCStrike15_v2_MatchmakingGC2ClientHello hello;
+            foundMatchmakingHello = ParseHostProtobuf(events[i], hello)
+                && hello.player_level() == 1
+                && hello.player_cur_xp() == 0;
+        }
+        else if (type == k_EMsgGCCStrike15_v2_Client2GCRequestPrestigeCoin)
+        {
+            foundResponse = ParseHostProtobuf(events[i], response);
+            responseEventIndex = i;
+        }
+    }
+
+    actualItemId = item.id();
+    return itemEventIndex < responseEventIndex
+        && item.def_index() == expectedDefIndex
+        && (!expectedItemId || item.id() == expectedItemId)
+        && item.origin() == ItemOriginLevelUpReward
+        && (!expectedCreate
+            || item.inventory() == InventoryUnacknowledged(UnacknowledgedLevelUpReward))
+        && foundPersona
+        && persona.player_level() == 1
+        && itemData.version() < personaData.version()
+        && foundMatchmakingHello
+        && foundResponse
+        && response.defindex() == expectedDefIndex
+        && response.upgradeid() == item.id()
+        && response.prestigetime() != 0;
+}
+
+static bool ServiceMedalsFollowBuildYearAndPersistPrestige()
+{
+    constexpr uint64_t SteamId = 76561197960265729ull;
+    RemovePrestigeFixtures();
+
+    bool valid = WritePrestigeFixtures("Mar 28 2019");
+    if (valid)
+    {
+        ClientGC gc{ SteamId };
+        CMsgGCCStrike15_v2_Client2GCRequestPrestigeCoin response;
+        valid &= RequestPrestigeInquiry(gc, response)
+            && response.defindex() == 1376
+            && !response.has_upgradeid()
+            && !response.has_prestigetime();
+    }
+
+    RemovePrestigeFixtures();
+    valid &= WritePrestigeFixtures("invalid");
+
+    uint64_t medalItemId = 0;
+    if (valid)
+    {
+        ClientGC gc{ SteamId };
+        CMsgGCCStrike15_v2_Client2GCRequestPrestigeCoin inquiry;
+        valid &= RequestPrestigeInquiry(gc, inquiry)
+            && inquiry.defindex() == 4873
+            && !inquiry.has_upgradeid();
+
+        CMsgGCCStrike15_v2_Client2GCRequestPrestigeCoin staleClaim;
+        staleClaim.set_defindex(4874);
+        SendGCProtobuf(gc, k_EMsgGCCStrike15_v2_Client2GCRequestPrestigeCoin, staleClaim);
+        valid &= HostMessageNotReceived(gc,
+            k_EMsgGCCStrike15_v2_Client2GCRequestPrestigeCoin);
+
+        inquiry.Clear();
+        valid &= RequestPrestigeInquiry(gc, inquiry) && inquiry.defindex() == 4873;
+
+        CMsgGCCStrike15_v2_Client2GCRequestPrestigeCoin claim;
+        claim.set_defindex(4873);
+        SendGCProtobuf(gc, k_EMsgGCCStrike15_v2_Client2GCRequestPrestigeCoin, claim);
+
+        std::vector<EventData> events;
+        valid &= WaitForHostMessagesUntil(gc,
+            k_EMsgGCCStrike15_v2_Client2GCRequestPrestigeCoin, events)
+            && ValidatePrestigeClaimEvents(events, true, 4873, 0, medalItemId);
+
+        CMsgGCCStrike15_v2_Client2GCRequestPrestigeCoin ineligibleInquiry;
+        SendGCProtobuf(gc, k_EMsgGCCStrike15_v2_Client2GCRequestPrestigeCoin,
+            ineligibleInquiry);
+        valid &= HostMessageNotReceived(gc,
+            k_EMsgGCCStrike15_v2_Client2GCRequestPrestigeCoin);
+    }
+
+    valid &= medalItemId != 0
+        && PersistedPlayerProgressIs(1, 0)
+        && PersistedItemHasDefIndex(medalItemId, 4873);
+
+    if (valid)
+    {
+        ClientGC gc{ SteamId };
+        CMsgGCCStrike15_v2_Client2GCRequestPrestigeCoin inquiry;
+        SendGCProtobuf(gc, k_EMsgGCCStrike15_v2_Client2GCRequestPrestigeCoin, inquiry);
+        valid &= HostMessageNotReceived(gc,
+            k_EMsgGCCStrike15_v2_Client2GCRequestPrestigeCoin);
+
+        CMsgClientHello hello;
+        SendGCProtobuf(gc, k_EMsgGCClientHello, hello);
+        EventData event;
+        CMsgClientWelcome welcome;
+        CMsgGCCStrike15_v2_MatchmakingGC2ClientHello matchmakingHello;
+        valid &= WaitForHostMessage(gc, k_EMsgGCClientWelcome, event)
+            && ParseHostProtobuf(event, welcome)
+            && matchmakingHello.ParseFromString(welcome.game_data2())
+            && matchmakingHello.player_level() == 1
+            && matchmakingHello.player_cur_xp() == 0;
+    }
+
+    valid &= SetPersistedPlayerProgress(CSGOMaxPlayerLevel, 4999);
+    if (valid)
+    {
+        ClientGC gc{ SteamId };
+        CMsgGCCStrike15_v2_Client2GCRequestPrestigeCoin inquiry;
+        valid &= RequestPrestigeInquiry(gc, inquiry)
+            && inquiry.defindex() == 4874
+            && inquiry.upgradeid() == medalItemId;
+
+        CMsgGCCStrike15_v2_Client2GCRequestPrestigeCoin claim;
+        claim.set_defindex(4874);
+        SendGCProtobuf(gc, k_EMsgGCCStrike15_v2_Client2GCRequestPrestigeCoin, claim);
+
+        std::vector<EventData> events;
+        uint64_t upgradedItemId = 0;
+        valid &= WaitForHostMessagesUntil(gc,
+            k_EMsgGCCStrike15_v2_Client2GCRequestPrestigeCoin, events)
+            && ValidatePrestigeClaimEvents(events, false, 4874, medalItemId, upgradedItemId)
+            && upgradedItemId == medalItemId;
+    }
+
+    valid &= PersistedPlayerProgressIs(1, 0)
+        && PersistedItemHasDefIndex(medalItemId, 4874)
+        && SetPersistedPlayerProgress(CSGOMaxPlayerLevel, 4999);
+
+    if (valid)
+    {
+        ClientGC gc{ SteamId };
+        CMsgGCCStrike15_v2_Client2GCRequestPrestigeCoin inquiry;
+        SendGCProtobuf(gc, k_EMsgGCCStrike15_v2_Client2GCRequestPrestigeCoin, inquiry);
+        valid &= HostMessageNotReceived(gc,
+            k_EMsgGCCStrike15_v2_Client2GCRequestPrestigeCoin);
+    }
+
+    RemovePrestigeFixtures();
+    return valid;
+}
+
 int main()
 {
     struct TestCase
@@ -1452,6 +1810,8 @@ int main()
         { "StatTrakSwapToolTwoPackCreatesTwoTools", StatTrakSwapToolTwoPackCreatesTwoTools },
         { "UnusualStatTrakKnivesCanSwapCounters", UnusualStatTrakKnivesCanSwapCounters },
         { "StorePurchasesFinalizeTransactionally", StorePurchasesFinalizeTransactionally },
+        { "ServiceMedalsFollowBuildYearAndPersistPrestige",
+            ServiceMedalsFollowBuildYearAndPersistPrestige },
     };
 
     bool allPassed = true;

--- a/csgo_gc/inventory.cpp
+++ b/csgo_gc/inventory.cpp
@@ -108,6 +108,10 @@ static bool IsUncustomizedBaseItemClone(const CSOEconItem &item)
 
 Inventory::Inventory(uint64_t steamId)
     : m_steamId{ steamId }
+    , m_configuredPlayerLevel{ GetConfig().Level() }
+    , m_configuredPlayerXp{ GetConfig().Xp() }
+    , m_playerLevel{ m_configuredPlayerLevel }
+    , m_playerXp{ m_configuredPlayerXp }
     , m_version{ InitialInventoryVersion() }
 {
     ReadFromFile();
@@ -175,6 +179,118 @@ const CSOEconItem *Inventory::GetItem(uint64_t itemId) const
     }
 
     return &it->second;
+}
+
+std::optional<Inventory::PrestigeMedalPlan> Inventory::GetPrestigeMedalPlan(uint32_t year) const
+{
+    std::vector<uint32_t> defIndexes = m_itemSchema.PrestigeMedalDefIndexes(year);
+    if (defIndexes.empty())
+    {
+        return std::nullopt;
+    }
+
+    size_t currentLevel = defIndexes.size();
+    uint64_t currentItemId = 0;
+    for (const auto &[itemId, item] : m_items)
+    {
+        auto defIndex = std::lower_bound(defIndexes.begin(), defIndexes.end(), item.def_index());
+        if (defIndex == defIndexes.end() || *defIndex != item.def_index())
+        {
+            continue;
+        }
+
+        size_t medalLevel = static_cast<size_t>(defIndex - defIndexes.begin());
+        if (!currentItemId || medalLevel > currentLevel)
+        {
+            currentLevel = medalLevel;
+            currentItemId = itemId;
+        }
+    }
+
+    size_t targetLevel = 0;
+    if (currentItemId)
+    {
+        if (currentLevel + 1 >= defIndexes.size())
+        {
+            return std::nullopt;
+        }
+        targetLevel = currentLevel + 1;
+    }
+
+    return PrestigeMedalPlan{ defIndexes[targetLevel], currentItemId };
+}
+
+bool Inventory::ClaimPrestigeMedal(uint32_t year, uint32_t expectedDefIndex,
+    PrestigeMedalClaim &claim)
+{
+    if (m_playerLevel < CSGOMaxPlayerLevel)
+    {
+        return false;
+    }
+
+    std::optional<PrestigeMedalPlan> plan = GetPrestigeMedalPlan(year);
+    if (!plan || plan->defIndex != expectedDefIndex)
+    {
+        return false;
+    }
+
+    const int previousPlayerLevel = m_playerLevel;
+    const int previousPlayerXp = m_playerXp;
+    const uint64_t previousVersion = m_version;
+    const uint32_t previousLastHighItemId = m_lastHighItemId;
+    uint32_t previousDefIndex = 0;
+
+    if (plan->upgradeId)
+    {
+        auto item = m_items.find(plan->upgradeId);
+        if (item == m_items.end())
+        {
+            return false;
+        }
+
+        previousDefIndex = item->second.def_index();
+        item->second.set_def_index(plan->defIndex);
+        ToSingleObject(claim.itemData, item->second);
+        claim.itemId = item->second.id();
+        claim.created = false;
+    }
+    else
+    {
+        CSOEconItem &item = CreateItem(plan->defIndex,
+            ItemOriginLevelUpReward, UnacknowledgedLevelUpReward);
+        ToSingleObject(claim.itemData, item);
+        claim.itemId = item.id();
+        claim.created = true;
+    }
+
+    m_playerLevel = 1;
+    m_playerXp = 0;
+
+    CSOPersonaDataPublic personaData;
+    personaData.set_player_level(m_playerLevel);
+    personaData.set_elevated_state(true);
+    ToSingleObject(claim.personaData, SOTypePersonaDataPublic, personaData);
+
+    if (!WriteToFile())
+    {
+        if (claim.created)
+        {
+            m_items.erase(claim.itemId);
+            m_lastHighItemId = previousLastHighItemId;
+        }
+        else
+        {
+            m_items.at(claim.itemId).set_def_index(previousDefIndex);
+        }
+
+        m_playerLevel = previousPlayerLevel;
+        m_playerXp = previousPlayerXp;
+        m_version = previousVersion;
+        claim = PrestigeMedalClaim{};
+        return false;
+    }
+
+    return true;
 }
 
 CSOEconItem &Inventory::AllocateItem(uint32_t highItemId)
@@ -266,6 +382,19 @@ void Inventory::ReadFromFile()
         return;
     }
 
+    const KeyValue *playerState = inventoryKey.GetSubkey("player_state");
+    if (playerState
+        && playerState->GetSubkey("configured_level")
+        && playerState->GetSubkey("configured_xp")
+        && playerState->GetSubkey("level")
+        && playerState->GetSubkey("xp")
+        && playerState->GetNumber<int>("configured_level") == m_configuredPlayerLevel
+        && playerState->GetNumber<int>("configured_xp") == m_configuredPlayerXp)
+    {
+        m_playerLevel = playerState->GetNumber<int>("level");
+        m_playerXp = playerState->GetNumber<int>("xp");
+    }
+
     const KeyValue *itemsKey = inventoryKey.GetSubkey("items");
     if (itemsKey)
     {
@@ -349,16 +478,24 @@ void Inventory::ReadItem(const KeyValue &itemKey, CSOEconItem &item) const
     }
 }
 
-void Inventory::WriteToFile() const
+bool Inventory::WriteToFile() const
 {
     if (!m_saveEnabled)
     {
         Platform::Print("Inventory: save skipped to preserve unreadable %s\n", InventoryFilePath);
-        return;
+        return false;
     }
 
     KeyValue inventoryKey{ "inventory" };
     inventoryKey.AddNumber("format_version", 1);
+
+    {
+        KeyValue &playerState = inventoryKey.AddSubkey("player_state");
+        playerState.AddNumber("configured_level", m_configuredPlayerLevel);
+        playerState.AddNumber("configured_xp", m_configuredPlayerXp);
+        playerState.AddNumber("level", m_playerLevel);
+        playerState.AddNumber("xp", m_playerXp);
+    }
 
     {
         KeyValue &itemsKey = inventoryKey.AddSubkey("items");
@@ -385,7 +522,10 @@ void Inventory::WriteToFile() const
     if (!inventoryKey.WriteToFile(InventoryFilePath))
     {
         Platform::Print("Inventory: failed to save %s; original file was preserved\n", InventoryFilePath);
+        return false;
     }
+
+    return true;
 }
 
 void Inventory::WriteItem(KeyValue &itemKey, const CSOEconItem &item) const
@@ -417,7 +557,7 @@ void Inventory::WriteItem(KeyValue &itemKey, const CSOEconItem &item) const
     }
 }
 
-void Inventory::BuildCacheSubscription(CMsgSOCacheSubscribed &message, int level, bool server)
+void Inventory::BuildCacheSubscription(CMsgSOCacheSubscribed &message, bool server)
 {
     message.set_version(m_version);
     message.mutable_owner_soid()->set_type(SoIdTypeSteamId);
@@ -440,7 +580,7 @@ void Inventory::BuildCacheSubscription(CMsgSOCacheSubscribed &message, int level
 
     {
         CSOPersonaDataPublic personaData;
-        personaData.set_player_level(level);
+        personaData.set_player_level(m_playerLevel);
         personaData.set_elevated_state(true);
 
         CMsgSOCacheSubscribed_SubscribedType *object = message.add_objects();

--- a/csgo_gc/inventory.h
+++ b/csgo_gc/inventory.h
@@ -45,8 +45,28 @@ public:
         std::array<std::optional<float>, 6> stickerRotation;
     };
 
-    void BuildCacheSubscription(CMsgSOCacheSubscribed &message, int level, bool server);
+    void BuildCacheSubscription(CMsgSOCacheSubscribed &message, bool server);
     uint64_t Version() const { return m_version; }
+    int PlayerLevel() const { return m_playerLevel; }
+    int PlayerXp() const { return m_playerXp; }
+
+    struct PrestigeMedalPlan
+    {
+        uint32_t defIndex{};
+        uint64_t upgradeId{};
+    };
+
+    struct PrestigeMedalClaim
+    {
+        CMsgSOSingleObject itemData;
+        CMsgSOSingleObject personaData;
+        uint64_t itemId{};
+        bool created{};
+    };
+
+    std::optional<PrestigeMedalPlan> GetPrestigeMedalPlan(uint32_t year) const;
+    bool ClaimPrestigeMedal(uint32_t year, uint32_t expectedDefIndex,
+        PrestigeMedalClaim &claim);
 
     bool EquipItem(uint64_t itemId, uint32_t classId, uint32_t slotId, bool swap,
         CMsgSOMultipleObjects &update);
@@ -185,7 +205,7 @@ public:
         std::string &error);
     size_t ItemCount() const { return m_items.size(); }
     const ItemMap &Items() const { return m_items; }
-    void Save() const { WriteToFile(); }
+    bool Save() const { return WriteToFile(); }
 
 private:
     uint32_t AccountId() const;
@@ -202,7 +222,7 @@ private:
     void ReadItem(const KeyValue &itemKey, CSOEconItem &item) const;
     void LogInventoryConsistency() const;
 
-    void WriteToFile() const;
+    bool WriteToFile() const;
     void WriteItem(KeyValue &itemKey, const CSOEconItem &item) const;
 
     // helper, only called via EquipItem
@@ -249,6 +269,10 @@ private:
     void ConsumeToolItem(uint64_t toolId, CMsgSOSingleObject &removalMsg);
 
     const uint64_t m_steamId;
+    const int m_configuredPlayerLevel;
+    const int m_configuredPlayerXp;
+    int m_playerLevel;
+    int m_playerXp;
     uint64_t m_version;
     ItemSchema m_itemSchema;
     Random m_random;

--- a/csgo_gc/item_schema.cpp
+++ b/csgo_gc/item_schema.cpp
@@ -69,6 +69,7 @@ ItemInfo::ItemInfo(uint32_t defIndex)
     , m_level{ 1 }
     , m_supplyCrateSeries{ 0 }
     , m_stickerSlotCount{ 0 }
+    , m_prestigeYear{ 0 }
     , m_canSticker{ false }
     , m_canPatch{ false }
     , m_nameable{ false }
@@ -900,6 +901,9 @@ void ItemSchema::ParseItemRecursive(ItemInfo &info, const KeyValue &itemKey, con
     const KeyValue *attributes = itemKey.GetSubkey("attributes");
     if (attributes)
     {
+        info.m_prestigeYear = attributes->GetNumber<uint32_t>(
+            "prestige year", info.m_prestigeYear);
+
         const KeyValue *supplyCrateSeries = attributes->GetSubkey("set supply crate series");
         if (supplyCrateSeries)
         {
@@ -1735,4 +1739,19 @@ bool ItemSchema::CanStatTrakSwapDefIndex(uint32_t defIndex) const
 {
     const ItemInfo *info = ItemInfoByDefIndex(defIndex);
     return info && info->m_canStatTrakSwap;
+}
+
+std::vector<uint32_t> ItemSchema::PrestigeMedalDefIndexes(uint32_t year) const
+{
+    std::vector<uint32_t> defIndexes;
+    for (const auto &[defIndex, info] : m_itemInfo)
+    {
+        if (info.m_itemType == "prestige_coin" && info.m_prestigeYear == year)
+        {
+            defIndexes.push_back(defIndex);
+        }
+    }
+
+    std::sort(defIndexes.begin(), defIndexes.end());
+    return defIndexes;
 }

--- a/csgo_gc/item_schema.h
+++ b/csgo_gc/item_schema.h
@@ -41,6 +41,7 @@ public:
     uint32_t m_level;
     uint32_t m_supplyCrateSeries; // cases only
     uint32_t m_stickerSlotCount;
+    uint32_t m_prestigeYear;
     TournamentMetadata m_tournament;
     std::string m_itemType;
     std::vector<std::string> m_prefabs;
@@ -195,6 +196,7 @@ public:
     bool CanApplyPatchToDefIndex(uint32_t defIndex) const;
     bool CanNameDefIndex(uint32_t defIndex) const;
     bool CanStatTrakSwapDefIndex(uint32_t defIndex) const;
+    std::vector<uint32_t> PrestigeMedalDefIndexes(uint32_t year) const;
 
 
 public:

--- a/csgo_gc/item_schema_tests.cpp
+++ b/csgo_gc/item_schema_tests.cpp
@@ -116,6 +116,34 @@ public:
             && partiallyOverridden->m_maxFloat == 0.5f;
     }
 
+    bool ParsePrestigeMedals()
+    {
+        KeyValue prefabs{ "prefabs" };
+        prefabs.AddSubkey("prestige_coin").AddString("item_type", "prestige_coin");
+
+        KeyValue items{ "items" };
+        auto addMedal = [&](const char *defIndex, uint32_t year)
+        {
+            KeyValue &item = items.AddSubkey(defIndex);
+            item.AddString("prefab", "prestige_coin");
+            item.AddSubkey("attributes").AddNumber("prestige year", year);
+        };
+
+        addMedal("5002", 2023);
+        addMedal("5000", 2023);
+        addMedal("4999", 2022);
+        items.AddSubkey("5001").AddSubkey("attributes").AddNumber("prestige year", 2023);
+
+        schema.ParseItems(&items, &prefabs);
+
+        const ItemInfo *medal = schema.ItemInfoByDefIndex(5000);
+        const std::vector<uint32_t> expected{ 5000, 5002 };
+        return medal
+            && medal->m_itemType == "prestige_coin"
+            && medal->m_prestigeYear == 2023
+            && schema.PrestigeMedalDefIndexes(2023) == expected;
+    }
+
     ItemSchema schema;
 };
 
@@ -159,6 +187,12 @@ static bool PaintKitWearRangesInheritDefaults()
     return fixture.ParsePaintKitWearRanges();
 }
 
+static bool PrestigeMedalsUseSchemaYearAndSortedDefIndexes()
+{
+    ItemSchemaTestFixture fixture;
+    return fixture.ParsePrestigeMedals();
+}
+
 int main()
 {
     if (!TournamentStickerCapsuleIsNotSouvenir())
@@ -179,6 +213,11 @@ int main()
     if (!PaintKitWearRangesInheritDefaults())
     {
         return 4;
+    }
+
+    if (!PrestigeMedalsUseSchemaYearAndSortedDefIndexes())
+    {
+        return 5;
     }
 
     return 0;


### PR DESCRIPTION
Resolve #72

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for prestige medal inquiries and claims.
  - Players can receive new prestige medals, upgrade existing medals, and retain progress after saving.
  - Added build-year detection to select the appropriate prestige medal set, with a fallback year when unavailable.

- **Improvements**
  - Inventory and matchmaking now use current player level and experience data.
  - Added validation for eligible levels, medal years, and claim requests.
  - Improved inventory synchronization and reporting when saves fail.
  - Added correlated responses for prestige medal requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->