### PR TITLE
Add offline Viewer Pass activation and event favorites

### DIFF
--- a/csgo_gc/gc_client.cpp
+++ b/csgo_gc/gc_client.cpp
@@ -1001,6 +1001,14 @@ void ClientGC::HandleMessage(uint32_t type, const void *data, uint32_t size)
             ClientRequestPlayersProfile(messageRead);
             break;
 
+        case k_EMsgGCCStrike15_v2_SetEventFavorite:
+            SetEventFavorite(messageRead);
+            break;
+
+        case k_EMsgGCCStrike15_v2_GetEventFavorites_Request:
+            GetEventFavorites(messageRead);
+            break;
+
         case k_EMsgGCSetItemPositions:
             SetItemPositions(messageRead);
             break;
@@ -1158,6 +1166,51 @@ void ClientGC::ClientRequestPlayersProfile(GCMessageRead &messageRead)
     }
 
     SendMessageToGame(false, k_EMsgGCCStrike15_v2_PlayersProfile, response);
+}
+
+void ClientGC::SetEventFavorite(GCMessageRead &messageRead)
+{
+    CMsgGCCStrike15_v2_SetEventFavorite message;
+    if (!messageRead.ReadProtobuf(message))
+    {
+        Platform::Print("Parsing CMsgGCCStrike15_v2_SetEventFavorite failed, ignoring\n");
+        return;
+    }
+
+    m_inventory.SetEventFavorite(message.eventid(), message.is_favorite());
+}
+
+void ClientGC::GetEventFavorites(GCMessageRead &messageRead)
+{
+    CMsgGCCStrike15_v2_GetEventFavorites_Request request;
+    if (!messageRead.ReadProtobuf(request))
+    {
+        Platform::Print("Parsing CMsgGCCStrike15_v2_GetEventFavorites_Request failed, ignoring\n");
+        return;
+    }
+
+    std::ostringstream favorites;
+    favorites << '[';
+    bool first = true;
+    for (uint64_t eventId : m_inventory.EventFavorites())
+    {
+        if (!first)
+        {
+            favorites << ',';
+        }
+        first = false;
+        favorites << eventId;
+    }
+    favorites << ']';
+
+    CMsgGCCStrike15_v2_GetEventFavorites_Response response;
+    response.set_all_events(request.all_events());
+    response.set_json_favorites(favorites.str());
+    response.set_json_featured("[]");
+    SendMessageToGame(false,
+        k_EMsgGCCStrike15_v2_GetEventFavorites_Response,
+        response,
+        messageRead.JobId());
 }
 
 void ClientGC::SendMessageToGame(bool sendToGameServer, uint32_t type,

--- a/csgo_gc/gc_client.cpp
+++ b/csgo_gc/gc_client.cpp
@@ -1476,16 +1476,24 @@ void ClientGC::UseItemRequest(GCMessageRead &messageRead)
         return;
     }
 
-    CMsgSOSingleObject destroy;
-    CMsgSOMultipleObjects updateMultiple;
-    CMsgGCItemCustomizationNotification notification;
-
-    if (m_inventory.UseItem(message.item_id(), destroy, updateMultiple, notification))
+    Inventory::UseItemResult result;
+    if (m_inventory.UseItem(message.item_id(), result))
     {
-        SendMessageToGame(true, k_ESOMsg_Destroy, destroy);
-        SendMessageToGame(true, k_ESOMsg_UpdateMultiple, updateMultiple);
+        SendMessageToGame(true, k_ESOMsg_Destroy, result.destroy);
 
-        SendMessageToGame(false, k_EMsgGCItemCustomizationNotification, notification);
+        if (result.itemChange != Inventory::UseItemChange::None)
+        {
+            SendMessageToGame(true,
+                result.itemChange == Inventory::UseItemChange::Create
+                    ? k_ESOMsg_Create : k_ESOMsg_Update,
+                result.itemData);
+        }
+        if (result.updateMultiple.objects_modified_size())
+        {
+            SendMessageToGame(true, k_ESOMsg_UpdateMultiple, result.updateMultiple);
+        }
+
+        SendMessageToGame(false, k_EMsgGCItemCustomizationNotification, result.notification);
     }
 }
 

--- a/csgo_gc/gc_client.h
+++ b/csgo_gc/gc_client.h
@@ -67,6 +67,8 @@ private:
     void UseItemRequest(GCMessageRead &messageRead);
     void ClientRequestJoinServerData(GCMessageRead &messageRead);
     void ClientRequestPlayersProfile(GCMessageRead &messageRead);
+    void SetEventFavorite(GCMessageRead &messageRead);
+    void GetEventFavorites(GCMessageRead &messageRead);
     void SetItemPositions(GCMessageRead &messageRead);
     void IncrementKillCountAttribute(GCMessageRead &messageRead);
     // Increment the equipped StatTrak music kit when the local player receives round MVP.

--- a/csgo_gc/gc_message_tests.cpp
+++ b/csgo_gc/gc_message_tests.cpp
@@ -2201,6 +2201,72 @@ static bool ViewerPassTokenPacksUpdatePersistedJournal()
     return valid;
 }
 
+static bool RequestEventFavorites(ClientGC &gc, bool allEvents, uint64_t jobId,
+    std::string_view expectedFavorites)
+{
+    CMsgGCCStrike15_v2_GetEventFavorites_Request request;
+    request.set_all_events(allEvents);
+    if (!SendGCProtobufJob(gc,
+        k_EMsgGCCStrike15_v2_GetEventFavorites_Request, request, jobId))
+    {
+        return false;
+    }
+
+    EventData event;
+    CMsgGCCStrike15_v2_GetEventFavorites_Response response;
+    return WaitForHostMessage(gc,
+            k_EMsgGCCStrike15_v2_GetEventFavorites_Response, event)
+        && ParseHostJobProtobuf(event, jobId, response)
+        && response.all_events() == allEvents
+        && response.json_favorites() == expectedFavorites
+        && response.json_featured() == "[]";
+}
+
+static bool EventFavoritesPersistAndPreserveRequestJobs()
+{
+    constexpr uint64_t SteamId = 76561197960265729ull;
+    constexpr const char *InventoryPath = "csgo_gc/inventory.txt";
+    TestFilesystem::RemoveFile(InventoryPath);
+    if (!TestFilesystem::MakeDirectory("csgo_gc"))
+    {
+        return false;
+    }
+
+    bool valid = true;
+    {
+        ClientGC gc{ SteamId };
+        CMsgGCCStrike15_v2_SetEventFavorite favorite;
+        favorite.set_eventid(21);
+        favorite.set_is_favorite(true);
+        SendGCProtobuf(gc, k_EMsgGCCStrike15_v2_SetEventFavorite, favorite);
+
+        favorite.set_eventid(7);
+        SendGCProtobuf(gc, k_EMsgGCCStrike15_v2_SetEventFavorite, favorite);
+
+        valid &= RequestEventFavorites(gc, true, 7001, "[7,21]");
+    }
+
+    {
+        ClientGC gc{ SteamId };
+        valid &= RequestEventFavorites(gc, false, 7002, "[7,21]");
+
+        CMsgGCCStrike15_v2_SetEventFavorite favorite;
+        favorite.set_eventid(7);
+        favorite.set_is_favorite(false);
+        SendGCProtobuf(gc, k_EMsgGCCStrike15_v2_SetEventFavorite, favorite);
+        valid &= RequestEventFavorites(gc, true, 7003, "[21]");
+    }
+
+    {
+        Inventory persisted{ SteamId };
+        valid &= persisted.EventFavorites() == std::set<uint64_t>{ 21 };
+    }
+
+    TestFilesystem::RemoveFile(InventoryPath);
+    TestFilesystem::RemoveDirectory("csgo_gc");
+    return valid;
+}
+
 int main()
 {
     struct TestCase
@@ -2232,6 +2298,8 @@ int main()
             ViewerPassActivationCreatesAndPersistsJournal },
         { "ViewerPassTokenPacksUpdatePersistedJournal",
             ViewerPassTokenPacksUpdatePersistedJournal },
+        { "EventFavoritesPersistAndPreserveRequestJobs",
+            EventFavoritesPersistAndPreserveRequestJobs },
     };
 
     bool allPassed = true;

--- a/csgo_gc/gc_message_tests.cpp
+++ b/csgo_gc/gc_message_tests.cpp
@@ -1908,6 +1908,299 @@ static bool ServiceMedalsFollowBuildYearAndPersistPrestige()
     return valid;
 }
 
+static void RemoveTournamentAccessFixtures()
+{
+    TestFilesystem::RemoveFile("csgo_gc/inventory.txt");
+    TestFilesystem::RemoveFile("csgo_gc/unusual_loot_lists.txt");
+    TestFilesystem::RemoveFile("csgo_gc/gc_loot_lists.txt");
+    TestFilesystem::RemoveFile("csgo/scripts/items/items_game.txt");
+    TestFilesystem::RemoveDirectory("csgo/scripts/items");
+    TestFilesystem::RemoveDirectory("csgo/scripts");
+    TestFilesystem::RemoveDirectory("csgo");
+    TestFilesystem::RemoveDirectory("csgo_gc");
+}
+
+static bool WriteTournamentAccessFixtures(std::initializer_list<uint32_t> inventoryDefIndexes)
+{
+    if (!TestFilesystem::MakeDirectory("csgo")
+        || !TestFilesystem::MakeDirectory("csgo/scripts")
+        || !TestFilesystem::MakeDirectory("csgo/scripts/items")
+        || !TestFilesystem::MakeDirectory("csgo_gc"))
+    {
+        return false;
+    }
+
+    KeyValue schema{ "root" };
+    KeyValue &itemsGame = schema.AddSubkey("items_game");
+    KeyValue &attributes = itemsGame.AddSubkey("attributes");
+    auto addIntegerAttribute = [&](uint32_t defIndex, const char *name)
+    {
+        KeyValue &attribute = attributes.AddSubkey(std::to_string(defIndex));
+        attribute.AddString("name", name);
+        attribute.AddNumber("stored_as_integer", 1);
+    };
+    addIntegerAttribute(ItemSchema::AttributeStickerId0, "sticker slot 0 id");
+    addIntegerAttribute(ItemSchema::AttributeTournamentEventId, "tournament event id");
+    addIntegerAttribute(ItemSchema::AttributeCampaignId, "campaign id");
+    addIntegerAttribute(ItemSchema::AttributeCampaignCompletionBitfield,
+        "campaign completion bitfield");
+    addIntegerAttribute(ItemSchema::AttributeOperationDropsAwardedPurchased,
+        "operation drops awarded 1");
+    addIntegerAttribute(ItemSchema::AttributeOperationDropsAwardedRedeemed,
+        "operation drops awarded 0");
+
+    KeyValue &prefabs = itemsGame.AddSubkey("prefabs");
+    prefabs.AddSubkey("fan_token");
+    prefabs.AddSubkey("fan_shield");
+
+    KeyValue &passPrefab = prefabs.AddSubkey("paris_pass");
+    passPrefab.AddString("prefab", "fan_token");
+    KeyValue &passEvent = passPrefab.AddSubkey("attributes")
+        .AddSubkey("tournament event id");
+    passEvent.AddNumber("value", 21);
+
+    KeyValue &journalPrefab = prefabs.AddSubkey("paris_journal");
+    journalPrefab.AddString("prefab", "fan_shield");
+    KeyValue &journalAttributes = journalPrefab.AddSubkey("attributes");
+    journalAttributes.AddSubkey("tournament event id").AddNumber("value", 21);
+    auto addGenerated = [&](const char *name, uint32_t value)
+    {
+        KeyValue &attribute = journalAttributes.AddSubkey(name);
+        attribute.AddNumber("value", value);
+        attribute.AddNumber("force_gc_to_generate", 1);
+    };
+    addGenerated("sticker slot 0 id", 6732);
+    addGenerated("campaign id", 15);
+    addGenerated("campaign completion bitfield", 1);
+    addGenerated("operation drops awarded 1", 0);
+    addGenerated("operation drops awarded 0", 0);
+
+    KeyValue &items = itemsGame.AddSubkey("items");
+    auto addItemDefinition = [&](uint32_t defIndex, const char *name, const char *prefab)
+    {
+        KeyValue &item = items.AddSubkey(std::to_string(defIndex));
+        item.AddString("name", name);
+        item.AddString("prefab", prefab);
+    };
+    addItemDefinition(100, "tournament_pass_paris2023", "paris_pass");
+    addItemDefinition(101, "tournament_pass_paris2023_pack", "paris_pass");
+    addItemDefinition(102, "tournament_pass_paris2023_charge", "paris_pass");
+    addItemDefinition(200, "tournament_journal_paris2023", "paris_journal");
+
+    KeyValue inventory{ "inventory" };
+    inventory.AddNumber("format_version", 1);
+    KeyValue &inventoryItems = inventory.AddSubkey("items");
+    uint32_t highItemId = 1;
+    for (uint32_t defIndex : inventoryDefIndexes)
+    {
+        KeyValue &item = inventoryItems.AddSubkey(std::to_string(highItemId++));
+        item.AddNumber("def_index", defIndex);
+        item.AddNumber("origin", ItemOriginPurchased);
+    }
+
+    KeyValue unusualLootLists{ "unusual_loot_lists" };
+    KeyValue gcLootLists{ "gc_loot_lists" };
+    return schema.WriteToFile("csgo/scripts/items/items_game.txt")
+        && inventory.WriteToFile("csgo_gc/inventory.txt")
+        && unusualLootLists.WriteToFile("csgo_gc/unusual_loot_lists.txt")
+        && gcLootLists.WriteToFile("csgo_gc/gc_loot_lists.txt");
+}
+
+static uint64_t TournamentFixtureItemId(uint64_t steamId, uint32_t highItemId)
+{
+    return (static_cast<uint64_t>(highItemId) << 32) | (steamId & UINT32_MAX);
+}
+
+static bool ValidateTournamentActivationEvents(const std::vector<EventData> &events,
+    uint64_t consumedItemId, uint32_t journalMessageType, uint32_t expectedTokens,
+    uint64_t &journalItemId)
+{
+    size_t destroyIndex = events.size();
+    size_t journalIndex = events.size();
+    size_t notificationIndex = events.size();
+    CSOEconItem journal;
+    bool valid = true;
+
+    for (size_t i = 0; i < events.size(); i++)
+    {
+        const uint32_t type = static_cast<uint32_t>(events[i].id) & ~ProtobufMask;
+        if (type == k_ESOMsg_Destroy)
+        {
+            CMsgSOSingleObject object;
+            CSOEconItem consumed;
+            valid &= destroyIndex == events.size()
+                && ParseHostProtobuf(events[i], object)
+                && ParseItemObject(object, consumed)
+                && consumed.id() == consumedItemId;
+            destroyIndex = i;
+        }
+        else if (type == journalMessageType)
+        {
+            CMsgSOSingleObject object;
+            valid &= journalIndex == events.size()
+                && ParseHostProtobuf(events[i], object)
+                && ParseItemObject(object, journal)
+                && journal.def_index() == 200;
+            journalIndex = i;
+        }
+        else if (type == k_EMsgGCItemCustomizationNotification)
+        {
+            CMsgGCItemCustomizationNotification notification;
+            const bool parsed = ParseHostProtobuf(events[i], notification);
+            valid &= notificationIndex == events.size()
+                && parsed
+                && notification.request()
+                    == k_EGCItemCustomizationNotification_ActivateFanToken
+                && notification.item_id_size() == 1;
+            if (parsed && notification.item_id_size() == 1)
+            {
+                journalItemId = notification.item_id(0);
+            }
+            notificationIndex = i;
+        }
+    }
+
+    uint32_t tokenCount = 0;
+    valid &= destroyIndex < journalIndex
+        && journalIndex < notificationIndex
+        && journal.id() == journalItemId
+        && GetUint32Attribute(journal,
+            ItemSchema::AttributeOperationDropsAwardedPurchased, tokenCount)
+        && tokenCount == expectedTokens;
+    return valid;
+}
+
+static bool ViewerPassActivationCreatesAndPersistsJournal()
+{
+    constexpr uint64_t SteamId = 76561197960265729ull;
+    RemoveTournamentAccessFixtures();
+    if (!WriteTournamentAccessFixtures({ 100, 100 }))
+    {
+        RemoveTournamentAccessFixtures();
+        return false;
+    }
+
+    const uint64_t passId = TournamentFixtureItemId(SteamId, 1);
+    const uint64_t duplicatePassId = TournamentFixtureItemId(SteamId, 2);
+    uint64_t journalId = 0;
+    bool valid = true;
+    {
+        ClientGC gc{ SteamId };
+        CMsgUseItem request;
+        request.set_item_id(passId);
+        SendGCProtobuf(gc, k_EMsgGCUseItemRequest, request);
+
+        std::vector<EventData> events;
+        valid &= WaitForHostMessagesUntil(gc,
+            k_EMsgGCItemCustomizationNotification, events)
+            && ValidateTournamentActivationEvents(events, passId,
+                k_ESOMsg_Create, 0, journalId);
+
+        request.set_item_id(duplicatePassId);
+        SendGCProtobuf(gc, k_EMsgGCUseItemRequest, request);
+        valid &= HostMessageNotReceived(gc, k_EMsgGCItemCustomizationNotification);
+    }
+
+    {
+        Inventory persisted{ SteamId };
+        const CSOEconItem *journal = persisted.GetItem(journalId);
+        uint32_t stickerId = 0;
+        uint32_t campaignId = 0;
+        uint32_t completion = 0;
+        uint32_t purchased = 0;
+        uint32_t redeemed = 0;
+        valid &= !persisted.GetItem(passId)
+            && persisted.GetItem(duplicatePassId)
+            && journal
+            && journal->origin() == ItemOriginPurchased
+            && journal->inventory() == InventoryUnacknowledged(UnacknowledgedPurchased)
+            && GetUint32Attribute(*journal, ItemSchema::AttributeStickerId0, stickerId)
+            && stickerId == 6732
+            && GetUint32Attribute(*journal, ItemSchema::AttributeCampaignId, campaignId)
+            && campaignId == 15
+            && GetUint32Attribute(*journal,
+                ItemSchema::AttributeCampaignCompletionBitfield, completion)
+            && completion == 1
+            && GetUint32Attribute(*journal,
+                ItemSchema::AttributeOperationDropsAwardedPurchased, purchased)
+            && purchased == 0
+            && GetUint32Attribute(*journal,
+                ItemSchema::AttributeOperationDropsAwardedRedeemed, redeemed)
+            && redeemed == 0;
+    }
+
+    RemoveTournamentAccessFixtures();
+    return valid;
+}
+
+static bool ViewerPassTokenPacksUpdatePersistedJournal()
+{
+    constexpr uint64_t SteamId = 76561197960265729ull;
+    RemoveTournamentAccessFixtures();
+    if (!WriteTournamentAccessFixtures({ 101, 102 }))
+    {
+        RemoveTournamentAccessFixtures();
+        return false;
+    }
+
+    const uint64_t packId = TournamentFixtureItemId(SteamId, 1);
+    const uint64_t tokenId = TournamentFixtureItemId(SteamId, 2);
+    uint64_t journalId = 0;
+    bool valid = true;
+    {
+        ClientGC gc{ SteamId };
+        CMsgUseItem request;
+        request.set_item_id(packId);
+        SendGCProtobuf(gc, k_EMsgGCUseItemRequest, request);
+
+        std::vector<EventData> events;
+        valid &= WaitForHostMessagesUntil(gc,
+            k_EMsgGCItemCustomizationNotification, events)
+            && ValidateTournamentActivationEvents(events, packId,
+                k_ESOMsg_Create, 3, journalId);
+
+        request.set_item_id(tokenId);
+        SendGCProtobuf(gc, k_EMsgGCUseItemRequest, request);
+        events.clear();
+        uint64_t updatedJournalId = 0;
+        valid &= WaitForHostMessagesUntil(gc,
+            k_EMsgGCItemCustomizationNotification, events)
+            && ValidateTournamentActivationEvents(events, tokenId,
+                k_ESOMsg_Update, 4, updatedJournalId)
+            && updatedJournalId == journalId;
+    }
+
+    {
+        Inventory persisted{ SteamId };
+        const CSOEconItem *journal = persisted.GetItem(journalId);
+        uint32_t purchased = 0;
+        valid &= !persisted.GetItem(packId)
+            && !persisted.GetItem(tokenId)
+            && journal
+            && GetUint32Attribute(*journal,
+                ItemSchema::AttributeOperationDropsAwardedPurchased, purchased)
+            && purchased == 4;
+    }
+
+    RemoveTournamentAccessFixtures();
+    valid &= WriteTournamentAccessFixtures({ 102 });
+    if (valid)
+    {
+        ClientGC gc{ SteamId };
+        CMsgUseItem request;
+        request.set_item_id(TournamentFixtureItemId(SteamId, 1));
+        SendGCProtobuf(gc, k_EMsgGCUseItemRequest, request);
+        valid &= HostMessageNotReceived(gc, k_EMsgGCItemCustomizationNotification);
+    }
+    {
+        Inventory persisted{ SteamId };
+        valid &= persisted.GetItem(TournamentFixtureItemId(SteamId, 1)) != nullptr;
+    }
+
+    RemoveTournamentAccessFixtures();
+    return valid;
+}
+
 int main()
 {
     struct TestCase
@@ -1935,6 +2228,10 @@ int main()
         { "StorePurchasesFinalizeTransactionally", StorePurchasesFinalizeTransactionally },
         { "ServiceMedalsFollowBuildYearAndPersistPrestige",
             ServiceMedalsFollowBuildYearAndPersistPrestige },
+        { "ViewerPassActivationCreatesAndPersistsJournal",
+            ViewerPassActivationCreatesAndPersistsJournal },
+        { "ViewerPassTokenPacksUpdatePersistedJournal",
+            ViewerPassTokenPacksUpdatePersistedJournal },
     };
 
     bool allPassed = true;

--- a/csgo_gc/gc_message_tests.cpp
+++ b/csgo_gc/gc_message_tests.cpp
@@ -2201,6 +2201,49 @@ static bool ViewerPassTokenPacksUpdatePersistedJournal()
     return valid;
 }
 
+static bool SouvenirTokenInitializesMissingPurchasedCount()
+{
+    constexpr uint64_t SteamId = 76561197960265729ull;
+    RemoveTournamentAccessFixtures();
+    if (!WriteTournamentAccessFixtures({ 200, 102 }))
+    {
+        RemoveTournamentAccessFixtures();
+        return false;
+    }
+
+    const uint64_t journalId = TournamentFixtureItemId(SteamId, 1);
+    const uint64_t tokenId = TournamentFixtureItemId(SteamId, 2);
+    bool valid = true;
+    {
+        ClientGC gc{ SteamId };
+        CMsgUseItem request;
+        request.set_item_id(tokenId);
+        SendGCProtobuf(gc, k_EMsgGCUseItemRequest, request);
+
+        std::vector<EventData> events;
+        uint64_t updatedJournalId = 0;
+        valid &= WaitForHostMessagesUntil(gc,
+            k_EMsgGCItemCustomizationNotification, events)
+            && ValidateTournamentActivationEvents(events, tokenId,
+                k_ESOMsg_Update, 1, updatedJournalId)
+            && updatedJournalId == journalId;
+    }
+
+    {
+        Inventory persisted{ SteamId };
+        const CSOEconItem *journal = persisted.GetItem(journalId);
+        uint32_t purchased = 0;
+        valid &= !persisted.GetItem(tokenId)
+            && journal
+            && GetUint32Attribute(*journal,
+                ItemSchema::AttributeOperationDropsAwardedPurchased, purchased)
+            && purchased == 1;
+    }
+
+    RemoveTournamentAccessFixtures();
+    return valid;
+}
+
 static bool RequestEventFavorites(ClientGC &gc, bool allEvents, uint64_t jobId,
     std::string_view expectedFavorites)
 {
@@ -2298,6 +2341,8 @@ int main()
             ViewerPassActivationCreatesAndPersistsJournal },
         { "ViewerPassTokenPacksUpdatePersistedJournal",
             ViewerPassTokenPacksUpdatePersistedJournal },
+        { "SouvenirTokenInitializesMissingPurchasedCount",
+            SouvenirTokenInitializesMissingPurchasedCount },
         { "EventFavoritesPersistAndPreserveRequestJobs",
             EventFavoritesPersistAndPreserveRequestJobs },
     };

--- a/csgo_gc/inventory.cpp
+++ b/csgo_gc/inventory.cpp
@@ -956,9 +956,19 @@ bool Inventory::ActivateTournamentAccessItem(ItemMap::iterator accessItem,
     else
     {
         previousJournal = journal->second;
-        CSOEconItemAttribute *purchased = FindOrAddAttribute(journal->second,
+        CSOEconItemAttribute *purchased = FindAttribute(journal->second,
             ItemSchema::AttributeOperationDropsAwardedPurchased);
-        const uint32_t tokenCount = m_itemSchema.AttributeUint32(purchased);
+        uint32_t tokenCount = 0;
+        if (purchased)
+        {
+            tokenCount = m_itemSchema.AttributeUint32(purchased);
+        }
+        else
+        {
+            purchased = FindOrAddAttribute(journal->second,
+                ItemSchema::AttributeOperationDropsAwardedPurchased);
+            m_itemSchema.SetAttributeUint32(purchased, 0);
+        }
         if (tokenCount == UINT32_MAX)
         {
             return false;

--- a/csgo_gc/inventory.cpp
+++ b/csgo_gc/inventory.cpp
@@ -816,16 +816,19 @@ bool Inventory::RemoveItem(uint64_t itemId, CMsgSOSingleObject &response)
     return true;
 }
 
-bool Inventory::UseItem(uint64_t itemId,
-    CMsgSOSingleObject &destroy,
-    CMsgSOMultipleObjects &updateMultiple,
-    CMsgGCItemCustomizationNotification &notification)
+bool Inventory::UseItem(uint64_t itemId, UseItemResult &result)
 {
     auto it = m_items.find(itemId);
     if (it == m_items.end())
     {
         assert(false);
         return false;
+    }
+
+    if (std::optional<TournamentAccessInfo> access
+        = m_itemSchema.TournamentAccessByDefIndex(it->second.def_index()))
+    {
+        return ActivateTournamentAccessItem(it, *access, result);
     }
 
     if (it->second.def_index() != ItemSchema::ItemSpray)
@@ -839,10 +842,10 @@ bool Inventory::UseItem(uint64_t itemId,
     unsealed.set_def_index(ItemSchema::ItemSprayPaint);
 
     // remove the sealed spray from our inventory
-    DestroyItem(it, destroy);
+    DestroyItem(it, result.destroy);
 
     // equip the new spray, this will also unequip the old one if we had one
-    EquipItem(unsealed.id(), 0, ItemSchema::LoadoutSlotGraffiti, false, updateMultiple);
+    EquipItem(unsealed.id(), 0, ItemSchema::LoadoutSlotGraffiti, false, result.updateMultiple);
 
     // remove this to have unlimited sprays
     CSOEconItemAttribute *attribute = unsealed.add_attribute();
@@ -850,10 +853,85 @@ bool Inventory::UseItem(uint64_t itemId,
     m_itemSchema.SetAttributeUint32(attribute, 50);
 
     // set notification
-    notification.add_item_id(unsealed.id());
-    notification.set_request(k_EGCItemCustomizationNotification_GraffitiUnseal);
+    result.notification.add_item_id(unsealed.id());
+    result.notification.set_request(k_EGCItemCustomizationNotification_GraffitiUnseal);
 
     return true;
+}
+
+bool Inventory::ActivateTournamentAccessItem(ItemMap::iterator accessItem,
+    const TournamentAccessInfo &access, UseItemResult &result)
+{
+    auto journal = std::find_if(m_items.begin(), m_items.end(), [&](const auto &pair) {
+        return pair.second.def_index() == access.journalDefIndex;
+    });
+
+    const bool createsJournal = access.type != TournamentAccessType::Token;
+    if ((createsJournal && journal != m_items.end())
+        || (!createsJournal && journal == m_items.end()))
+    {
+        return false;
+    }
+
+    const uint64_t previousVersion = m_version;
+    const uint32_t previousLastHighItemId = m_lastHighItemId;
+    const CSOEconItem previousAccessItem = accessItem->second;
+    CSOEconItem previousJournal;
+
+    if (createsJournal)
+    {
+        CSOEconItem &created = CreateItem(access.journalDefIndex,
+            ItemOriginPurchased, UnacknowledgedPurchased);
+        journal = m_items.find(created.id());
+        accessItem = m_items.find(previousAccessItem.id());
+
+        if (access.includedTokens)
+        {
+            CSOEconItemAttribute *purchased = FindOrAddAttribute(created,
+                ItemSchema::AttributeOperationDropsAwardedPurchased);
+            m_itemSchema.SetAttributeUint32(purchased, access.includedTokens);
+        }
+
+        result.itemChange = UseItemChange::Create;
+    }
+    else
+    {
+        previousJournal = journal->second;
+        CSOEconItemAttribute *purchased = FindOrAddAttribute(journal->second,
+            ItemSchema::AttributeOperationDropsAwardedPurchased);
+        const uint32_t tokenCount = m_itemSchema.AttributeUint32(purchased);
+        if (tokenCount == UINT32_MAX)
+        {
+            return false;
+        }
+        m_itemSchema.SetAttributeUint32(purchased, tokenCount + 1);
+        result.itemChange = UseItemChange::Update;
+    }
+
+    const uint64_t journalId = journal->second.id();
+    DestroyItem(accessItem, result.destroy);
+    ToSingleObject(result.itemData, journal->second);
+    result.notification.add_item_id(journalId);
+    result.notification.set_request(k_EGCItemCustomizationNotification_ActivateFanToken);
+
+    if (WriteToFile())
+    {
+        return true;
+    }
+
+    m_items.emplace(previousAccessItem.id(), previousAccessItem);
+    if (createsJournal)
+    {
+        m_items.erase(journalId);
+    }
+    else
+    {
+        m_items.at(journalId) = previousJournal;
+    }
+    m_version = previousVersion;
+    m_lastHighItemId = previousLastHighItemId;
+    result = UseItemResult{};
+    return false;
 }
 
 bool Inventory::UnlockCrate(uint64_t crateId,

--- a/csgo_gc/inventory.cpp
+++ b/csgo_gc/inventory.cpp
@@ -423,6 +423,19 @@ void Inventory::ReadFromFile()
         }
     }
 
+    const KeyValue *eventFavoritesKey = inventoryKey.GetSubkey("event_favorites");
+    if (eventFavoritesKey)
+    {
+        for (const KeyValue &favoriteKey : *eventFavoritesKey)
+        {
+            const uint64_t eventId = FromString<uint64_t>(favoriteKey.Name());
+            if (eventId)
+            {
+                m_eventFavorites.insert(eventId);
+            }
+        }
+    }
+
     LogInventoryConsistency();
 }
 
@@ -519,6 +532,14 @@ bool Inventory::WriteToFile() const
         }
     }
 
+    {
+        KeyValue &eventFavoritesKey = inventoryKey.AddSubkey("event_favorites");
+        for (uint64_t eventId : m_eventFavorites)
+        {
+            eventFavoritesKey.AddNumber(std::to_string(eventId), 1);
+        }
+    }
+
     if (!inventoryKey.WriteToFile(InventoryFilePath))
     {
         Platform::Print("Inventory: failed to save %s; original file was preserved\n", InventoryFilePath);
@@ -526,6 +547,44 @@ bool Inventory::WriteToFile() const
     }
 
     return true;
+}
+
+bool Inventory::SetEventFavorite(uint64_t eventId, bool favorite)
+{
+    if (!eventId)
+    {
+        return false;
+    }
+
+    const bool wasFavorite = m_eventFavorites.contains(eventId);
+    if (wasFavorite == favorite)
+    {
+        return true;
+    }
+
+    if (favorite)
+    {
+        m_eventFavorites.insert(eventId);
+    }
+    else
+    {
+        m_eventFavorites.erase(eventId);
+    }
+
+    if (WriteToFile())
+    {
+        return true;
+    }
+
+    if (wasFavorite)
+    {
+        m_eventFavorites.insert(eventId);
+    }
+    else
+    {
+        m_eventFavorites.erase(eventId);
+    }
+    return false;
 }
 
 void Inventory::WriteItem(KeyValue &itemKey, const CSOEconItem &item) const

--- a/csgo_gc/inventory.h
+++ b/csgo_gc/inventory.h
@@ -218,6 +218,8 @@ public:
         std::string &error);
     size_t ItemCount() const { return m_items.size(); }
     const ItemMap &Items() const { return m_items; }
+    const std::set<uint64_t> &EventFavorites() const { return m_eventFavorites; }
+    bool SetEventFavorite(uint64_t eventId, bool favorite);
     bool Save() const { return WriteToFile(); }
 
 private:
@@ -294,5 +296,6 @@ private:
     uint32_t m_lastHighItemId{};
     ItemMap m_items;
     std::vector<CSOEconDefaultEquippedDefinitionInstanceClient> m_defaultEquips;
+    std::set<uint64_t> m_eventFavorites;
     bool m_saveEnabled{ true };
 };

--- a/csgo_gc/inventory.h
+++ b/csgo_gc/inventory.h
@@ -73,10 +73,23 @@ public:
 
     bool RemoveItem(uint64_t itemId, CMsgSOSingleObject &destroy);
 
-    bool UseItem(uint64_t itemId,
-        CMsgSOSingleObject &destroy,
-        CMsgSOMultipleObjects &updateMultiple,
-        CMsgGCItemCustomizationNotification &notification);
+    enum class UseItemChange
+    {
+        None,
+        Create,
+        Update
+    };
+
+    struct UseItemResult
+    {
+        CMsgSOSingleObject destroy;
+        CMsgSOSingleObject itemData;
+        CMsgSOMultipleObjects updateMultiple;
+        CMsgGCItemCustomizationNotification notification;
+        UseItemChange itemChange{ UseItemChange::None };
+    };
+
+    bool UseItem(uint64_t itemId, UseItemResult &result);
 
     bool UnlockCrate(uint64_t crateId,
         uint64_t keyId,
@@ -230,6 +243,8 @@ private:
     void UnequipSlotForClass(uint32_t classId, uint32_t slotId, CMsgSOMultipleObjects &update);
 
     void DestroyItem(ItemMap::iterator iterator, CMsgSOSingleObject &message);
+    bool ActivateTournamentAccessItem(ItemMap::iterator accessItem,
+        const TournamentAccessInfo &access, UseItemResult &result);
 
     // move this to the item schema maybe?
     void ItemToPreviewDataBlock(const CSOEconItem &item, CEconItemPreviewDataBlock &block);

--- a/csgo_gc/item_schema.cpp
+++ b/csgo_gc/item_schema.cpp
@@ -149,16 +149,16 @@ ItemSchema::ItemSchema(bool loadFiles)
         return;
     }
 
-    const KeyValue *itemsKey = itemsGame->GetSubkey("items");
-    if (itemsKey)
-    {
-        ParseItems(itemsKey, itemsGame->GetSubkey("prefabs"));
-    }
-
     const KeyValue *attributesKey = itemsGame->GetSubkey("attributes");
     if (attributesKey)
     {
         ParseAttributes(attributesKey);
+    }
+
+    const KeyValue *itemsKey = itemsGame->GetSubkey("items");
+    if (itemsKey)
+    {
+        ParseItems(itemsKey, itemsGame->GetSubkey("prefabs"));
     }
 
     const KeyValue *stickerKitsKey = itemsGame->GetSubkey("sticker_kits");
@@ -693,6 +693,42 @@ bool ItemSchema::CreateItem(uint32_t defIndex, ItemOrigin origin, Unacknowledged
     econItem.set_in_use(false);
     econItem.set_rarity(itemInfo.m_rarity);
 
+    return ApplyGeneratedAttributes(itemInfo, econItem);
+}
+
+bool ItemSchema::ApplyGeneratedAttributes(const ItemInfo &info, CSOEconItem &item) const
+{
+    for (const GeneratedItemAttribute &generated : info.m_generatedAttributes)
+    {
+        auto attributeInfo = m_attributeInfo.find(generated.defIndex);
+        if (attributeInfo == m_attributeInfo.end())
+        {
+            return false;
+        }
+
+        CSOEconItemAttribute *attribute = item.add_attribute();
+        attribute->set_def_index(generated.defIndex);
+
+        bool applied = false;
+        switch (attributeInfo->second.m_type)
+        {
+        case AttributeType::Float:
+            applied = SetAttributeFloat(attribute, FromString<float>(generated.value));
+            break;
+        case AttributeType::Uint32:
+            applied = SetAttributeUint32(attribute, FromString<uint32_t>(generated.value));
+            break;
+        case AttributeType::String:
+            applied = SetAttributeString(attribute, generated.value);
+            break;
+        }
+
+        if (!applied)
+        {
+            return false;
+        }
+    }
+
     return true;
 }
 
@@ -712,6 +748,11 @@ void ItemSchema::ParseItems(const KeyValue *itemsKey, const KeyValue *prefabsKey
         auto emplace = m_itemInfo.try_emplace(defIndex, defIndex);
 
         ParseItemRecursive(emplace.first->second, itemKey, prefabsKey);
+
+        if (!emplace.first->second.m_name.empty())
+        {
+            m_itemDefIndexByName[emplace.first->second.m_name] = defIndex;
+        }
 
         // FIXME: remove, temp slop to make sure we parse correctly
         auto &itemInfo = emplace.first->second;
@@ -924,6 +965,36 @@ void ItemSchema::ParseItemRecursive(ItemInfo &info, const KeyValue &itemKey, con
         parseTournamentAttribute("tournament event team0 id", info.m_tournament.team0Id);
         parseTournamentAttribute("tournament event team1 id", info.m_tournament.team1Id);
         parseTournamentAttribute("tournament mvp account id", info.m_tournament.mvpAccountId);
+
+        for (const KeyValue &attribute : *attributes)
+        {
+            if (!attribute.GetNumber<int>("force_gc_to_generate"))
+            {
+                continue;
+            }
+
+            auto defIndex = m_attributeDefIndexByName.find(std::string{ attribute.Name() });
+            if (defIndex == m_attributeDefIndexByName.end())
+            {
+                Platform::Print("Unknown generated attribute '%s' for item %u\n",
+                    std::string{ attribute.Name() }.c_str(), info.m_defIndex);
+                continue;
+            }
+
+            const std::string value{ attribute.GetString("value") };
+            auto existing = std::find_if(info.m_generatedAttributes.begin(),
+                info.m_generatedAttributes.end(), [&](const GeneratedItemAttribute &generated) {
+                    return generated.defIndex == defIndex->second;
+                });
+            if (existing != info.m_generatedAttributes.end())
+            {
+                existing->value = value;
+            }
+            else
+            {
+                info.m_generatedAttributes.push_back({ defIndex->second, value });
+            }
+        }
     }
 }
 
@@ -936,6 +1007,12 @@ void ItemSchema::ParseAttributes(const KeyValue *attributesKey)
         uint32_t defIndex = FromString<uint32_t>(attributeKey.Name());
         assert(defIndex);
         m_attributeInfo.try_emplace(defIndex, attributeKey);
+
+        std::string_view name = attributeKey.GetString("name");
+        if (!name.empty())
+        {
+            m_attributeDefIndexByName[std::string{ name }] = defIndex;
+        }
     }
 }
 
@@ -1297,19 +1374,15 @@ void ItemSchema::ParseRevolvingLootLists(const KeyValue *revolvingLootListsKey)
     }
 }
 
-ItemInfo *ItemSchema::ItemInfoByName(std::string_view name)
+const ItemInfo *ItemSchema::ItemInfoByName(std::string_view name) const
 {
-    for (auto &pair : m_itemInfo)
+    auto defIndex = m_itemDefIndexByName.find(std::string{ name });
+    if (defIndex == m_itemDefIndexByName.end())
     {
-        const ItemInfo &info = pair.second;
-        if (info.m_name == name)
-        {
-            return &pair.second;
-        }
+        return nullptr;
     }
 
-    assert(false);
-    return nullptr;
+    return ItemInfoByDefIndex(defIndex->second);
 }
 
 const ItemInfo *ItemSchema::ItemInfoByDefIndex(uint32_t defIndex) const
@@ -1321,6 +1394,55 @@ const ItemInfo *ItemSchema::ItemInfoByDefIndex(uint32_t defIndex) const
     }
 
     return &it->second;
+}
+
+std::optional<TournamentAccessInfo> ItemSchema::TournamentAccessByDefIndex(uint32_t defIndex) const
+{
+    const ItemInfo *accessItem = ItemInfoByDefIndex(defIndex);
+    if (!accessItem || !accessItem->m_tournament.eventId
+        || !accessItem->m_name.starts_with("tournament_pass_"))
+    {
+        return std::nullopt;
+    }
+
+    if (std::find(accessItem->m_prefabs.begin(), accessItem->m_prefabs.end(), "fan_token")
+        == accessItem->m_prefabs.end())
+    {
+        return std::nullopt;
+    }
+
+    TournamentAccessInfo result;
+    result.eventId = accessItem->m_tournament.eventId;
+
+    std::string_view suffix = std::string_view{ accessItem->m_name }.substr(
+        std::string_view{ "tournament_pass_" }.size());
+    if (suffix.ends_with("_charge"))
+    {
+        result.type = TournamentAccessType::Token;
+        suffix.remove_suffix(std::string_view{ "_charge" }.size());
+    }
+    else if (suffix.ends_with("_pack"))
+    {
+        result.type = TournamentAccessType::PassWithTokens;
+        result.includedTokens = 3;
+        suffix.remove_suffix(std::string_view{ "_pack" }.size());
+    }
+    else
+    {
+        result.type = TournamentAccessType::Pass;
+    }
+
+    const std::string journalName = std::string{ "tournament_journal_" } + std::string{ suffix };
+    const ItemInfo *journal = ItemInfoByName(journalName);
+    if (!journal || journal->m_tournament.eventId != result.eventId
+        || std::find(journal->m_prefabs.begin(), journal->m_prefabs.end(), "fan_shield")
+            == journal->m_prefabs.end())
+    {
+        return std::nullopt;
+    }
+
+    result.journalDefIndex = journal->m_defIndex;
+    return result;
 }
 
 StickerKitInfo *ItemSchema::MutableStickerKitInfoByName(std::string_view name)

--- a/csgo_gc/item_schema.h
+++ b/csgo_gc/item_schema.h
@@ -29,6 +29,27 @@ struct TournamentMetadata
     uint32_t mvpAccountId{};
 };
 
+struct GeneratedItemAttribute
+{
+    uint32_t defIndex{};
+    std::string value;
+};
+
+enum class TournamentAccessType
+{
+    Pass,
+    PassWithTokens,
+    Token
+};
+
+struct TournamentAccessInfo
+{
+    TournamentAccessType type{};
+    uint32_t eventId{};
+    uint32_t journalDefIndex{};
+    uint32_t includedTokens{};
+};
+
 class ItemInfo
 {
 public:
@@ -45,6 +66,7 @@ public:
     TournamentMetadata m_tournament;
     std::string m_itemType;
     std::vector<std::string> m_prefabs;
+    std::vector<GeneratedItemAttribute> m_generatedAttributes;
     std::string m_toolRestriction;
     bool m_canSticker;
     bool m_canPatch;
@@ -174,6 +196,8 @@ public:
 
     // trade-up helpers
     const ItemInfo *ItemInfoByDefIndex(uint32_t defIndex) const;
+    const ItemInfo *ItemInfoByName(std::string_view name) const;
+    std::optional<TournamentAccessInfo> TournamentAccessByDefIndex(uint32_t defIndex) const;
     const PaintKitInfo *PaintKitInfoByDefIndex(uint32_t defIndex) const;
     const StickerKitInfo *StickerKitInfoByDefIndex(uint32_t defIndex) const;
     const MusicDefinitionInfo *MusicDefinitionInfoByDefIndex(uint32_t defIndex) const;
@@ -293,9 +317,15 @@ public:
         AttributeMusicId = 166,
         AttributeQuestId = 168,
 
+        AttributeCampaignId = 184,
+        AttributeCampaignCompletionBitfield = 185,
+
         AttributeSpraysRemaining = 232,
         AttributeSprayTintId = 233,
+        AttributeOperationDropsAwardedPurchased = 237,
+        AttributeOperationDropsAwardedRedeemed = 240,
 
+        AttributeUpgradeLevel = 268,
         AttributeCasketItemsCount = 270,
         AttributeCasketModificationDate = 271,
         AttributeCasketIdLow = 272,
@@ -323,15 +353,17 @@ private:
     void ParseRevolvingLootLists(const KeyValue *revolvingLootListsKey);
 
     bool ParseLootListItem(LootListItem &item, std::string_view name);
+    bool ApplyGeneratedAttributes(const ItemInfo &info, CSOEconItem &item) const;
 
     // internal slop
-    ItemInfo *ItemInfoByName(std::string_view name);
     StickerKitInfo *MutableStickerKitInfoByName(std::string_view name);
     PaintKitInfo *PaintKitInfoByName(std::string_view name);
     MusicDefinitionInfo *MusicDefinitionInfoByName(std::string_view name);
 
     std::unordered_map<uint32_t, ItemInfo> m_itemInfo;
     std::unordered_map<uint32_t, AttributeInfo> m_attributeInfo;
+    std::unordered_map<std::string, uint32_t> m_itemDefIndexByName;
+    std::unordered_map<std::string, uint32_t> m_attributeDefIndexByName;
 
     std::unordered_map<std::string, StickerKitInfo> m_stickerKitInfo;
     std::unordered_map<std::string, PaintKitInfo> m_paintKitInfo;

--- a/csgo_gc/item_schema_tests.cpp
+++ b/csgo_gc/item_schema_tests.cpp
@@ -144,6 +144,102 @@ public:
             && schema.PrestigeMedalDefIndexes(2023) == expected;
     }
 
+    bool ParseTournamentAccessItems()
+    {
+        KeyValue attributes{ "attributes" };
+        auto addIntegerAttribute = [&](uint32_t defIndex, const char *name)
+        {
+            KeyValue &attribute = attributes.AddSubkey(std::to_string(defIndex));
+            attribute.AddString("name", name);
+            attribute.AddNumber("stored_as_integer", 1);
+        };
+        addIntegerAttribute(ItemSchema::AttributeStickerId0, "sticker slot 0 id");
+        addIntegerAttribute(ItemSchema::AttributeTournamentEventId, "tournament event id");
+        addIntegerAttribute(ItemSchema::AttributeCampaignCompletionBitfield,
+            "campaign completion bitfield");
+        addIntegerAttribute(ItemSchema::AttributeOperationDropsAwardedPurchased,
+            "operation drops awarded 1");
+        addIntegerAttribute(ItemSchema::AttributeOperationDropsAwardedRedeemed,
+            "operation drops awarded 0");
+        schema.ParseAttributes(&attributes);
+
+        KeyValue prefabs{ "prefabs" };
+        prefabs.AddSubkey("fan_token");
+        prefabs.AddSubkey("fan_shield");
+
+        KeyValue &passPrefab = prefabs.AddSubkey("paris_pass");
+        passPrefab.AddString("prefab", "fan_token");
+        KeyValue &passEvent = passPrefab.AddSubkey("attributes")
+            .AddSubkey("tournament event id");
+        passEvent.AddNumber("value", 21);
+
+        KeyValue &journalPrefab = prefabs.AddSubkey("paris_journal");
+        journalPrefab.AddString("prefab", "fan_shield");
+        KeyValue &journalAttributes = journalPrefab.AddSubkey("attributes");
+        journalAttributes.AddSubkey("tournament event id").AddNumber("value", 21);
+        auto addGenerated = [&](const char *name, uint32_t value)
+        {
+            KeyValue &attribute = journalAttributes.AddSubkey(name);
+            attribute.AddNumber("value", value);
+            attribute.AddNumber("force_gc_to_generate", 1);
+        };
+        addGenerated("sticker slot 0 id", 6732);
+        addGenerated("campaign completion bitfield", 1);
+        addGenerated("operation drops awarded 1", 0);
+        addGenerated("operation drops awarded 0", 0);
+
+        KeyValue items{ "items" };
+        auto addItem = [&](const char *defIndex, const char *name, const char *prefab)
+        {
+            KeyValue &item = items.AddSubkey(defIndex);
+            item.AddString("name", name);
+            item.AddString("prefab", prefab);
+        };
+        addItem("100", "tournament_pass_paris2023", "paris_pass");
+        addItem("101", "tournament_pass_paris2023_pack", "paris_pass");
+        addItem("102", "tournament_pass_paris2023_charge", "paris_pass");
+        addItem("200", "tournament_journal_paris2023", "paris_journal");
+        schema.ParseItems(&items, &prefabs);
+
+        auto pass = schema.TournamentAccessByDefIndex(100);
+        auto pack = schema.TournamentAccessByDefIndex(101);
+        auto token = schema.TournamentAccessByDefIndex(102);
+        if (!pass || !pack || !token
+            || pass->type != TournamentAccessType::Pass
+            || pack->type != TournamentAccessType::PassWithTokens
+            || pack->includedTokens != 3
+            || token->type != TournamentAccessType::Token
+            || pass->eventId != 21 || pass->journalDefIndex != 200
+            || pack->journalDefIndex != 200 || token->journalDefIndex != 200)
+        {
+            return false;
+        }
+
+        CSOEconItem journal;
+        if (!schema.CreateItem(200, ItemOriginPurchased, UnacknowledgedPurchased, journal))
+        {
+            return false;
+        }
+
+        auto generatedValue = [&](uint32_t defIndex) -> std::optional<uint32_t>
+        {
+            for (const CSOEconItemAttribute &attribute : journal.attribute())
+            {
+                if (attribute.def_index() == defIndex)
+                {
+                    return schema.AttributeUint32(&attribute);
+                }
+            }
+            return std::nullopt;
+        };
+
+        return journal.attribute_size() == 4
+            && generatedValue(ItemSchema::AttributeStickerId0) == 6732
+            && generatedValue(ItemSchema::AttributeCampaignCompletionBitfield) == 1
+            && generatedValue(ItemSchema::AttributeOperationDropsAwardedPurchased) == 0
+            && generatedValue(ItemSchema::AttributeOperationDropsAwardedRedeemed) == 0;
+    }
+
     ItemSchema schema;
 };
 
@@ -193,6 +289,12 @@ static bool PrestigeMedalsUseSchemaYearAndSortedDefIndexes()
     return fixture.ParsePrestigeMedals();
 }
 
+static bool TournamentAccessUsesSchemaMetadataAndGeneratedAttributes()
+{
+    ItemSchemaTestFixture fixture;
+    return fixture.ParseTournamentAccessItems();
+}
+
 int main()
 {
     if (!TournamentStickerCapsuleIsNotSouvenir())
@@ -218,6 +320,11 @@ int main()
     if (!PrestigeMedalsUseSchemaYearAndSortedDefIndexes())
     {
         return 5;
+    }
+
+    if (!TournamentAccessUsesSchemaMetadataAndGeneratedAttributes())
+    {
+        return 6;
     }
 
     return 0;


### PR DESCRIPTION
## Summary

- Parse schema-driven GC-generated attributes for tournament Journals/Coins and map Viewer Pass, Pass + 3 Token pack, and Souvenir Token definitions to their matching Journal.
- Activate tournament access items transactionally: consume the source item, create or update the Journal, persist the inventory, publish ordered SO changes, and send the `ActivateFanToken` customization notification.
- Persist tournament Event Favorites and handle the 9200/9201/9203 message flow with the request job ID preserved.

## Implemented scope

- Viewer Pass activation.
- Viewer Pass + 3 Souvenir Tokens activation.
- Separate Souvenir Token activation for an existing matching Coin/Journal.
- Schema-generated Journal/Coin attributes and inventory persistence.
- Correct destroy/create-or-update/notification ordering.
- Persistent Event Favorites add/remove/query support.

## Not implemented yet

- Pick'Em requests, uploads, validation, or scoring.
- Historical tournament schedules and match catalogs.
- Match-based Souvenir Token redemption and souvenir package creation.
- Live GOTV, Steam.tv, or event chat services.
- Automatic historical Coin upgrades based on completed challenges.

These deferred features require historical tournament data or external/live services beyond local GC inventory state.

## Validation

- Built `item_schema_tests` and `gc_message_tests` in the configured x86 Release build.
- Ran the full configured CTest suite: 6/6 tests passed.
- Linked `csgo_gc.dll` successfully in a fresh x86 Release verification build.

Progress on #74.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for activating tournament passes, tokens, and access items.
  - Automatically creates or updates tournament journals and initializes related token counts.
  - Added event favorites with persistence, removal, and querying support.
  - Added generated item attributes during item creation.

- **Bug Fixes**
  - Improved inventory updates and notifications after item use.
  - Added rollback protection when inventory changes cannot be saved.
  - Improved handling of missing or invalid tournament item data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->