### PR TITLE
Handle offline GC compatibility requests

### DIFF
--- a/csgo_gc/gc_client.cpp
+++ b/csgo_gc/gc_client.cpp
@@ -1218,7 +1218,16 @@ void ClientGC::HandleMatchListRequest(GCMessageRead &messageRead)
         return;
     }
 
+    const uint32_t requestType = messageRead.TypeUnmasked();
+    if (requestType == k_EMsgGCCStrike15_v2_MatchListRequestTournamentPredictions)
+    {
+        CMsgGCCStrike15_v2_Predictions response;
+        SendMessageToGame(false, requestType, response, messageRead.JobId());
+        return;
+    }
+
     CMsgGCCStrike15_v2_MatchList response;
+    response.set_msgrequestid(requestType);
     response.set_accountid(AccountId());
     response.set_servertime(static_cast<uint32_t>(std::time(nullptr)));
     SendMessageToGame(false, k_EMsgGCCStrike15_v2_MatchList, response, messageRead.JobId());

--- a/csgo_gc/gc_client.cpp
+++ b/csgo_gc/gc_client.cpp
@@ -1226,6 +1226,15 @@ void ClientGC::HandleMatchListRequest(GCMessageRead &messageRead)
         return;
     }
 
+    if (requestType == k_EMsgGCCStrike15_v2_MatchListRequestTournamentGames)
+    {
+        CMsgGCCStrike15_v2_MatchListRequestTournamentGames request;
+        if (!messageRead.ReadProtobuf(request))
+        {
+            return;
+        }
+    }
+
     CMsgGCCStrike15_v2_MatchList response;
     response.set_msgrequestid(requestType);
     response.set_accountid(AccountId());

--- a/csgo_gc/gc_client.cpp
+++ b/csgo_gc/gc_client.cpp
@@ -9,6 +9,7 @@
 #include <cerrno>
 #include <cmath>
 #include <cstdlib>
+#include <ctime>
 
 namespace
 {
@@ -1057,6 +1058,40 @@ void ClientGC::HandleMessage(uint32_t type, const void *data, uint32_t size)
             HandleRequestSouvenir(messageRead);
             break;
 
+        case k_EMsgGCCStrike15_v2_MatchmakingStart:
+            IgnoreMatchmakingStart(messageRead);
+            break;
+
+        case k_EMsgGCCStrike15_v2_MatchmakingStop:
+            IgnoreMatchmakingStop(messageRead);
+            break;
+
+        case k_EMsgGCCStrike15_v2_Party_Register:
+            IgnorePartyRegister(messageRead);
+            break;
+
+        case k_EMsgGCCStrike15_v2_Party_Unregister:
+            IgnorePartyUnregister(messageRead);
+            break;
+
+        case k_EMsgGCCStrike15_v2_Party_Search:
+            HandlePartySearch(messageRead);
+            break;
+
+        case k_EMsgGCCStrike15_v2_Account_RequestCoPlays:
+            HandleAccountRequestCoPlays(messageRead);
+            break;
+
+        case k_EMsgGCCStrike15_v2_AccountPrivacySettings:
+            HandleAccountPrivacySettings(messageRead);
+            break;
+
+        case k_EMsgGCCStrike15_v2_MatchListRequestCurrentLiveGames:
+        case k_EMsgGCCStrike15_v2_MatchListRequestTournamentGames:
+        case k_EMsgGCCStrike15_v2_MatchListRequestTournamentPredictions:
+            HandleMatchListRequest(messageRead);
+            break;
+
         default:
             Platform::Print("ClientGC::HandleMessage: unhandled protobuf message %s\n",
                 MessageName(messageRead.TypeUnmasked()));
@@ -1097,6 +1132,96 @@ void ClientGC::HandleMessage(uint32_t type, const void *data, uint32_t size)
             break;
         }
     }
+}
+
+void ClientGC::IgnoreMatchmakingStart(GCMessageRead &messageRead)
+{
+    CMsgGCCStrike15_v2_MatchmakingStart request;
+    (void)messageRead.ReadProtobuf(request);
+}
+
+void ClientGC::IgnoreMatchmakingStop(GCMessageRead &messageRead)
+{
+    CMsgGCCStrike15_v2_MatchmakingStop request;
+    (void)messageRead.ReadProtobuf(request);
+}
+
+void ClientGC::IgnorePartyRegister(GCMessageRead &messageRead)
+{
+    CMsgGCCStrike15_v2_Party_Register request;
+    (void)messageRead.ReadProtobuf(request);
+}
+
+void ClientGC::IgnorePartyUnregister(GCMessageRead &messageRead)
+{
+    // Party_Unregister has no protobuf message definition.
+    (void)messageRead;
+}
+
+void ClientGC::HandlePartySearch(GCMessageRead &messageRead)
+{
+    CMsgGCCStrike15_v2_Party_Search request;
+    if (!messageRead.ReadProtobuf(request) || messageRead.JobId() == JobIdInvalid)
+    {
+        return;
+    }
+
+    // Party_SearchResults has no separate EMsg; it is a response to the request job.
+    CMsgGCCStrike15_v2_Party_SearchResults response;
+    SendMessageToGame(false, k_EMsgGCCStrike15_v2_Party_Search, response, messageRead.JobId());
+}
+
+void ClientGC::HandleAccountRequestCoPlays(GCMessageRead &messageRead)
+{
+    CMsgGCCStrike15_v2_Account_RequestCoPlays request;
+    if (!messageRead.ReadProtobuf(request) || messageRead.JobId() == JobIdInvalid)
+    {
+        return;
+    }
+
+    CMsgGCCStrike15_v2_Account_RequestCoPlays response;
+    for (int index = 0; index < request.players_size(); ++index)
+    {
+        const auto &player = request.players(index);
+        auto *responsePlayer = response.add_players();
+        responsePlayer->set_accountid(player.accountid());
+        if (player.has_rtcoplay())
+        {
+            responsePlayer->set_rtcoplay(player.rtcoplay());
+        }
+        responsePlayer->set_online(false);
+    }
+    response.set_servertime(static_cast<uint32_t>(std::time(nullptr)));
+
+    SendMessageToGame(false, k_EMsgGCCStrike15_v2_Account_RequestCoPlays,
+        response, messageRead.JobId());
+}
+
+void ClientGC::HandleAccountPrivacySettings(GCMessageRead &messageRead)
+{
+    CMsgGCCStrike15_v2_AccountPrivacySettings request;
+    if (!messageRead.ReadProtobuf(request) || messageRead.JobId() == JobIdInvalid)
+    {
+        return;
+    }
+
+    // The empty request used by the settings UI receives an empty default-setting list.
+    // Settings supplied by the client are echoed as the current session's values.
+    SendMessageToGame(false, k_EMsgGCCStrike15_v2_AccountPrivacySettings,
+        request, messageRead.JobId());
+}
+
+void ClientGC::HandleMatchListRequest(GCMessageRead &messageRead)
+{
+    if (messageRead.JobId() == JobIdInvalid)
+    {
+        return;
+    }
+
+    CMsgGCCStrike15_v2_MatchList response;
+    response.set_accountid(AccountId());
+    response.set_servertime(static_cast<uint32_t>(std::time(nullptr)));
+    SendMessageToGame(false, k_EMsgGCCStrike15_v2_MatchList, response, messageRead.JobId());
 }
 
 void ClientGC::HandleNetMessage(const void *data, uint32_t size)

--- a/csgo_gc/gc_client.h
+++ b/csgo_gc/gc_client.h
@@ -79,6 +79,14 @@ private:
     void StoreGetUserData(GCMessageRead &messageRead);
     void StorePurchaseInit(GCMessageRead &messageRead);
     void StorePurchaseFinalize(GCMessageRead &messageRead);
+    void IgnoreMatchmakingStart(GCMessageRead &messageRead);
+    void IgnoreMatchmakingStop(GCMessageRead &messageRead);
+    void IgnorePartyRegister(GCMessageRead &messageRead);
+    void IgnorePartyUnregister(GCMessageRead &messageRead);
+    void HandlePartySearch(GCMessageRead &messageRead);
+    void HandleAccountRequestCoPlays(GCMessageRead &messageRead);
+    void HandleAccountPrivacySettings(GCMessageRead &messageRead);
+    void HandleMatchListRequest(GCMessageRead &messageRead);
 
     void DeleteItem(GCMessageRead &messageRead);
     void UnlockCrate(GCMessageRead &messageRead);

--- a/csgo_gc/gc_message_tests.cpp
+++ b/csgo_gc/gc_message_tests.cpp
@@ -2971,6 +2971,14 @@ static bool OfflineGCRequestsReceiveMinimalResponses()
         && !tournamentPredictions.has_event_id()
         && tournamentPredictions.group_match_team_picks_size() == 0;
 
+    constexpr uint8_t TruncatedTournamentGamesRequest[] = { 0x80 };
+    valid &= SendGCProtobufJobData(gc,
+            k_EMsgGCCStrike15_v2_MatchListRequestTournamentGames,
+            TruncatedTournamentGamesRequest,
+            sizeof(TruncatedTournamentGamesRequest),
+            8108)
+        && HostMessageNotReceived(gc, k_EMsgGCCStrike15_v2_MatchList);
+
     return valid
         && Platform::g_printCount.load(std::memory_order_relaxed) == printCountBefore;
 }

--- a/csgo_gc/gc_message_tests.cpp
+++ b/csgo_gc/gc_message_tests.cpp
@@ -11,8 +11,11 @@
 namespace Platform
 {
 
+static std::atomic<uint32_t> g_printCount{};
+
 void Print(const char *, ...)
 {
+    g_printCount.fetch_add(1, std::memory_order_relaxed);
 }
 
 bool UpdateGraffitiKey(std::string_view, const void *, const void *, size_t)
@@ -2848,6 +2851,121 @@ static bool EventFavoritesPersistAndPreserveRequestJobs()
     return valid;
 }
 
+static bool OfflineGCRequestsReceiveMinimalResponses()
+{
+    constexpr uint64_t SteamId = 76561197960265729ull;
+    ClientGC gc{ SteamId };
+
+    const uint32_t printCountBefore = Platform::g_printCount.load(std::memory_order_relaxed);
+    bool valid = true;
+
+    CMsgGCCStrike15_v2_MatchmakingStart matchmakingStart;
+    SendGCProtobuf(gc, k_EMsgGCCStrike15_v2_MatchmakingStart, matchmakingStart);
+
+    CMsgGCCStrike15_v2_MatchmakingStop matchmakingStop;
+    SendGCProtobuf(gc, k_EMsgGCCStrike15_v2_MatchmakingStop, matchmakingStop);
+
+    CMsgGCCStrike15_v2_Party_Register partyRegister;
+    SendGCProtobuf(gc, k_EMsgGCCStrike15_v2_Party_Register, partyRegister);
+
+    CMsgGCCStrike15_v2_MatchListRequestCurrentLiveGames emptyRequest;
+    SendGCProtobuf(gc, k_EMsgGCCStrike15_v2_Party_Unregister, emptyRequest);
+
+    CMsgGCCStrike15_v2_Party_Search partySearch;
+    partySearch.set_game_type(1234);
+    constexpr uint64_t PartySearchJobId = 8101;
+    valid &= SendGCProtobufJob(gc, k_EMsgGCCStrike15_v2_Party_Search,
+        partySearch, PartySearchJobId);
+
+    EventData event;
+    CMsgGCCStrike15_v2_Party_SearchResults partySearchResponse;
+    valid &= WaitForHostMessage(gc, k_EMsgGCCStrike15_v2_Party_Search, event)
+        && ParseHostJobProtobuf(event, PartySearchJobId, partySearchResponse)
+        && partySearchResponse.entries_size() == 0;
+
+    CMsgGCCStrike15_v2_Account_RequestCoPlays coPlays;
+    auto *firstPlayer = coPlays.add_players();
+    firstPlayer->set_accountid(123);
+    firstPlayer->set_rtcoplay(456);
+    auto *secondPlayer = coPlays.add_players();
+    secondPlayer->set_accountid(789);
+    constexpr uint64_t CoPlaysJobId = 8102;
+    valid &= SendGCProtobufJob(gc, k_EMsgGCCStrike15_v2_Account_RequestCoPlays,
+        coPlays, CoPlaysJobId);
+
+    event = {};
+    CMsgGCCStrike15_v2_Account_RequestCoPlays coPlaysResponse;
+    valid &= WaitForHostMessage(gc, k_EMsgGCCStrike15_v2_Account_RequestCoPlays, event)
+        && ParseHostJobProtobuf(event, CoPlaysJobId, coPlaysResponse)
+        && coPlaysResponse.players_size() == 2
+        && coPlaysResponse.players(0).accountid() == 123
+        && coPlaysResponse.players(0).rtcoplay() == 456
+        && !coPlaysResponse.players(0).online()
+        && coPlaysResponse.players(1).accountid() == 789
+        && !coPlaysResponse.players(1).has_rtcoplay()
+        && !coPlaysResponse.players(1).online()
+        && coPlaysResponse.servertime() != 0;
+
+    CMsgGCCStrike15_v2_AccountPrivacySettings privacySettings;
+    constexpr uint64_t PrivacySettingsJobId = 8103;
+    valid &= SendGCProtobufJob(gc, k_EMsgGCCStrike15_v2_AccountPrivacySettings,
+        privacySettings, PrivacySettingsJobId);
+
+    event = {};
+    CMsgGCCStrike15_v2_AccountPrivacySettings privacySettingsResponse;
+    valid &= WaitForHostMessage(gc, k_EMsgGCCStrike15_v2_AccountPrivacySettings, event)
+        && ParseHostJobProtobuf(event, PrivacySettingsJobId, privacySettingsResponse)
+        && privacySettingsResponse.settings_size() == 0;
+
+    auto *privacySetting = privacySettings.add_settings();
+    privacySetting->set_setting_type(1);
+    privacySetting->set_setting_value(3);
+    constexpr uint64_t PrivacySettingsUpdateJobId = 8104;
+    valid &= SendGCProtobufJob(gc, k_EMsgGCCStrike15_v2_AccountPrivacySettings,
+        privacySettings, PrivacySettingsUpdateJobId);
+
+    event = {};
+    privacySettingsResponse.Clear();
+    valid &= WaitForHostMessage(gc, k_EMsgGCCStrike15_v2_AccountPrivacySettings, event)
+        && ParseHostJobProtobuf(event, PrivacySettingsUpdateJobId, privacySettingsResponse)
+        && privacySettingsResponse.settings_size() == 1
+        && privacySettingsResponse.settings(0).setting_type() == 1
+        && privacySettingsResponse.settings(0).setting_value() == 3;
+
+    auto checkEmptyMatchList = [&gc, &event](uint32_t requestType,
+        const void *requestData, uint32_t requestSize, uint64_t jobId)
+    {
+        if (!SendGCProtobufJobData(gc, requestType, requestData, requestSize, jobId))
+        {
+            return false;
+        }
+
+        event = {};
+        CMsgGCCStrike15_v2_MatchList matchList;
+        return WaitForHostMessage(gc, k_EMsgGCCStrike15_v2_MatchList, event)
+            && ParseHostJobProtobuf(event, jobId, matchList)
+            && matchList.accountid() == static_cast<uint32_t>(SteamId)
+            && matchList.servertime() != 0
+            && matchList.matches_size() == 0;
+    };
+
+    valid &= checkEmptyMatchList(k_EMsgGCCStrike15_v2_MatchListRequestCurrentLiveGames,
+        nullptr, 0, 8105);
+
+    CMsgGCCStrike15_v2_MatchListRequestTournamentGames tournamentGames;
+    tournamentGames.set_eventid(2023);
+    std::string tournamentGamesData;
+    valid &= tournamentGames.SerializeToString(&tournamentGamesData)
+        && checkEmptyMatchList(k_EMsgGCCStrike15_v2_MatchListRequestTournamentGames,
+            tournamentGamesData.data(), static_cast<uint32_t>(tournamentGamesData.size()), 8106);
+
+    valid &= checkEmptyMatchList(k_EMsgGCCStrike15_v2_MatchListRequestTournamentPredictions,
+        nullptr, 0, 8107);
+
+    return valid
+        && Platform::g_printCount.load(std::memory_order_relaxed) == printCountBefore;
+}
+
 int main()
 {
     struct TestCase
@@ -2890,6 +3008,8 @@ int main()
             SeasonalMissionCardSelectionValidatesAndPersists },
         { "EventFavoritesPersistAndPreserveRequestJobs",
             EventFavoritesPersistAndPreserveRequestJobs },
+        { "OfflineGCRequestsReceiveMinimalResponses",
+            OfflineGCRequestsReceiveMinimalResponses },
     };
 
     bool allPassed = true;

--- a/csgo_gc/gc_message_tests.cpp
+++ b/csgo_gc/gc_message_tests.cpp
@@ -2944,6 +2944,7 @@ static bool OfflineGCRequestsReceiveMinimalResponses()
         CMsgGCCStrike15_v2_MatchList matchList;
         return WaitForHostMessage(gc, k_EMsgGCCStrike15_v2_MatchList, event)
             && ParseHostJobProtobuf(event, jobId, matchList)
+            && matchList.msgrequestid() == requestType
             && matchList.accountid() == static_cast<uint32_t>(SteamId)
             && matchList.servertime() != 0
             && matchList.matches_size() == 0;
@@ -2959,8 +2960,16 @@ static bool OfflineGCRequestsReceiveMinimalResponses()
         && checkEmptyMatchList(k_EMsgGCCStrike15_v2_MatchListRequestTournamentGames,
             tournamentGamesData.data(), static_cast<uint32_t>(tournamentGamesData.size()), 8106);
 
-    valid &= checkEmptyMatchList(k_EMsgGCCStrike15_v2_MatchListRequestTournamentPredictions,
-        nullptr, 0, 8107);
+    constexpr uint64_t TournamentPredictionsJobId = 8107;
+    valid &= SendGCProtobufJobData(gc, k_EMsgGCCStrike15_v2_MatchListRequestTournamentPredictions,
+            nullptr, 0, TournamentPredictionsJobId);
+
+    event = {};
+    CMsgGCCStrike15_v2_Predictions tournamentPredictions;
+    valid &= WaitForHostMessage(gc, k_EMsgGCCStrike15_v2_MatchListRequestTournamentPredictions, event)
+        && ParseHostJobProtobuf(event, TournamentPredictionsJobId, tournamentPredictions)
+        && !tournamentPredictions.has_event_id()
+        && tournamentPredictions.group_match_team_picks_size() == 0;
 
     return valid
         && Platform::g_printCount.load(std::memory_order_relaxed) == printCountBefore;


### PR DESCRIPTION
## Summary
- handle final-client matchmaking, party, co-play, privacy, and match-list requests without unhandled-message spam
- return protocol-correct minimal offline responses for client jobs
- add regression coverage for response bodies and target job IDs

## Validation
- build csgo_gc and gc_message_tests
- run CTest: 6/6 passed

Fixes #81

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded offline game-coordinator support for matchmaking, party search, co-play, privacy settings, and match-list requests.
  - Added correlated responses for party-search and match-list requests.
  - Offline co-play responses now include the current server time.
  - Privacy-setting requests now receive an echoed response.
  - Tournament prediction requests now receive an empty response.
  - Unsupported requests are handled gracefully, and malformed tournament-game requests are rejected safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->