### PR TITLE
Add experimental Riptide operation state support

### DIFF
--- a/csgo_gc/gc_client.cpp
+++ b/csgo_gc/gc_client.cpp
@@ -1541,6 +1541,13 @@ void ClientGC::UseItemRequest(GCMessageRead &messageRead)
                     ? k_ESOMsg_Create : k_ESOMsg_Update,
                 result.itemData);
         }
+        if (result.operationChange != Inventory::UseItemChange::None)
+        {
+            SendMessageToGame(true,
+                result.operationChange == Inventory::UseItemChange::Create
+                    ? k_ESOMsg_Create : k_ESOMsg_Update,
+                result.operationData);
+        }
         if (result.updateMultiple.objects_modified_size())
         {
             SendMessageToGame(true, k_ESOMsg_UpdateMultiple, result.updateMultiple);

--- a/csgo_gc/gc_client.cpp
+++ b/csgo_gc/gc_client.cpp
@@ -993,6 +993,10 @@ void ClientGC::HandleMessage(uint32_t type, const void *data, uint32_t size)
             UseItemRequest(messageRead);
             break;
 
+        case k_EMsgGCCStrike15_v2_ClientRequestNewMission:
+            ClientRequestNewMission(messageRead);
+            break;
+
         case k_EMsgGCCStrike15_v2_ClientRequestJoinServerData:
             ClientRequestJoinServerData(messageRead);
             break;
@@ -1554,6 +1558,24 @@ void ClientGC::UseItemRequest(GCMessageRead &messageRead)
         }
 
         SendMessageToGame(false, k_EMsgGCItemCustomizationNotification, result.notification);
+    }
+}
+
+void ClientGC::ClientRequestNewMission(GCMessageRead &messageRead)
+{
+    CMsgGCCstrike15_v2_ClientRequestNewMission request;
+    if (!messageRead.ReadProtobuf(request))
+    {
+        Platform::Print("Parsing CMsgGCCstrike15_v2_ClientRequestNewMission failed, ignoring\n");
+        return;
+    }
+
+    CMsgSOSingleObject update;
+    if (m_inventory.SelectSeasonalMissionCard(
+            request.campaign_id(), request.mission_id(), update)
+        && update.has_object_data())
+    {
+        SendMessageToGame(true, k_ESOMsg_Update, update);
     }
 }
 

--- a/csgo_gc/gc_client.h
+++ b/csgo_gc/gc_client.h
@@ -65,6 +65,7 @@ private:
     void AdjustItemEquippedState(GCMessageRead &messageRead);
     void ClientPlayerDecalSign(GCMessageRead &messageRead);
     void UseItemRequest(GCMessageRead &messageRead);
+    void ClientRequestNewMission(GCMessageRead &messageRead);
     void ClientRequestJoinServerData(GCMessageRead &messageRead);
     void ClientRequestPlayersProfile(GCMessageRead &messageRead);
     void SetEventFavorite(GCMessageRead &messageRead);

--- a/csgo_gc/gc_const_csgo.h
+++ b/csgo_gc/gc_const_csgo.h
@@ -73,6 +73,7 @@ enum SOTypeId : uint32_t
     SOTypePersonaDataPublic = 2,
     SOTypeEquipSlot = 3,
     SOTypeGameAccountClient = 7,
+    SOTypeAccountSeasonalOperation = 41,
     SOTypeDefaultEquippedDefinitionInstanceClient = 43
 };
 

--- a/csgo_gc/gc_message_tests.cpp
+++ b/csgo_gc/gc_message_tests.cpp
@@ -302,6 +302,31 @@ static bool HostMessageNotReceived(ClientGC &gc, uint32_t type,
     return true;
 }
 
+static bool HostMessageOrNetMessageNotReceived(ClientGC &gc, uint32_t type,
+    std::chrono::milliseconds duration = std::chrono::milliseconds{ 100 })
+{
+    std::vector<EventData> events;
+    auto deadline = std::chrono::steady_clock::now() + duration;
+    while (std::chrono::steady_clock::now() < deadline)
+    {
+        gc.GetHostEvents(events);
+        for (const EventData &event : events)
+        {
+            if ((event.type == static_cast<int>(HostEvent::Message)
+                    || event.type == static_cast<int>(HostEvent::NetMessage))
+                && (event.id & ~ProtobufMask) == type)
+            {
+                return false;
+            }
+        }
+
+        events.clear();
+        std::this_thread::sleep_for(std::chrono::milliseconds{ 1 });
+    }
+
+    return true;
+}
+
 template<typename T>
 static bool ParseHostProtobuf(const EventData &event, T &message)
 {
@@ -2702,7 +2727,7 @@ static bool SeasonalMissionCardSelectionValidatesAndPersists()
         missionRequest.set_mission_id(9051);
         SendGCProtobuf(gc,
             k_EMsgGCCStrike15_v2_ClientRequestNewMission, missionRequest);
-        valid &= HostMessageNotReceived(gc, k_ESOMsg_Update);
+        valid &= HostMessageOrNetMessageNotReceived(gc, k_ESOMsg_Update);
 
         CMsgUseItem passRequest;
         passRequest.set_item_id(passId);
@@ -2714,13 +2739,13 @@ static bool SeasonalMissionCardSelectionValidatesAndPersists()
         missionRequest.set_campaign_id(9);
         SendGCProtobuf(gc,
             k_EMsgGCCStrike15_v2_ClientRequestNewMission, missionRequest);
-        valid &= HostMessageNotReceived(gc, k_ESOMsg_Update);
+        valid &= HostMessageOrNetMessageNotReceived(gc, k_ESOMsg_Update);
 
         missionRequest.set_campaign_id(10);
         missionRequest.set_mission_id(9999);
         SendGCProtobuf(gc,
             k_EMsgGCCStrike15_v2_ClientRequestNewMission, missionRequest);
-        valid &= HostMessageNotReceived(gc, k_ESOMsg_Update);
+        valid &= HostMessageOrNetMessageNotReceived(gc, k_ESOMsg_Update);
 
         missionRequest.set_mission_id(9052);
         SendGCProtobuf(gc,
@@ -2733,7 +2758,7 @@ static bool SeasonalMissionCardSelectionValidatesAndPersists()
 
         SendGCProtobuf(gc,
             k_EMsgGCCStrike15_v2_ClientRequestNewMission, missionRequest);
-        valid &= HostMessageNotReceived(gc, k_ESOMsg_Update);
+        valid &= HostMessageOrNetMessageNotReceived(gc, k_ESOMsg_Update);
     }
 
     {

--- a/csgo_gc/gc_message_tests.cpp
+++ b/csgo_gc/gc_message_tests.cpp
@@ -2620,6 +2620,143 @@ static bool SeasonPassActivationCreatesAndPersistsOperationState()
     return valid;
 }
 
+static bool WaitForSeasonalOperationUpdate(ClientGC &gc, uint32_t seasonValue,
+    uint32_t missionCardId, CSOAccountSeasonalOperation &clientOperation,
+    CSOAccountSeasonalOperation &serverOperation)
+{
+    bool receivedClientUpdate = false;
+    bool receivedServerUpdate = false;
+    std::vector<EventData> events;
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds{ 1 };
+    while (std::chrono::steady_clock::now() < deadline)
+    {
+        gc.GetHostEvents(events);
+        for (const EventData &event : events)
+        {
+            if (event.type != static_cast<int>(HostEvent::Message)
+                && event.type != static_cast<int>(HostEvent::NetMessage))
+            {
+                continue;
+            }
+
+            GCMessageRead messageRead{
+                0, event.buffer.data(), static_cast<uint32_t>(event.buffer.size())
+            };
+            if (!messageRead.IsValid() || !messageRead.IsProtobuf()
+                || messageRead.TypeUnmasked() != k_ESOMsg_Update)
+            {
+                continue;
+            }
+
+            CMsgSOSingleObject update;
+            CSOAccountSeasonalOperation operation;
+            if (!messageRead.ReadProtobuf(update)
+                || update.type_id() != SOTypeAccountSeasonalOperation
+                || !operation.ParseFromString(update.object_data())
+                || operation.season_value() != seasonValue
+                || operation.mission_id() != missionCardId)
+            {
+                continue;
+            }
+
+            if (event.type == static_cast<int>(HostEvent::Message))
+            {
+                clientOperation = std::move(operation);
+                receivedClientUpdate = true;
+            }
+            else
+            {
+                serverOperation = std::move(operation);
+                receivedServerUpdate = true;
+            }
+        }
+
+        if (receivedClientUpdate && receivedServerUpdate)
+        {
+            return true;
+        }
+
+        events.clear();
+        std::this_thread::sleep_for(std::chrono::milliseconds{ 1 });
+    }
+
+    return false;
+}
+
+static bool SeasonalMissionCardSelectionValidatesAndPersists()
+{
+    constexpr uint64_t SteamId = 76561197960265729ull;
+    RemoveSeasonalOperationFixtures();
+    if (!WriteSeasonalOperationFixtures())
+    {
+        RemoveSeasonalOperationFixtures();
+        return false;
+    }
+
+    const uint64_t passId = TournamentFixtureItemId(SteamId, 1);
+    bool valid = true;
+    {
+        ClientGC gc{ SteamId };
+        CMsgGCCstrike15_v2_ClientRequestNewMission missionRequest;
+        missionRequest.set_campaign_id(10);
+        missionRequest.set_mission_id(9051);
+        SendGCProtobuf(gc,
+            k_EMsgGCCStrike15_v2_ClientRequestNewMission, missionRequest);
+        valid &= HostMessageNotReceived(gc, k_ESOMsg_Update);
+
+        CMsgUseItem passRequest;
+        passRequest.set_item_id(passId);
+        SendGCProtobuf(gc, k_EMsgGCUseItemRequest, passRequest);
+        std::vector<EventData> activationEvents;
+        valid &= WaitForHostMessagesUntil(gc,
+            k_EMsgGCItemCustomizationNotification, activationEvents);
+
+        missionRequest.set_campaign_id(9);
+        SendGCProtobuf(gc,
+            k_EMsgGCCStrike15_v2_ClientRequestNewMission, missionRequest);
+        valid &= HostMessageNotReceived(gc, k_ESOMsg_Update);
+
+        missionRequest.set_campaign_id(10);
+        missionRequest.set_mission_id(9999);
+        SendGCProtobuf(gc,
+            k_EMsgGCCStrike15_v2_ClientRequestNewMission, missionRequest);
+        valid &= HostMessageNotReceived(gc, k_ESOMsg_Update);
+
+        missionRequest.set_mission_id(9052);
+        SendGCProtobuf(gc,
+            k_EMsgGCCStrike15_v2_ClientRequestNewMission, missionRequest);
+        CSOAccountSeasonalOperation clientOperation;
+        CSOAccountSeasonalOperation serverOperation;
+        valid &= WaitForSeasonalOperationUpdate(gc, 10, 9052,
+                clientOperation, serverOperation)
+            && clientOperation.SerializeAsString() == serverOperation.SerializeAsString();
+
+        SendGCProtobuf(gc,
+            k_EMsgGCCStrike15_v2_ClientRequestNewMission, missionRequest);
+        valid &= HostMessageNotReceived(gc, k_ESOMsg_Update);
+    }
+
+    {
+        Inventory persisted{ SteamId };
+        const CSOAccountSeasonalOperation *operation = persisted.GetSeasonalOperation(10);
+        valid &= operation && operation->mission_id() == 9052;
+
+        CMsgSOCacheSubscribed clientSubscription;
+        CMsgSOCacheSubscribed serverSubscription;
+        persisted.BuildCacheSubscription(clientSubscription, false);
+        persisted.BuildCacheSubscription(serverSubscription, true);
+        CSOAccountSeasonalOperation clientOperation;
+        CSOAccountSeasonalOperation serverOperation;
+        valid &= FindSeasonalOperation(clientSubscription, 10, clientOperation)
+            && FindSeasonalOperation(serverSubscription, 10, serverOperation)
+            && clientOperation.mission_id() == 9052
+            && clientOperation.SerializeAsString() == serverOperation.SerializeAsString();
+    }
+
+    RemoveSeasonalOperationFixtures();
+    return valid;
+}
+
 static bool RequestEventFavorites(ClientGC &gc, bool allEvents, uint64_t jobId,
     std::string_view expectedFavorites)
 {
@@ -2724,6 +2861,8 @@ int main()
             SouvenirTokenInitializesMissingPurchasedCount },
         { "SeasonPassActivationCreatesAndPersistsOperationState",
             SeasonPassActivationCreatesAndPersistsOperationState },
+        { "SeasonalMissionCardSelectionValidatesAndPersists",
+            SeasonalMissionCardSelectionValidatesAndPersists },
         { "EventFavoritesPersistAndPreserveRequestJobs",
             EventFavoritesPersistAndPreserveRequestJobs },
     };

--- a/csgo_gc/gc_message_tests.cpp
+++ b/csgo_gc/gc_message_tests.cpp
@@ -2414,6 +2414,212 @@ static bool SouvenirTokenInitializesMissingPurchasedCount()
     return valid;
 }
 
+static void RemoveSeasonalOperationFixtures()
+{
+    TestFilesystem::RemoveFile("csgo_gc/inventory.txt");
+    TestFilesystem::RemoveFile("csgo_gc/unusual_loot_lists.txt");
+    TestFilesystem::RemoveFile("csgo_gc/gc_loot_lists.txt");
+    TestFilesystem::RemoveFile("csgo/scripts/items/items_game.txt");
+    TestFilesystem::RemoveDirectory("csgo/scripts/items");
+    TestFilesystem::RemoveDirectory("csgo/scripts");
+    TestFilesystem::RemoveDirectory("csgo");
+    TestFilesystem::RemoveDirectory("csgo_gc");
+}
+
+static bool WriteSeasonalOperationFixtures()
+{
+    if (!TestFilesystem::MakeDirectory("csgo")
+        || !TestFilesystem::MakeDirectory("csgo/scripts")
+        || !TestFilesystem::MakeDirectory("csgo/scripts/items")
+        || !TestFilesystem::MakeDirectory("csgo_gc"))
+    {
+        return false;
+    }
+
+    KeyValue schema{ "root" };
+    KeyValue &itemsGame = schema.AddSubkey("items_game");
+    KeyValue &prefabs = itemsGame.AddSubkey("prefabs");
+    KeyValue &seasonPass = prefabs.AddSubkey("season_pass");
+    seasonPass.AddSubkey("tool").AddString("type", "season_pass");
+    prefabs.AddSubkey("operation_coin");
+    KeyValue &seasonCoin = prefabs.AddSubkey("season11_coin");
+    seasonCoin.AddString("prefab", "operation_coin");
+    seasonCoin.AddSubkey("attributes").AddNumber("season access", 10);
+
+    KeyValue &items = itemsGame.AddSubkey("items");
+    KeyValue &pass = items.AddSubkey("4758");
+    pass.AddString("name", "CommunitySeasonEleven2021");
+    pass.AddString("prefab", "season_pass");
+    pass.AddSubkey("attributes").AddNumber("season access", 10);
+
+    KeyValue &coin = items.AddSubkey("4759");
+    coin.AddString("name", "CommunitySeasonEleven2021 Coin 1");
+    coin.AddString("prefab", "season11_coin");
+    coin.AddNumber("min_ilevel", 1);
+    coin.AddNumber("max_ilevel", 1);
+
+    KeyValue &operation = itemsGame.AddSubkey("seasonaloperations").AddSubkey("10");
+    operation.AddSubkey("quest_mission_card").AddNumber("id", 9051);
+    operation.AddSubkey("quest_mission_card").AddNumber("id", 9052);
+
+    KeyValue inventory{ "inventory" };
+    inventory.AddNumber("format_version", 1);
+    KeyValue &inventoryItems = inventory.AddSubkey("items");
+    for (uint32_t highItemId = 1; highItemId <= 2; highItemId++)
+    {
+        KeyValue &item = inventoryItems.AddSubkey(std::to_string(highItemId));
+        item.AddNumber("def_index", 4758);
+        item.AddNumber("origin", ItemOriginPurchased);
+    }
+
+    KeyValue unusualLootLists{ "unusual_loot_lists" };
+    KeyValue gcLootLists{ "gc_loot_lists" };
+    return schema.WriteToFile("csgo/scripts/items/items_game.txt")
+        && inventory.WriteToFile("csgo_gc/inventory.txt")
+        && unusualLootLists.WriteToFile("csgo_gc/unusual_loot_lists.txt")
+        && gcLootLists.WriteToFile("csgo_gc/gc_loot_lists.txt");
+}
+
+static bool FindSeasonalOperation(const CMsgSOCacheSubscribed &subscription,
+    uint32_t seasonValue, CSOAccountSeasonalOperation &result)
+{
+    for (const CMsgSOCacheSubscribed_SubscribedType &type : subscription.objects())
+    {
+        if (type.type_id() != SOTypeAccountSeasonalOperation)
+        {
+            continue;
+        }
+
+        for (const std::string &data : type.object_data())
+        {
+            CSOAccountSeasonalOperation operation;
+            if (operation.ParseFromString(data) && operation.season_value() == seasonValue)
+            {
+                result = std::move(operation);
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+static bool SeasonPassActivationCreatesAndPersistsOperationState()
+{
+    constexpr uint64_t SteamId = 76561197960265729ull;
+    RemoveSeasonalOperationFixtures();
+    if (!WriteSeasonalOperationFixtures())
+    {
+        RemoveSeasonalOperationFixtures();
+        return false;
+    }
+
+    const uint64_t passId = TournamentFixtureItemId(SteamId, 1);
+    const uint64_t duplicatePassId = TournamentFixtureItemId(SteamId, 2);
+    uint64_t coinId = 0;
+    bool valid = true;
+    {
+        ClientGC gc{ SteamId };
+        CMsgUseItem request;
+        request.set_item_id(passId);
+        SendGCProtobuf(gc, k_EMsgGCUseItemRequest, request);
+
+        std::vector<EventData> events;
+        valid &= WaitForHostMessagesUntil(gc,
+            k_EMsgGCItemCustomizationNotification, events);
+
+        size_t destroyIndex = events.size();
+        size_t coinIndex = events.size();
+        size_t operationIndex = events.size();
+        size_t notificationIndex = events.size();
+        CSOAccountSeasonalOperation operation;
+        for (size_t i = 0; i < events.size(); i++)
+        {
+            const uint32_t type = static_cast<uint32_t>(events[i].id) & ~ProtobufMask;
+            if (type == k_ESOMsg_Destroy)
+            {
+                CMsgSOSingleObject object;
+                CSOEconItem destroyed;
+                valid &= ParseHostProtobuf(events[i], object)
+                    && ParseItemObject(object, destroyed)
+                    && destroyed.id() == passId;
+                destroyIndex = i;
+            }
+            else if (type == k_ESOMsg_Create)
+            {
+                CMsgSOSingleObject object;
+                valid &= ParseHostProtobuf(events[i], object);
+                if (object.type_id() == SOTypeItem)
+                {
+                    CSOEconItem coin;
+                    valid &= coin.ParseFromString(object.object_data())
+                        && coin.def_index() == 4759;
+                    coinId = coin.id();
+                    coinIndex = i;
+                }
+                else if (object.type_id() == SOTypeAccountSeasonalOperation)
+                {
+                    valid &= operation.ParseFromString(object.object_data());
+                    operationIndex = i;
+                }
+            }
+            else if (type == k_EMsgGCItemCustomizationNotification)
+            {
+                CMsgGCItemCustomizationNotification notification;
+                valid &= ParseHostProtobuf(events[i], notification)
+                    && notification.request()
+                        == k_EGCItemCustomizationNotification_ActivateOperationCoin
+                    && notification.item_id_size() == 1;
+                if (notification.item_id_size() == 1)
+                {
+                    valid &= notification.item_id(0) == coinId;
+                }
+                notificationIndex = i;
+            }
+        }
+
+        valid &= destroyIndex < coinIndex
+            && coinIndex < operationIndex
+            && operationIndex < notificationIndex
+            && operation.season_value() == 10
+            && operation.tier_unlocked() == 0
+            && operation.premium_tiers() == 0
+            && operation.mission_id() == 0
+            && operation.missions_completed() == 0
+            && operation.redeemable_balance() == 0
+            && operation.season_pass_time() != 0;
+
+        request.set_item_id(duplicatePassId);
+        SendGCProtobuf(gc, k_EMsgGCUseItemRequest, request);
+        valid &= HostMessageNotReceived(gc, k_EMsgGCItemCustomizationNotification);
+    }
+
+    {
+        Inventory persisted{ SteamId };
+        const CSOAccountSeasonalOperation *operation = persisted.GetSeasonalOperation(10);
+        valid &= !persisted.GetItem(passId)
+            && persisted.GetItem(duplicatePassId)
+            && persisted.GetItem(coinId)
+            && persisted.GetItem(coinId)->def_index() == 4759
+            && operation
+            && operation->season_value() == 10
+            && operation->season_pass_time() != 0;
+
+        CMsgSOCacheSubscribed clientSubscription;
+        CMsgSOCacheSubscribed serverSubscription;
+        persisted.BuildCacheSubscription(clientSubscription, false);
+        persisted.BuildCacheSubscription(serverSubscription, true);
+        CSOAccountSeasonalOperation clientOperation;
+        CSOAccountSeasonalOperation serverOperation;
+        valid &= FindSeasonalOperation(clientSubscription, 10, clientOperation)
+            && FindSeasonalOperation(serverSubscription, 10, serverOperation)
+            && clientOperation.SerializeAsString() == serverOperation.SerializeAsString();
+    }
+
+    RemoveSeasonalOperationFixtures();
+    return valid;
+}
+
 static bool RequestEventFavorites(ClientGC &gc, bool allEvents, uint64_t jobId,
     std::string_view expectedFavorites)
 {
@@ -2516,6 +2722,8 @@ int main()
             ViewerPassTokenPacksUpdatePersistedJournal },
         { "SouvenirTokenInitializesMissingPurchasedCount",
             SouvenirTokenInitializesMissingPurchasedCount },
+        { "SeasonPassActivationCreatesAndPersistsOperationState",
+            SeasonPassActivationCreatesAndPersistsOperationState },
         { "EventFavoritesPersistAndPreserveRequestJobs",
             EventFavoritesPersistAndPreserveRequestJobs },
     };

--- a/csgo_gc/gc_message_tests.cpp
+++ b/csgo_gc/gc_message_tests.cpp
@@ -303,7 +303,7 @@ static bool HostMessageNotReceived(ClientGC &gc, uint32_t type,
 }
 
 static bool HostMessageOrNetMessageNotReceived(ClientGC &gc, uint32_t type,
-    std::chrono::milliseconds duration = std::chrono::milliseconds{ 100 })
+    std::chrono::milliseconds duration = std::chrono::seconds{ 1 })
 {
     std::vector<EventData> events;
     auto deadline = std::chrono::steady_clock::now() + duration;

--- a/csgo_gc/inventory.cpp
+++ b/csgo_gc/inventory.cpp
@@ -1059,6 +1059,37 @@ bool Inventory::UseItem(uint64_t itemId, UseItemResult &result)
     return true;
 }
 
+bool Inventory::SelectSeasonalMissionCard(uint32_t seasonValue,
+    uint32_t missionCardId, CMsgSOSingleObject &update)
+{
+    auto operation = m_seasonalOperations.find(seasonValue);
+    if (operation == m_seasonalOperations.end()
+        || !m_itemSchema.IsSeasonalMissionCard(seasonValue, missionCardId))
+    {
+        return false;
+    }
+
+    if (operation->second.mission_id() == missionCardId)
+    {
+        return true;
+    }
+
+    const uint64_t previousVersion = m_version;
+    const CSOAccountSeasonalOperation previousOperation = operation->second;
+    operation->second.set_mission_id(missionCardId);
+    ToSingleObject(update, SOTypeAccountSeasonalOperation, operation->second);
+
+    if (WriteToFile())
+    {
+        return true;
+    }
+
+    operation->second = previousOperation;
+    m_version = previousVersion;
+    update.Clear();
+    return false;
+}
+
 bool Inventory::ActivateSeasonPassItem(ItemMap::iterator passItem,
     const SeasonPassInfo &pass, UseItemResult &result)
 {

--- a/csgo_gc/inventory.cpp
+++ b/csgo_gc/inventory.cpp
@@ -188,6 +188,12 @@ bool Inventory::HasItemDefinition(uint32_t defIndex) const
     });
 }
 
+const CSOAccountSeasonalOperation *Inventory::GetSeasonalOperation(uint32_t seasonValue) const
+{
+    auto operation = m_seasonalOperations.find(seasonValue);
+    return operation == m_seasonalOperations.end() ? nullptr : &operation->second;
+}
+
 std::optional<Inventory::PrestigeMedalPlan> Inventory::GetPrestigeMedalPlan(uint32_t year) const
 {
     std::vector<uint32_t> defIndexes = m_itemSchema.PrestigeMedalDefIndexes(year);
@@ -417,6 +423,42 @@ void Inventory::ReadFromFile()
         DeduplicateStatsSubscriptions();
     }
 
+    const KeyValue *seasonalOperationsKey = inventoryKey.GetSubkey("seasonal_operations");
+    if (seasonalOperationsKey)
+    {
+        for (const KeyValue &operationKey : *seasonalOperationsKey)
+        {
+            const uint32_t seasonValue = FromString<uint32_t>(operationKey.Name());
+            CSOAccountSeasonalOperation &operation = m_seasonalOperations[seasonValue];
+            operation.set_season_value(seasonValue);
+
+            if (operationKey.GetSubkey("tier_unlocked"))
+            {
+                operation.set_tier_unlocked(operationKey.GetNumber<uint32_t>("tier_unlocked"));
+            }
+            if (operationKey.GetSubkey("premium_tiers"))
+            {
+                operation.set_premium_tiers(operationKey.GetNumber<uint32_t>("premium_tiers"));
+            }
+            if (operationKey.GetSubkey("mission_id"))
+            {
+                operation.set_mission_id(operationKey.GetNumber<uint32_t>("mission_id"));
+            }
+            if (operationKey.GetSubkey("missions_completed"))
+            {
+                operation.set_missions_completed(operationKey.GetNumber<uint32_t>("missions_completed"));
+            }
+            if (operationKey.GetSubkey("redeemable_balance"))
+            {
+                operation.set_redeemable_balance(operationKey.GetNumber<uint32_t>("redeemable_balance"));
+            }
+            if (operationKey.GetSubkey("season_pass_time"))
+            {
+                operation.set_season_pass_time(operationKey.GetNumber<uint32_t>("season_pass_time"));
+            }
+        }
+    }
+
     const KeyValue *defaultEquipsKey = inventoryKey.GetSubkey("default_equips");
     if (defaultEquipsKey)
     {
@@ -572,6 +614,38 @@ bool Inventory::WriteToFile() const
     }
 
     {
+        KeyValue &seasonalOperationsKey = inventoryKey.AddSubkey("seasonal_operations");
+        for (const auto &[seasonValue, operation] : m_seasonalOperations)
+        {
+            KeyValue &operationKey = seasonalOperationsKey.AddSubkey(std::to_string(seasonValue));
+            if (operation.has_tier_unlocked())
+            {
+                operationKey.AddNumber("tier_unlocked", operation.tier_unlocked());
+            }
+            if (operation.has_premium_tiers())
+            {
+                operationKey.AddNumber("premium_tiers", operation.premium_tiers());
+            }
+            if (operation.has_mission_id())
+            {
+                operationKey.AddNumber("mission_id", operation.mission_id());
+            }
+            if (operation.has_missions_completed())
+            {
+                operationKey.AddNumber("missions_completed", operation.missions_completed());
+            }
+            if (operation.has_redeemable_balance())
+            {
+                operationKey.AddNumber("redeemable_balance", operation.redeemable_balance());
+            }
+            if (operation.has_season_pass_time())
+            {
+                operationKey.AddNumber("season_pass_time", operation.season_pass_time());
+            }
+        }
+    }
+
+    {
         KeyValue &defaultEquipsKey = inventoryKey.AddSubkey("default_equips");
 
         for (const CSOEconDefaultEquippedDefinitionInstanceClient &defaultEquip : m_defaultEquips)
@@ -695,6 +769,17 @@ void Inventory::BuildCacheSubscription(CMsgSOCacheSubscribed &message, bool serv
         CMsgSOCacheSubscribed_SubscribedType *object = message.add_objects();
         object->set_type_id(SOTypePersonaDataPublic);
         object->add_object_data(personaData.SerializeAsString());
+    }
+
+    if (!m_seasonalOperations.empty())
+    {
+        CMsgSOCacheSubscribed_SubscribedType *object = message.add_objects();
+        object->set_type_id(SOTypeAccountSeasonalOperation);
+        for (const auto &entry : m_seasonalOperations)
+        {
+            const CSOAccountSeasonalOperation &operation = entry.second;
+            object->add_object_data(operation.SerializeAsString());
+        }
     }
 
     if (!server)
@@ -940,6 +1025,12 @@ bool Inventory::UseItem(uint64_t itemId, UseItemResult &result)
         return ActivateTournamentAccessItem(it, *access, result);
     }
 
+    if (std::optional<SeasonPassInfo> pass
+        = m_itemSchema.SeasonPassByDefIndex(it->second.def_index()))
+    {
+        return ActivateSeasonPassItem(it, *pass, result);
+    }
+
     if (it->second.def_index() != ItemSchema::ItemSpray)
     {
         assert(false);
@@ -966,6 +1057,62 @@ bool Inventory::UseItem(uint64_t itemId, UseItemResult &result)
     result.notification.set_request(k_EGCItemCustomizationNotification_GraffitiUnseal);
 
     return true;
+}
+
+bool Inventory::ActivateSeasonPassItem(ItemMap::iterator passItem,
+    const SeasonPassInfo &pass, UseItemResult &result)
+{
+    if (m_seasonalOperations.contains(pass.seasonValue)
+        || HasItemDefinition(pass.coinDefIndex))
+    {
+        return false;
+    }
+
+    const uint64_t previousVersion = m_version;
+    const uint32_t previousLastHighItemId = m_lastHighItemId;
+    const CSOEconItem previousPassItem = passItem->second;
+
+    CSOEconItem &coin = CreateItem(pass.coinDefIndex,
+        ItemOriginPurchased, UnacknowledgedPurchased);
+    const uint64_t coinId = coin.id();
+    passItem = m_items.find(previousPassItem.id());
+
+    CSOAccountSeasonalOperation operation;
+    operation.set_season_value(pass.seasonValue);
+    operation.set_tier_unlocked(0);
+    operation.set_premium_tiers(0);
+    operation.set_mission_id(0);
+    operation.set_missions_completed(0);
+    operation.set_redeemable_balance(0);
+    operation.set_season_pass_time(static_cast<uint32_t>(time(nullptr)));
+    auto [operationIt, inserted] = m_seasonalOperations.emplace(pass.seasonValue, operation);
+    if (!inserted)
+    {
+        m_items.erase(coinId);
+        m_lastHighItemId = previousLastHighItemId;
+        return false;
+    }
+
+    DestroyItem(passItem, result.destroy);
+    ToSingleObject(result.itemData, coin);
+    result.itemChange = UseItemChange::Create;
+    ToSingleObject(result.operationData, SOTypeAccountSeasonalOperation, operationIt->second);
+    result.operationChange = UseItemChange::Create;
+    result.notification.add_item_id(coinId);
+    result.notification.set_request(k_EGCItemCustomizationNotification_ActivateOperationCoin);
+
+    if (WriteToFile())
+    {
+        return true;
+    }
+
+    m_items.erase(coinId);
+    m_items.emplace(previousPassItem.id(), previousPassItem);
+    m_seasonalOperations.erase(pass.seasonValue);
+    m_lastHighItemId = previousLastHighItemId;
+    m_version = previousVersion;
+    result = UseItemResult{};
+    return false;
 }
 
 bool Inventory::ActivateTournamentAccessItem(ItemMap::iterator accessItem,

--- a/csgo_gc/inventory.h
+++ b/csgo_gc/inventory.h
@@ -92,6 +92,8 @@ public:
     };
 
     bool UseItem(uint64_t itemId, UseItemResult &result);
+    bool SelectSeasonalMissionCard(uint32_t seasonValue, uint32_t missionCardId,
+        CMsgSOSingleObject &update);
 
     bool UnlockCrate(uint64_t crateId,
         uint64_t keyId,

--- a/csgo_gc/inventory.h
+++ b/csgo_gc/inventory.h
@@ -84,9 +84,11 @@ public:
     {
         CMsgSOSingleObject destroy;
         CMsgSOSingleObject itemData;
+        CMsgSOSingleObject operationData;
         CMsgSOMultipleObjects updateMultiple;
         CMsgGCItemCustomizationNotification notification;
         UseItemChange itemChange{ UseItemChange::None };
+        UseItemChange operationChange{ UseItemChange::None };
     };
 
     bool UseItem(uint64_t itemId, UseItemResult &result);
@@ -219,6 +221,7 @@ public:
     size_t ItemCount() const { return m_items.size(); }
     const ItemMap &Items() const { return m_items; }
     bool HasItemDefinition(uint32_t defIndex) const;
+    const CSOAccountSeasonalOperation *GetSeasonalOperation(uint32_t seasonValue) const;
     const std::set<uint64_t> &EventFavorites() const { return m_eventFavorites; }
     bool SetEventFavorite(uint64_t eventId, bool favorite);
     bool Save() const { return WriteToFile(); }
@@ -247,6 +250,8 @@ private:
     void UnequipSlotForClass(uint32_t classId, uint32_t slotId, CMsgSOMultipleObjects &update);
 
     void DestroyItem(ItemMap::iterator iterator, CMsgSOSingleObject &message);
+    bool ActivateSeasonPassItem(ItemMap::iterator passItem,
+        const SeasonPassInfo &pass, UseItemResult &result);
     bool ActivateTournamentAccessItem(ItemMap::iterator accessItem,
         const TournamentAccessInfo &access, UseItemResult &result);
 
@@ -297,6 +302,7 @@ private:
     Random m_random;
     uint32_t m_lastHighItemId{};
     ItemMap m_items;
+    std::unordered_map<uint32_t, CSOAccountSeasonalOperation> m_seasonalOperations;
     std::vector<CSOEconDefaultEquippedDefinitionInstanceClient> m_defaultEquips;
     std::set<uint64_t> m_eventFavorites;
     bool m_saveEnabled{ true };

--- a/csgo_gc/item_schema.cpp
+++ b/csgo_gc/item_schema.cpp
@@ -161,6 +161,12 @@ ItemSchema::ItemSchema(bool loadFiles)
         ParseItems(itemsKey, itemsGame->GetSubkey("prefabs"));
     }
 
+    const KeyValue *seasonalOperationsKey = itemsGame->GetSubkey("seasonaloperations");
+    if (seasonalOperationsKey)
+    {
+        ParseSeasonalOperations(seasonalOperationsKey);
+    }
+
     const KeyValue *stickerKitsKey = itemsGame->GetSubkey("sticker_kits");
     if (stickerKitsKey)
     {
@@ -749,13 +755,21 @@ void ItemSchema::ParseItems(const KeyValue *itemsKey, const KeyValue *prefabsKey
 
         ParseItemRecursive(emplace.first->second, itemKey, prefabsKey);
 
-        if (!emplace.first->second.m_name.empty())
+        auto &itemInfo = emplace.first->second;
+
+        if (!itemInfo.m_name.empty())
         {
-            m_itemDefIndexByName[emplace.first->second.m_name] = defIndex;
+            m_itemDefIndexByName[itemInfo.m_name] = defIndex;
+        }
+
+        if (itemInfo.m_seasonAccess && itemInfo.m_level == 1
+            && std::find(itemInfo.m_prefabs.begin(), itemInfo.m_prefabs.end(), "operation_coin")
+                != itemInfo.m_prefabs.end())
+        {
+            m_operationCoinDefIndexBySeason.try_emplace(*itemInfo.m_seasonAccess, defIndex);
         }
 
         // FIXME: remove, temp slop to make sure we parse correctly
-        auto &itemInfo = emplace.first->second;
         if (itemInfo.m_isCoupon)
         {
             assert(itemInfo.m_lootListName.size());
@@ -932,6 +946,12 @@ void ItemSchema::ParseItemRecursive(ItemInfo &info, const KeyValue &itemKey, con
     const KeyValue *tool = itemKey.GetSubkey("tool");
     if (tool)
     {
+        std::string_view type = tool->GetString("type");
+        if (type.size())
+        {
+            info.m_toolType = type;
+        }
+
         std::string_view restriction = tool->GetString("restriction");
         if (restriction.size())
         {
@@ -942,6 +962,12 @@ void ItemSchema::ParseItemRecursive(ItemInfo &info, const KeyValue &itemKey, con
     const KeyValue *attributes = itemKey.GetSubkey("attributes");
     if (attributes)
     {
+        const KeyValue *seasonAccess = attributes->GetSubkey("season access");
+        if (seasonAccess)
+        {
+            info.m_seasonAccess = FromString<uint32_t>(seasonAccess->String());
+        }
+
         info.m_prestigeYear = attributes->GetNumber<uint32_t>(
             "prestige year", info.m_prestigeYear);
 
@@ -993,6 +1019,30 @@ void ItemSchema::ParseItemRecursive(ItemInfo &info, const KeyValue &itemKey, con
             else
             {
                 info.m_generatedAttributes.push_back({ defIndex->second, value });
+            }
+        }
+    }
+}
+
+void ItemSchema::ParseSeasonalOperations(const KeyValue *seasonalOperationsKey)
+{
+    for (const KeyValue &operationKey : *seasonalOperationsKey)
+    {
+        const uint32_t seasonValue = FromString<uint32_t>(operationKey.Name());
+        std::vector<uint32_t> &missionCards = m_missionCardsBySeason[seasonValue];
+        for (const KeyValue &entry : operationKey)
+        {
+            if (entry.Name() != "quest_mission_card")
+            {
+                continue;
+            }
+
+            const uint32_t missionCardId = entry.GetNumber<uint32_t>("id");
+            if (missionCardId
+                && std::find(missionCards.begin(), missionCards.end(), missionCardId)
+                    == missionCards.end())
+            {
+                missionCards.push_back(missionCardId);
             }
         }
     }
@@ -1443,6 +1493,35 @@ std::optional<TournamentAccessInfo> ItemSchema::TournamentAccessByDefIndex(uint3
 
     result.journalDefIndex = journal->m_defIndex;
     return result;
+}
+
+std::optional<SeasonPassInfo> ItemSchema::SeasonPassByDefIndex(uint32_t defIndex) const
+{
+    const ItemInfo *pass = ItemInfoByDefIndex(defIndex);
+    if (!pass || pass->m_toolType != "season_pass" || !pass->m_seasonAccess)
+    {
+        return std::nullopt;
+    }
+
+    auto coin = m_operationCoinDefIndexBySeason.find(*pass->m_seasonAccess);
+    if (coin == m_operationCoinDefIndexBySeason.end())
+    {
+        return std::nullopt;
+    }
+
+    return SeasonPassInfo{ *pass->m_seasonAccess, coin->second };
+}
+
+bool ItemSchema::IsSeasonalMissionCard(uint32_t seasonValue, uint32_t missionCardId) const
+{
+    auto operation = m_missionCardsBySeason.find(seasonValue);
+    if (operation == m_missionCardsBySeason.end())
+    {
+        return false;
+    }
+
+    return std::find(operation->second.begin(), operation->second.end(), missionCardId)
+        != operation->second.end();
 }
 
 StickerKitInfo *ItemSchema::MutableStickerKitInfoByName(std::string_view name)

--- a/csgo_gc/item_schema.cpp
+++ b/csgo_gc/item_schema.cpp
@@ -1029,7 +1029,6 @@ void ItemSchema::ParseSeasonalOperations(const KeyValue *seasonalOperationsKey)
     for (const KeyValue &operationKey : *seasonalOperationsKey)
     {
         const uint32_t seasonValue = FromString<uint32_t>(operationKey.Name());
-        std::vector<uint32_t> &missionCards = m_missionCardsBySeason[seasonValue];
         for (const KeyValue &entry : operationKey)
         {
             if (entry.Name() != "quest_mission_card")
@@ -1038,9 +1037,14 @@ void ItemSchema::ParseSeasonalOperations(const KeyValue *seasonalOperationsKey)
             }
 
             const uint32_t missionCardId = entry.GetNumber<uint32_t>("id");
-            if (missionCardId
-                && std::find(missionCards.begin(), missionCards.end(), missionCardId)
-                    == missionCards.end())
+            if (!missionCardId)
+            {
+                continue;
+            }
+
+            std::vector<uint32_t> &missionCards = m_missionCardsBySeason[seasonValue];
+            if (std::find(missionCards.begin(), missionCards.end(), missionCardId)
+                == missionCards.end())
             {
                 missionCards.push_back(missionCardId);
             }

--- a/csgo_gc/item_schema.h
+++ b/csgo_gc/item_schema.h
@@ -50,6 +50,12 @@ struct TournamentAccessInfo
     uint32_t includedTokens{};
 };
 
+struct SeasonPassInfo
+{
+    uint32_t seasonValue{};
+    uint32_t coinDefIndex{};
+};
+
 class ItemInfo
 {
 public:
@@ -67,7 +73,9 @@ public:
     std::string m_itemType;
     std::vector<std::string> m_prefabs;
     std::vector<GeneratedItemAttribute> m_generatedAttributes;
+    std::string m_toolType;
     std::string m_toolRestriction;
+    std::optional<uint32_t> m_seasonAccess;
     bool m_canSticker;
     bool m_canPatch;
     bool m_nameable;
@@ -198,6 +206,8 @@ public:
     const ItemInfo *ItemInfoByDefIndex(uint32_t defIndex) const;
     const ItemInfo *ItemInfoByName(std::string_view name) const;
     std::optional<TournamentAccessInfo> TournamentAccessByDefIndex(uint32_t defIndex) const;
+    std::optional<SeasonPassInfo> SeasonPassByDefIndex(uint32_t defIndex) const;
+    bool IsSeasonalMissionCard(uint32_t seasonValue, uint32_t missionCardId) const;
     const PaintKitInfo *PaintKitInfoByDefIndex(uint32_t defIndex) const;
     const StickerKitInfo *StickerKitInfoByDefIndex(uint32_t defIndex) const;
     const MusicDefinitionInfo *MusicDefinitionInfoByDefIndex(uint32_t defIndex) const;
@@ -344,6 +354,7 @@ private:
 
     void ParseItems(const KeyValue *itemsKey, const KeyValue *prefabsKey);
     void ParseItemRecursive(ItemInfo &info, const KeyValue &itemKey, const KeyValue *prefabsKey);
+    void ParseSeasonalOperations(const KeyValue *seasonalOperationsKey);
     void ParseAttributes(const KeyValue *attributesKey);
     void ParseStickerKits(const KeyValue *stickerKitsKey);
     void ParsePaintKits(const KeyValue *paintKitsKey);
@@ -365,6 +376,8 @@ private:
     std::unordered_map<uint32_t, AttributeInfo> m_attributeInfo;
     std::unordered_map<std::string, uint32_t> m_itemDefIndexByName;
     std::unordered_map<std::string, uint32_t> m_attributeDefIndexByName;
+    std::unordered_map<uint32_t, uint32_t> m_operationCoinDefIndexBySeason;
+    std::unordered_map<uint32_t, std::vector<uint32_t>> m_missionCardsBySeason;
 
     std::unordered_map<std::string, StickerKitInfo> m_stickerKitInfo;
     std::unordered_map<std::string, PaintKitInfo> m_paintKitInfo;

--- a/csgo_gc/item_schema_tests.cpp
+++ b/csgo_gc/item_schema_tests.cpp
@@ -272,6 +272,8 @@ public:
         riptide.AddSubkey("quest_mission_card").AddNumber("id", 9051);
         riptide.AddSubkey("quest_mission_card").AddNumber("id", 9052);
         riptide.AddString("xp_reward", "7,11,15");
+        seasonalOperations.AddSubkey("11").AddString("xp_reward", "7,11,15");
+        seasonalOperations.AddSubkey("12").AddSubkey("quest_mission_card").AddNumber("id", 0);
         schema.ParseSeasonalOperations(&seasonalOperations);
 
         std::optional<SeasonPassInfo> info = schema.SeasonPassByDefIndex(4758);
@@ -282,7 +284,9 @@ public:
             && schema.IsSeasonalMissionCard(10, 9051)
             && schema.IsSeasonalMissionCard(10, 9052)
             && !schema.IsSeasonalMissionCard(10, 9053)
-            && !schema.IsSeasonalMissionCard(9, 9051);
+            && !schema.IsSeasonalMissionCard(9, 9051)
+            && schema.m_missionCardsBySeason.find(11) == schema.m_missionCardsBySeason.end()
+            && schema.m_missionCardsBySeason.find(12) == schema.m_missionCardsBySeason.end();
     }
 
     ItemSchema schema;

--- a/csgo_gc/item_schema_tests.cpp
+++ b/csgo_gc/item_schema_tests.cpp
@@ -240,6 +240,51 @@ public:
             && generatedValue(ItemSchema::AttributeOperationDropsAwardedRedeemed) == 0;
     }
 
+    bool ParseSeasonalOperationData()
+    {
+        KeyValue prefabs{ "prefabs" };
+        KeyValue &seasonPass = prefabs.AddSubkey("season_pass");
+        seasonPass.AddSubkey("tool").AddString("type", "season_pass");
+        prefabs.AddSubkey("operation_coin");
+        KeyValue &seasonCoin = prefabs.AddSubkey("season11_coin");
+        seasonCoin.AddString("prefab", "operation_coin");
+        seasonCoin.AddSubkey("attributes").AddNumber("season access", 10);
+
+        KeyValue items{ "items" };
+        KeyValue &pass = items.AddSubkey("4758");
+        pass.AddString("prefab", "season_pass");
+        pass.AddSubkey("attributes").AddNumber("season access", 10);
+
+        KeyValue &bronzeCoin = items.AddSubkey("4759");
+        bronzeCoin.AddString("prefab", "season11_coin");
+        bronzeCoin.AddNumber("min_ilevel", 1);
+        bronzeCoin.AddNumber("max_ilevel", 1);
+
+        KeyValue &silverCoin = items.AddSubkey("4760");
+        silverCoin.AddString("prefab", "season11_coin");
+        silverCoin.AddNumber("min_ilevel", 2);
+        silverCoin.AddNumber("max_ilevel", 2);
+
+        schema.ParseItems(&items, &prefabs);
+
+        KeyValue seasonalOperations{ "seasonaloperations" };
+        KeyValue &riptide = seasonalOperations.AddSubkey("10");
+        riptide.AddSubkey("quest_mission_card").AddNumber("id", 9051);
+        riptide.AddSubkey("quest_mission_card").AddNumber("id", 9052);
+        riptide.AddString("xp_reward", "7,11,15");
+        schema.ParseSeasonalOperations(&seasonalOperations);
+
+        std::optional<SeasonPassInfo> info = schema.SeasonPassByDefIndex(4758);
+        return info
+            && info->seasonValue == 10
+            && info->coinDefIndex == 4759
+            && !schema.SeasonPassByDefIndex(4759)
+            && schema.IsSeasonalMissionCard(10, 9051)
+            && schema.IsSeasonalMissionCard(10, 9052)
+            && !schema.IsSeasonalMissionCard(10, 9053)
+            && !schema.IsSeasonalMissionCard(9, 9051);
+    }
+
     ItemSchema schema;
 };
 
@@ -295,6 +340,12 @@ static bool TournamentAccessUsesSchemaMetadataAndGeneratedAttributes()
     return fixture.ParseTournamentAccessItems();
 }
 
+static bool SeasonalOperationUsesSchemaPassCoinAndMissionCards()
+{
+    ItemSchemaTestFixture fixture;
+    return fixture.ParseSeasonalOperationData();
+}
+
 int main()
 {
     if (!TournamentStickerCapsuleIsNotSouvenir())
@@ -325,6 +376,11 @@ int main()
     if (!TournamentAccessUsesSchemaMetadataAndGeneratedAttributes())
     {
         return 6;
+    }
+
+    if (!SeasonalOperationUsesSchemaPassCoinAndMissionCards())
+    {
+        return 7;
     }
 
     return 0;


### PR DESCRIPTION
## Summary

- parse seasonal operation pass, base coin, and mission-card metadata from items_game.txt
- consume a recognized season pass and create the operation coin plus persisted type-41 CSOAccountSeasonalOperation state
- handle message 9165 by validating and persisting the selected mission card, then publish the SO update to the client and connected game server
- reject duplicate activation, missing operation state, wrong-season cards, unknown cards, and unchanged selections without publishing empty updates

## Scope and limitations

This is experimental, partial GC support. It does not restore the hidden Panorama entry point, simulate mission progress, grant operation rewards, or implement reward redemption (9209). It also does not add the retired Riptide pass to the current offline price sheet, so store purchase is not restored by this PR; the existing give_item 4758 path can be used to obtain a pass for testing.

The behavior is covered by schema and GC message tests, but has not yet been exercised against the restored Riptide Panorama UI.

## Testing

- built csgo_gc with the x86 MSVC toolchain
- built gc_message_tests
- ctest --test-dir build -C Release --output-on-failure (6/6 passed)

Relates to #80

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for activating seasonal operation passes and creating associated operation coins.
  * Added seasonal operation state tracking and persistence.
  * Added mission-card selection and seasonal mission requests.
  * Added validation for invalid or duplicate mission requests.
  * Improved inventory synchronization after seasonal operation actions.

* **Tests**
  * Added coverage for pass activation, mission selection, validation, persistence, synchronization, and duplicate-use scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->