### PR TITLE
Prevent duplicate stats subscription items

### DIFF
--- a/csgo_gc/gc_client.cpp
+++ b/csgo_gc/gc_client.cpp
@@ -1851,12 +1851,18 @@ void ClientGC::StorePurchaseInit(GCMessageRead &messageRead)
     std::vector<PendingStoreLineItem> lineItems;
     lineItems.reserve(message.line_items_size());
     uint64_t itemCount = 0;
+    bool includesStatsSubscription = false;
     for (const CGCStorePurchaseInit_LineItem &item : message.line_items())
     {
         itemCount += item.quantity();
+        const bool isStatsSubscription
+            = item.item_def_id() == ItemSchema::ItemStatsSubscription;
         if (!item.has_item_def_id() || !item.quantity()
             || itemCount > MaxStorePurchaseItems
-            || !m_inventory.GetItemSchema().ItemInfoByDefIndex(item.item_def_id()))
+            || !m_inventory.GetItemSchema().ItemInfoByDefIndex(item.item_def_id())
+            || (isStatsSubscription
+                && (item.quantity() != 1 || includesStatsSubscription
+                    || m_inventory.HasItemDefinition(ItemSchema::ItemStatsSubscription))))
         {
             Platform::Print("StorePurchaseInit rejected line item: def %u, quantity %u, total %llu\n",
                 item.item_def_id(), item.quantity(), itemCount);
@@ -1865,6 +1871,7 @@ void ClientGC::StorePurchaseInit(GCMessageRead &messageRead)
             return;
         }
 
+        includesStatsSubscription |= isStatsSubscription;
         lineItems.push_back({ item.item_def_id(), item.quantity() });
     }
 

--- a/csgo_gc/gc_message_tests.cpp
+++ b/csgo_gc/gc_message_tests.cpp
@@ -479,6 +479,70 @@ static bool InventoryPersistenceProtectsFiles()
     return preserved && validEmptyInventory;
 }
 
+static bool StatsSubscriptionDuplicatesKeepNewest()
+{
+    constexpr uint64_t SteamId = 76561197960265729ull;
+    constexpr uint32_t AccountId = SteamId & UINT32_MAX;
+    constexpr uint64_t OldSubscriptionId = (uint64_t{ 3 } << 32) | AccountId;
+    constexpr uint64_t NewSubscriptionId = (uint64_t{ 9 } << 32) | AccountId;
+    constexpr uint64_t OtherItemId = (uint64_t{ 6 } << 32) | AccountId;
+    constexpr const char *InventoryPath = "csgo_gc/inventory.txt";
+
+    TestFilesystem::RemoveFile(InventoryPath);
+    if (!TestFilesystem::MakeDirectory("csgo_gc"))
+    {
+        return false;
+    }
+
+    KeyValue inventoryKey{ "inventory" };
+    inventoryKey.AddNumber("format_version", 1);
+    KeyValue &items = inventoryKey.AddSubkey("items");
+    auto addItem = [&](uint32_t highItemId, uint32_t defIndex, uint32_t position) {
+        KeyValue &item = items.AddSubkey(std::to_string(highItemId));
+        item.AddNumber("def_index", defIndex);
+        item.AddNumber("inventory", position);
+    };
+    addItem(3, ItemSchema::ItemStatsSubscription, 30);
+    addItem(6, 7, 60);
+    addItem(9, ItemSchema::ItemStatsSubscription, 90);
+    if (!inventoryKey.WriteToFile(InventoryPath))
+    {
+        TestFilesystem::RemoveFile(InventoryPath);
+        TestFilesystem::RemoveDirectory("csgo_gc");
+        return false;
+    }
+
+    bool valid = true;
+    {
+        Inventory inventory{ SteamId };
+        const CSOEconItem *newSubscription = inventory.GetItem(NewSubscriptionId);
+        valid &= inventory.ItemCount() == 2
+            && !inventory.GetItem(OldSubscriptionId)
+            && newSubscription
+            && newSubscription->def_index() == ItemSchema::ItemStatsSubscription
+            && newSubscription->inventory() == 90
+            && inventory.GetItem(OtherItemId);
+    }
+
+    KeyValue persisted{ "inventory" };
+    const KeyValue *persistedItems = nullptr;
+    valid &= persisted.ParseFromFile(InventoryPath);
+    if (valid)
+    {
+        persistedItems = persisted.GetSubkey("items");
+        valid &= persistedItems
+            && persistedItems->SubkeyCount() == 2
+            && !persistedItems->GetSubkey("3")
+            && persistedItems->GetSubkey("6")
+            && persistedItems->GetSubkey("9")
+            && persistedItems->GetSubkey("9")->GetNumber<uint32_t>("inventory") == 90;
+    }
+
+    TestFilesystem::RemoveFile(InventoryPath);
+    TestFilesystem::RemoveDirectory("csgo_gc");
+    return valid;
+}
+
 static int EquippedSlotForClass(const CSOEconItem &item, uint32_t classId)
 {
     int slot = -1;
@@ -1324,6 +1388,8 @@ static bool WriteStoreFixtures()
     KeyValue &crate = items.AddSubkey("8");
     crate.AddString("name", "crate_test");
     crate.AddString("loot_list_name", "crate_test");
+    items.AddSubkey(std::to_string(ItemSchema::ItemStatsSubscription))
+        .AddString("name", "subscription1");
 
     KeyValue unusualLootLists{ "unusual_loot_lists" };
     unusualLootLists.AddSubkey("empty");
@@ -1508,6 +1574,110 @@ static bool StorePurchasesFinalizeTransactionally()
         valid &= WaitForHostMessage(gc, k_EMsgGCStorePurchaseFinalizeResponse, event)
             && ParseHostProtobuf(event, finalizeResponse)
             && finalizeResponse.result() != 1;
+    }
+
+    RemoveStoreFixtures();
+    return valid;
+}
+
+static bool StatsSubscriptionPurchasesRejectDuplicates()
+{
+    constexpr uint64_t SteamId = 76561197960265729ull;
+    RemoveStoreFixtures();
+    if (!WriteStoreFixtures())
+    {
+        RemoveStoreFixtures();
+        return false;
+    }
+
+    bool valid = true;
+    uint64_t subscriptionItemId = 0;
+    {
+        ClientGC gc{ SteamId };
+        EventData event;
+        CMsgGCStorePurchaseInitResponse initResponse;
+
+        CMsgGCStorePurchaseInit invalidQuantity;
+        CGCStorePurchaseInit_LineItem *lineItem = invalidQuantity.add_line_items();
+        lineItem->set_item_def_id(ItemSchema::ItemStatsSubscription);
+        lineItem->set_quantity(2);
+        SendGCProtobuf(gc, k_EMsgGCStorePurchaseInit, invalidQuantity);
+        valid &= WaitForHostMessage(gc, k_EMsgGCStorePurchaseInitResponse, event)
+            && ParseHostProtobuf(event, initResponse)
+            && initResponse.result() != 1
+            && initResponse.item_ids_size() == 0;
+
+        CMsgGCStorePurchaseInit purchaseInit;
+        lineItem = purchaseInit.add_line_items();
+        lineItem->set_item_def_id(ItemSchema::ItemStatsSubscription);
+        lineItem->set_quantity(1);
+        SendGCProtobuf(gc, k_EMsgGCStorePurchaseInit, purchaseInit);
+        event = {};
+        initResponse.Clear();
+        uint64_t authorizationTransactionId = 0;
+        valid &= WaitForHostMessage(gc, k_EMsgGCStorePurchaseInitResponse, event,
+                &authorizationTransactionId)
+            && ParseHostProtobuf(event, initResponse)
+            && initResponse.result() == 1
+            && initResponse.txn_id() != 0
+            && authorizationTransactionId == initResponse.txn_id();
+
+        CMsgGCStorePurchaseFinalize finalize;
+        finalize.set_txn_id(initResponse.txn_id());
+        SendGCProtobuf(gc, k_EMsgGCStorePurchaseFinalize, finalize);
+        event = {};
+        CMsgGCStorePurchaseFinalizeResponse finalizeResponse;
+        valid &= WaitForHostMessage(gc, k_EMsgGCStorePurchaseFinalizeResponse, event)
+            && ParseHostProtobuf(event, finalizeResponse)
+            && finalizeResponse.result() == 1
+            && finalizeResponse.item_ids_size() == 1;
+        if (finalizeResponse.item_ids_size() == 1)
+        {
+            subscriptionItemId = finalizeResponse.item_ids(0);
+        }
+
+        SendGCProtobuf(gc, k_EMsgGCStorePurchaseInit, purchaseInit);
+        event = {};
+        initResponse.Clear();
+        valid &= WaitForHostMessage(gc, k_EMsgGCStorePurchaseInitResponse, event)
+            && ParseHostProtobuf(event, initResponse)
+            && initResponse.result() != 1
+            && initResponse.item_ids_size() == 0;
+    }
+
+    {
+        ClientGC gc{ SteamId };
+        CMsgGCStorePurchaseInit purchaseInit;
+        CGCStorePurchaseInit_LineItem *lineItem = purchaseInit.add_line_items();
+        lineItem->set_item_def_id(ItemSchema::ItemStatsSubscription);
+        lineItem->set_quantity(1);
+        SendGCProtobuf(gc, k_EMsgGCStorePurchaseInit, purchaseInit);
+
+        EventData event;
+        CMsgGCStorePurchaseInitResponse initResponse;
+        valid &= WaitForHostMessage(gc, k_EMsgGCStorePurchaseInitResponse, event)
+            && ParseHostProtobuf(event, initResponse)
+            && initResponse.result() != 1;
+    }
+
+    KeyValue persisted{ "inventory" };
+    valid &= subscriptionItemId
+        && persisted.ParseFromFile("csgo_gc/inventory.txt");
+    if (valid)
+    {
+        const KeyValue *items = persisted.GetSubkey("items");
+        size_t subscriptionCount = 0;
+        if (items)
+        {
+            for (const KeyValue &item : *items)
+            {
+                subscriptionCount += item.GetNumber<uint32_t>("def_index")
+                    == ItemSchema::ItemStatsSubscription;
+            }
+        }
+        valid &= items
+            && subscriptionCount == 1
+            && items->GetSubkey(std::to_string(subscriptionItemId >> 32));
     }
 
     RemoveStoreFixtures();
@@ -2327,6 +2497,7 @@ int main()
         { "PlayerProfileRequestsReturnMinimalProfiles",
             PlayerProfileRequestsReturnMinimalProfiles },
         { "InventoryPersistenceProtectsFiles", InventoryPersistenceProtectsFiles },
+        { "StatsSubscriptionDuplicatesKeepNewest", StatsSubscriptionDuplicatesKeepNewest },
         { "LoadoutStateTransitionsPreserveClassesAndSwapSlots",
             LoadoutStateTransitionsPreserveClassesAndSwapSlots },
         { "SOCacheVersionNegotiationAndRefresh", SOCacheVersionNegotiationAndRefresh },
@@ -2335,6 +2506,8 @@ int main()
         { "StatTrakSwapToolTwoPackCreatesTwoTools", StatTrakSwapToolTwoPackCreatesTwoTools },
         { "UnusualStatTrakKnivesCanSwapCounters", UnusualStatTrakKnivesCanSwapCounters },
         { "StorePurchasesFinalizeTransactionally", StorePurchasesFinalizeTransactionally },
+        { "StatsSubscriptionPurchasesRejectDuplicates",
+            StatsSubscriptionPurchasesRejectDuplicates },
         { "ServiceMedalsFollowBuildYearAndPersistPrestige",
             ServiceMedalsFollowBuildYearAndPersistPrestige },
         { "ViewerPassActivationCreatesAndPersistsJournal",

--- a/csgo_gc/inventory.cpp
+++ b/csgo_gc/inventory.cpp
@@ -181,6 +181,13 @@ const CSOEconItem *Inventory::GetItem(uint64_t itemId) const
     return &it->second;
 }
 
+bool Inventory::HasItemDefinition(uint32_t defIndex) const
+{
+    return std::any_of(m_items.begin(), m_items.end(), [defIndex](const auto &pair) {
+        return pair.second.def_index() == defIndex;
+    });
+}
+
 std::optional<Inventory::PrestigeMedalPlan> Inventory::GetPrestigeMedalPlan(uint32_t year) const
 {
     std::vector<uint32_t> defIndexes = m_itemSchema.PrestigeMedalDefIndexes(year);
@@ -406,6 +413,8 @@ void Inventory::ReadFromFile()
             CSOEconItem &item = AllocateItem(highItemId);
             ReadItem(itemKey, item);
         }
+
+        DeduplicateStatsSubscriptions();
     }
 
     const KeyValue *defaultEquipsKey = inventoryKey.GetSubkey("default_equips");
@@ -437,6 +446,47 @@ void Inventory::ReadFromFile()
     }
 
     LogInventoryConsistency();
+}
+
+void Inventory::DeduplicateStatsSubscriptions()
+{
+    // Purchased item ids increase monotonically. Keep the newest subscription so
+    // the item id returned by the latest completed purchase remains valid.
+    uint64_t latestItemId = 0;
+    for (const auto &[itemId, item] : m_items)
+    {
+        if (item.def_index() == ItemSchema::ItemStatsSubscription
+            && itemId > latestItemId)
+        {
+            latestItemId = itemId;
+        }
+    }
+
+    if (!latestItemId)
+    {
+        return;
+    }
+
+    uint64_t removed = 0;
+    for (auto it = m_items.begin(); it != m_items.end();)
+    {
+        if (it->second.def_index() == ItemSchema::ItemStatsSubscription
+            && it->first != latestItemId)
+        {
+            it = m_items.erase(it);
+            ++removed;
+        }
+        else
+        {
+            ++it;
+        }
+    }
+
+    if (removed)
+    {
+        Platform::Print("Inventory: removed %llu duplicate stats subscription items; keeping %llu\n",
+            removed, latestItemId);
+    }
 }
 
 void Inventory::ReadItem(const KeyValue &itemKey, CSOEconItem &item) const
@@ -2452,6 +2502,12 @@ uint64_t Inventory::PurchaseItem(uint32_t defIndex, std::vector<CMsgSOSingleObje
     if (!m_itemSchema.ItemInfoByDefIndex(defIndex))
     {
         Platform::Print("PurchaseItem: unknown def_index %u\n", defIndex);
+        return 0;
+    }
+
+    if (defIndex == ItemSchema::ItemStatsSubscription && HasItemDefinition(defIndex))
+    {
+        Platform::Print("PurchaseItem: stats subscription already exists\n");
         return 0;
     }
 

--- a/csgo_gc/inventory.h
+++ b/csgo_gc/inventory.h
@@ -218,6 +218,7 @@ public:
         std::string &error);
     size_t ItemCount() const { return m_items.size(); }
     const ItemMap &Items() const { return m_items; }
+    bool HasItemDefinition(uint32_t defIndex) const;
     const std::set<uint64_t> &EventFavorites() const { return m_eventFavorites; }
     bool SetEventFavorite(uint64_t eventId, bool favorite);
     bool Save() const { return WriteToFile(); }
@@ -235,6 +236,7 @@ private:
 
     void ReadFromFile();
     void ReadItem(const KeyValue &itemKey, CSOEconItem &item) const;
+    void DeduplicateStatsSubscriptions();
     void LogInventoryConsistency() const;
 
     bool WriteToFile() const;

--- a/csgo_gc/item_schema.h
+++ b/csgo_gc/item_schema.h
@@ -277,7 +277,8 @@ public:
         ItemSpray = 1348,
         ItemSprayPaint = 1349,
         ItemStatTrakSwapToolBundle = 4088,
-        ItemPatch = 4609
+        ItemPatch = 4609,
+        ItemStatsSubscription = 4748
     };
 
     enum Attribute


### PR DESCRIPTION
## Summary
- reject stats subscription purchases when item definition 4748 is already owned, repeated in the same request, or requested with a quantity other than one
- deduplicate persisted subscription items on inventory load while keeping the newest item ID
- retain a finalize-time guard and add regression coverage for purchase rejection, persistence, and newest-item preservation

## Testing
- x86 MSVC/Ninja build: `cmake --build build --config Release --target csgo_gc gc_message_tests`
- full configured suite: `ctest --test-dir build -C Release --output-on-failure` (6/6 passed)

Closes #76

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate statistics subscription purchases.
  * Added validation to ensure subscription purchases have a quantity of exactly one.
  * Cleaned up duplicate subscription entries while preserving the newest item and other inventory data.
  * Improved persistence and consistency of subscription inventory records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->