### PR TITLE
Add prime_status config option to freeze the reported prime state

### DIFF
--- a/csgo_gc/CMakeLists.txt
+++ b/csgo_gc/CMakeLists.txt
@@ -133,6 +133,44 @@ if (BUILD_TESTING)
 
     add_test(NAME gc_message_tests COMMAND gc_message_tests)
 
+    add_executable(gc_message_non_prime_tests
+        appid.cpp
+        case_opening.cpp
+        config.cpp
+        gc_client.cpp
+        gc_shared.cpp
+        gc_message_non_prime_tests.cpp
+        gc_message.cpp
+        inventory.cpp
+        item_schema.cpp
+        item_utils.cpp
+        keyvalue.cpp
+        graffiti.cpp
+        networking_client.cpp
+        souvenir.cpp)
+
+    target_precompile_headers(gc_message_non_prime_tests PRIVATE stdafx.h)
+    target_link_libraries(gc_message_non_prime_tests PRIVATE
+        MbedTLS::mbedcrypto
+        csgo_gc_protobufs
+        steam_api
+        Threads::Threads)
+
+    if (MSVC)
+        target_compile_options(gc_message_non_prime_tests PRIVATE /W4 /wd4244 /wd4819)
+        target_compile_definitions(gc_message_non_prime_tests PRIVATE _CRT_SECURE_NO_WARNINGS)
+    else()
+        target_compile_options(gc_message_non_prime_tests PRIVATE -Wall -Wextra)
+    endif()
+
+    set(NON_PRIME_TEST_WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/gc_message_non_prime_test_workdir")
+    file(MAKE_DIRECTORY "${NON_PRIME_TEST_WORKING_DIRECTORY}/csgo_gc")
+    file(WRITE "${NON_PRIME_TEST_WORKING_DIRECTORY}/csgo_gc/config.txt"
+        "\"prime_status\"\t\t\"0\"\n")  # trailing newline required by the keyvalue parser
+    add_test(NAME gc_message_non_prime_tests COMMAND gc_message_non_prime_tests)
+    set_tests_properties(gc_message_non_prime_tests PROPERTIES
+        WORKING_DIRECTORY "${NON_PRIME_TEST_WORKING_DIRECTORY}")
+
     add_executable(item_schema_tests
         item_schema_tests.cpp
         item_schema.cpp

--- a/csgo_gc/config.cpp
+++ b/csgo_gc/config.cpp
@@ -48,6 +48,7 @@ GCConfig::GCConfig()
     }
 
     m_destroyUsedItems = config.GetNumber("destroy_used_items", m_destroyUsedItems);
+    m_primeStatus = config.GetNumber("prime_status", m_primeStatus);
 
     const KeyValue *rarityWeights = config.GetSubkey("rarity_weights");
     if (rarityWeights)

--- a/csgo_gc/config.h
+++ b/csgo_gc/config.h
@@ -42,6 +42,9 @@ public:
 
     bool DestroyUsedItems() const { return m_destroyUsedItems; }
 
+    // prime status shown to the game client, frozen at the configured value
+    bool PrimeStatus() const { return m_primeStatus; }
+
     bool AccountStatus() const { return m_vacBanned; }
     int CommendedFriendly() const { return m_commendedFriendly; }
     int CommendedTeaching() const { return m_commendedTeaching; }
@@ -71,6 +74,9 @@ private:
     int m_dangerZoneWins{ 0 };
 
     bool m_destroyUsedItems{ true };
+
+    // accounts default to prime so existing clients keep their current behavior
+    bool m_primeStatus{ true };
 
     bool m_vacBanned{ false };
     int m_commendedFriendly{ 0 };

--- a/csgo_gc/gc_message_non_prime_tests.cpp
+++ b/csgo_gc/gc_message_non_prime_tests.cpp
@@ -1,0 +1,74 @@
+#include "stdafx.h"
+#include "config.h"
+#include "inventory.h"
+#include "keyvalue.h"
+#include "networking_client.h"
+#include "test_filesystem.h"
+
+#include <cstdio>
+
+namespace Platform
+{
+
+void Print(const char *, ...)
+{
+}
+
+bool UpdateGraffitiKey(std::string_view, const void *, const void *, size_t)
+{
+    return true;
+}
+
+}
+
+S_API void S_CALLTYPE SteamAPI_RegisterCallback(CCallbackBase *, int)
+{
+}
+
+S_API void S_CALLTYPE SteamAPI_UnregisterCallback(CCallbackBase *)
+{
+}
+
+static bool NonPrimeStatusFreezesReportedElevatedState()
+{
+    constexpr uint64_t SteamId = 76561197960265729ull;
+
+    // This process is launched with a dedicated working directory whose
+    // csgo_gc/config.txt disables prime_status, since GetConfig() latches
+    // on first use and cannot switch configurations within one process.
+    bool valid = GetConfig().PrimeStatus() == false;
+    {
+        Inventory inventory{ SteamId };
+        CMsgSOCacheSubscribed subscription;
+        inventory.BuildCacheSubscription(subscription, false);
+
+        bool foundAccount = false;
+        bool foundPersona = false;
+        for (const CMsgSOCacheSubscribed_SubscribedType &type : subscription.objects())
+        {
+            if (type.type_id() == SOTypeGameAccountClient && type.object_data_size() == 1)
+            {
+                CSOEconGameAccountClient account;
+                foundAccount = account.ParseFromString(type.object_data(0));
+                valid &= foundAccount && account.elevated_state() == ElevatedStateNo;
+            }
+            else if (type.type_id() == SOTypePersonaDataPublic && type.object_data_size() == 1)
+            {
+                CSOPersonaDataPublic personaData;
+                foundPersona = personaData.ParseFromString(type.object_data(0));
+                valid &= foundPersona && !personaData.elevated_state();
+            }
+        }
+        valid &= foundAccount && foundPersona;
+    }
+
+    TestFilesystem::RemoveFile("csgo_gc/inventory.txt");
+    return valid;
+}
+
+int main()
+{
+    const bool passed = NonPrimeStatusFreezesReportedElevatedState();
+    std::printf("NonPrimeStatusFreezesReportedElevatedState: %s\n", passed ? "PASS" : "FAIL");
+    return passed ? 0 : 1;
+}

--- a/csgo_gc/gc_message_tests.cpp
+++ b/csgo_gc/gc_message_tests.cpp
@@ -818,6 +818,7 @@ static bool SOCacheVersionNegotiationAndRefresh()
                 && subscription.owner_soid().id() == SteamId;
 
             bool foundAccount = false;
+            bool foundPersona = false;
             for (const CMsgSOCacheSubscribed_SubscribedType &type : subscription.objects())
             {
                 if (type.type_id() == SOTypeGameAccountClient && type.object_data_size() == 1)
@@ -825,9 +826,18 @@ static bool SOCacheVersionNegotiationAndRefresh()
                     CSOEconGameAccountClient account;
                     foundAccount = account.ParseFromString(type.object_data(0));
                     valid &= foundAccount && !account.has_elevated_timestamp();
+                    // no config.txt is present in the test environment, so the
+                    // default frozen prime state must be reported
+                    valid &= foundAccount && account.elevated_state() == ElevatedStatePrime;
+                }
+                else if (type.type_id() == SOTypePersonaDataPublic && type.object_data_size() == 1)
+                {
+                    CSOPersonaDataPublic personaData;
+                    foundPersona = personaData.ParseFromString(type.object_data(0));
+                    valid &= foundPersona && personaData.elevated_state();
                 }
             }
-            valid &= foundAccount;
+            valid &= foundAccount && foundPersona;
         }
 
         CMsgClientHello currentHello;

--- a/csgo_gc/inventory.cpp
+++ b/csgo_gc/inventory.cpp
@@ -281,7 +281,7 @@ bool Inventory::ClaimPrestigeMedal(uint32_t year, uint32_t expectedDefIndex,
 
     CSOPersonaDataPublic personaData;
     personaData.set_player_level(m_playerLevel);
-    personaData.set_elevated_state(true);
+    personaData.set_elevated_state(GetConfig().PrimeStatus());
     ToSingleObject(claim.personaData, SOTypePersonaDataPublic, personaData);
 
     if (!WriteToFile())
@@ -764,7 +764,7 @@ void Inventory::BuildCacheSubscription(CMsgSOCacheSubscribed &message, bool serv
     {
         CSOPersonaDataPublic personaData;
         personaData.set_player_level(m_playerLevel);
-        personaData.set_elevated_state(true);
+        personaData.set_elevated_state(GetConfig().PrimeStatus());
 
         CMsgSOCacheSubscribed_SubscribedType *object = message.add_objects();
         object->set_type_id(SOTypePersonaDataPublic);
@@ -788,7 +788,7 @@ void Inventory::BuildCacheSubscription(CMsgSOCacheSubscribed &message, bool serv
         accountClient.set_additional_backpack_slots(0);
         accountClient.set_bonus_xp_timestamp_refresh(static_cast<uint32_t>(time(nullptr)));
         accountClient.set_bonus_xp_usedflags(16); // caught cheater lobbies, overwatch bonus etc
-        accountClient.set_elevated_state(ElevatedStatePrime);
+        accountClient.set_elevated_state(GetConfig().PrimeStatus() ? ElevatedStatePrime : ElevatedStateNo);
 
         CMsgSOCacheSubscribed_SubscribedType *object = message.add_objects();
         object->set_type_id(SOTypeGameAccountClient);

--- a/examples/config.txt
+++ b/examples/config.txt
@@ -16,6 +16,9 @@
 "player_level"	"39"
 "player_cur_xp"	"4999"
 
+// 1 reports the account as prime (unchanged behavior), 0 reports it as non-prime
+"prime_status"	"1"
+
 // these are the same weights valve uses
 "rarity_weights"
 {


### PR DESCRIPTION
Adds a \prime_status\ setting (default \1\) so the Prime state reported to the client is configurable instead of hardcoded.

Previously the GC always published every account as prime (\ElevatedStatePrime\ in \CSOEconGameAccountClient\ and \levated_state=true\ in \CSOPersonaDataPublic\). Setting \prime_status\ to \

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a configurable Prime status setting for accounts.
  - Prime status can be enabled or disabled through configuration.
  - Account and profile status information now reflects the configured Prime setting.
  - The default configuration keeps accounts marked as Prime.
  - Non-Prime accounts now report non-elevated status information.

- **Documentation**
  - Added configuration guidance explaining Prime status values: `1` for Prime and `0` for non-Prime.

- **Tests**
  - Added coverage verifying Prime and non-Prime account status behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->