### PR TITLE
Add local achievement persistence

### DIFF
--- a/csgo_gc/CMakeLists.txt
+++ b/csgo_gc/CMakeLists.txt
@@ -32,6 +32,7 @@ add_library(csgo_gc SHARED
     item_schema.cpp
     item_utils.cpp
     keyvalue.cpp
+    local_user_stats.cpp
     main.cpp
     networking_client.cpp
     networking_server.cpp
@@ -274,4 +275,26 @@ if (BUILD_TESTING)
     add_test(NAME saved_item_shuffles_tests COMMAND saved_item_shuffles_tests)
     set_tests_properties(saved_item_shuffles_tests PROPERTIES
         WORKING_DIRECTORY "${SAVED_ITEM_SHUFFLES_TEST_WORKING_DIRECTORY}")
+
+    add_executable(local_user_stats_tests
+        keyvalue.cpp
+        local_user_stats.cpp
+        local_user_stats_tests.cpp)
+
+    target_precompile_headers(local_user_stats_tests PRIVATE stdafx.h)
+    target_link_libraries(local_user_stats_tests PRIVATE csgo_gc_protobufs)
+
+    if (MSVC)
+        target_compile_options(local_user_stats_tests PRIVATE /W4 /wd4244 /wd4819)
+        target_compile_definitions(local_user_stats_tests PRIVATE _CRT_SECURE_NO_WARNINGS)
+    else()
+        target_compile_options(local_user_stats_tests PRIVATE -Wall -Wextra)
+    endif()
+
+    set(LOCAL_USER_STATS_TEST_WORKING_DIRECTORY
+        "${CMAKE_CURRENT_BINARY_DIR}/local_user_stats_test_workdir")
+    file(MAKE_DIRECTORY "${LOCAL_USER_STATS_TEST_WORKING_DIRECTORY}")
+    add_test(NAME local_user_stats_tests COMMAND local_user_stats_tests)
+    set_tests_properties(local_user_stats_tests PROPERTIES
+        WORKING_DIRECTORY "${LOCAL_USER_STATS_TEST_WORKING_DIRECTORY}")
 endif()

--- a/csgo_gc/local_user_stats.cpp
+++ b/csgo_gc/local_user_stats.cpp
@@ -3,7 +3,13 @@
 #include "keyvalue.h"
 
 #include <bit>
-#include <filesystem>
+#include <cerrno>
+
+#ifdef _WIN32
+#include <direct.h>
+#else
+#include <sys/stat.h>
+#endif
 
 namespace LocalUserStats
 {
@@ -56,6 +62,23 @@ std::vector<std::string> SortedNames(const std::unordered_map<std::string, T> &v
     }
     std::sort(names.begin(), names.end());
     return names;
+}
+
+bool EnsureParentDirectoryExists(std::string_view path)
+{
+    size_t separator = path.find_last_of("/\\");
+    if (separator == std::string_view::npos)
+    {
+        return true;
+    }
+
+    std::string parent{ path.substr(0, separator) };
+#ifdef _WIN32
+    int result = _mkdir(parent.c_str());
+#else
+    int result = mkdir(parent.c_str(), 0755);
+#endif
+    return result == 0 || errno == EEXIST;
 }
 
 } // namespace
@@ -247,15 +270,9 @@ bool Store::Save(std::vector<std::string> &storedAchievements)
         return false;
     }
 
-    std::filesystem::path parent = std::filesystem::path{ m_path }.parent_path();
-    std::error_code error;
-    if (!parent.empty())
+    if (!EnsureParentDirectoryExists(m_path))
     {
-        std::filesystem::create_directories(parent, error);
-        if (error)
-        {
-            return false;
-        }
+        return false;
     }
 
     KeyValue root{ "user_stats" };

--- a/csgo_gc/local_user_stats.cpp
+++ b/csgo_gc/local_user_stats.cpp
@@ -1,0 +1,318 @@
+#include "stdafx.h"
+#include "local_user_stats.h"
+#include "keyvalue.h"
+
+#include <bit>
+#include <filesystem>
+
+namespace LocalUserStats
+{
+
+namespace
+{
+
+constexpr uint32_t FileVersion = 1;
+constexpr size_t MaxNameLength = 127;
+
+bool IsSerializableName(std::string_view name)
+{
+    if (name.empty() || name.size() > MaxNameLength)
+    {
+        return false;
+    }
+
+    for (unsigned char character : name)
+    {
+        if (character < ' ' || character == '"')
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+template<typename T>
+bool ParseNumber(std::string_view string, T &value)
+{
+    T parsed{};
+    auto result = std::from_chars(string.data(), string.data() + string.size(), parsed);
+    if (result.ec != std::errc{} || result.ptr != string.data() + string.size())
+    {
+        return false;
+    }
+    value = parsed;
+    return true;
+}
+
+template<typename T>
+std::vector<std::string> SortedNames(const std::unordered_map<std::string, T> &values)
+{
+    std::vector<std::string> names;
+    names.reserve(values.size());
+    for (const auto &[name, value] : values)
+    {
+        (void)value;
+        names.push_back(name);
+    }
+    std::sort(names.begin(), names.end());
+    return names;
+}
+
+} // namespace
+
+Store::Store(std::string path)
+    : m_path{ std::move(path) }
+{
+}
+
+LoadResult Store::Load()
+{
+    KeyValue root{ "user_stats" };
+    KeyValueFileResult fileResult = root.ParseFromFileDetailed(m_path.c_str());
+    if (fileResult == KeyValueFileResult::NotFound)
+    {
+        m_integerStats.clear();
+        m_floatStats.clear();
+        m_achievements.clear();
+        m_pendingAchievements.clear();
+        m_loaded = true;
+        return LoadResult::NotFound;
+    }
+    if (fileResult == KeyValueFileResult::ReadError)
+    {
+        return LoadResult::ReadError;
+    }
+    if (fileResult != KeyValueFileResult::Success)
+    {
+        return LoadResult::InvalidFormat;
+    }
+
+    uint32_t version{};
+    const KeyValue *versionValue = root.GetSubkey("version");
+    if (!versionValue || !ParseNumber(versionValue->String(), version) || version != FileVersion)
+    {
+        return LoadResult::InvalidFormat;
+    }
+
+    std::unordered_map<std::string, int32_t> integerStats;
+    std::unordered_map<std::string, float> floatStats;
+    std::unordered_map<std::string, uint32_t> achievements;
+    if (const KeyValue *section = root.GetSubkey("integer_stats"))
+    {
+        for (const KeyValue &entry : *section)
+        {
+            int32_t value{};
+            if (!IsSerializableName(entry.Name()) || !ParseNumber(entry.String(), value))
+            {
+                return LoadResult::InvalidFormat;
+            }
+            if (!integerStats.emplace(entry.Name(), value).second)
+            {
+                return LoadResult::InvalidFormat;
+            }
+        }
+    }
+
+    if (const KeyValue *section = root.GetSubkey("float_stats"))
+    {
+        for (const KeyValue &entry : *section)
+        {
+            uint32_t bits{};
+            if (!IsSerializableName(entry.Name()) || !ParseNumber(entry.String(), bits)
+                || integerStats.contains(std::string{ entry.Name() }))
+            {
+                return LoadResult::InvalidFormat;
+            }
+            if (!floatStats.emplace(entry.Name(), std::bit_cast<float>(bits)).second)
+            {
+                return LoadResult::InvalidFormat;
+            }
+        }
+    }
+
+    if (const KeyValue *section = root.GetSubkey("achievements"))
+    {
+        for (const KeyValue &entry : *section)
+        {
+            uint32_t unlockTime{};
+            if (!IsSerializableName(entry.Name()) || !ParseNumber(entry.String(), unlockTime))
+            {
+                return LoadResult::InvalidFormat;
+            }
+            if (!achievements.emplace(entry.Name(), unlockTime).second)
+            {
+                return LoadResult::InvalidFormat;
+            }
+        }
+    }
+
+    m_integerStats = std::move(integerStats);
+    m_floatStats = std::move(floatStats);
+    m_achievements = std::move(achievements);
+    m_pendingAchievements.clear();
+    m_loaded = true;
+    return LoadResult::Success;
+}
+
+bool Store::IsValidName(std::string_view name)
+{
+    return IsSerializableName(name);
+}
+
+bool Store::GetStat(std::string_view name, int32_t &value) const
+{
+    if (!m_loaded || !IsValidName(name) || m_floatStats.contains(std::string{ name }))
+    {
+        return false;
+    }
+    auto it = m_integerStats.find(std::string{ name });
+    value = it == m_integerStats.end() ? 0 : it->second;
+    return true;
+}
+
+bool Store::GetStat(std::string_view name, float &value) const
+{
+    if (!m_loaded || !IsValidName(name) || m_integerStats.contains(std::string{ name }))
+    {
+        return false;
+    }
+    auto it = m_floatStats.find(std::string{ name });
+    value = it == m_floatStats.end() ? 0.0f : it->second;
+    return true;
+}
+
+bool Store::SetStat(std::string_view name, int32_t value)
+{
+    if (!m_loaded || !IsValidName(name) || m_floatStats.contains(std::string{ name }))
+    {
+        return false;
+    }
+    m_integerStats[std::string{ name }] = value;
+    return true;
+}
+
+bool Store::SetStat(std::string_view name, float value)
+{
+    if (!m_loaded || !IsValidName(name) || m_integerStats.contains(std::string{ name }))
+    {
+        return false;
+    }
+    m_floatStats[std::string{ name }] = value;
+    return true;
+}
+
+bool Store::GetAchievement(std::string_view name, bool &achieved, uint32_t &unlockTime) const
+{
+    if (!m_loaded || !IsValidName(name))
+    {
+        return false;
+    }
+    auto it = m_achievements.find(std::string{ name });
+    achieved = it != m_achievements.end();
+    unlockTime = achieved ? it->second : 0;
+    return true;
+}
+
+bool Store::SetAchievement(std::string_view name, uint32_t unlockTime)
+{
+    if (!m_loaded || !IsValidName(name))
+    {
+        return false;
+    }
+
+    std::string ownedName{ name };
+    if (m_achievements.emplace(ownedName, unlockTime).second)
+    {
+        m_pendingAchievements.emplace(std::move(ownedName));
+    }
+    return true;
+}
+
+bool Store::ClearAchievement(std::string_view name)
+{
+    if (!m_loaded || !IsValidName(name))
+    {
+        return false;
+    }
+    std::string ownedName{ name };
+    m_achievements.erase(ownedName);
+    m_pendingAchievements.erase(ownedName);
+    return true;
+}
+
+bool Store::Save(std::vector<std::string> &storedAchievements)
+{
+    if (!m_loaded)
+    {
+        return false;
+    }
+
+    std::filesystem::path parent = std::filesystem::path{ m_path }.parent_path();
+    std::error_code error;
+    if (!parent.empty())
+    {
+        std::filesystem::create_directories(parent, error);
+        if (error)
+        {
+            return false;
+        }
+    }
+
+    KeyValue root{ "user_stats" };
+    root.AddNumber("version", FileVersion);
+
+    if (!m_integerStats.empty())
+    {
+        KeyValue &section = root.AddSubkey("integer_stats");
+        for (const std::string &name : SortedNames(m_integerStats))
+        {
+            section.AddNumber(name, m_integerStats.at(name));
+        }
+    }
+
+    if (!m_floatStats.empty())
+    {
+        KeyValue &section = root.AddSubkey("float_stats");
+        for (const std::string &name : SortedNames(m_floatStats))
+        {
+            section.AddNumber(name, std::bit_cast<uint32_t>(m_floatStats.at(name)));
+        }
+    }
+
+    if (!m_achievements.empty())
+    {
+        KeyValue &section = root.AddSubkey("achievements");
+        for (const std::string &name : SortedNames(m_achievements))
+        {
+            section.AddNumber(name, m_achievements.at(name));
+        }
+    }
+
+    if (!root.WriteToFile(m_path.c_str()))
+    {
+        return false;
+    }
+
+    storedAchievements.assign(m_pendingAchievements.begin(), m_pendingAchievements.end());
+    std::sort(storedAchievements.begin(), storedAchievements.end());
+    m_pendingAchievements.clear();
+    return true;
+}
+
+bool Store::ResetAllStats(bool achievementsToo)
+{
+    if (!m_loaded)
+    {
+        return false;
+    }
+    m_integerStats.clear();
+    m_floatStats.clear();
+    if (achievementsToo)
+    {
+        m_achievements.clear();
+        m_pendingAchievements.clear();
+    }
+    return true;
+}
+
+} // namespace LocalUserStats

--- a/csgo_gc/local_user_stats.h
+++ b/csgo_gc/local_user_stats.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace LocalUserStats
+{
+
+enum class LoadResult
+{
+    Success,
+    NotFound,
+    ReadError,
+    InvalidFormat
+};
+
+constexpr const char *LocalPath = "csgo_gc/achievements.txt";
+
+class Store
+{
+public:
+    explicit Store(std::string path);
+
+    LoadResult Load();
+    bool IsLoaded() const { return m_loaded; }
+
+    bool GetStat(std::string_view name, int32_t &value) const;
+    bool GetStat(std::string_view name, float &value) const;
+    bool SetStat(std::string_view name, int32_t value);
+    bool SetStat(std::string_view name, float value);
+
+    bool GetAchievement(std::string_view name, bool &achieved, uint32_t &unlockTime) const;
+    bool SetAchievement(std::string_view name, uint32_t unlockTime);
+    bool ClearAchievement(std::string_view name);
+
+    bool Save(std::vector<std::string> &storedAchievements);
+    bool ResetAllStats(bool achievementsToo);
+
+private:
+    static bool IsValidName(std::string_view name);
+
+    std::string m_path;
+    bool m_loaded{};
+    std::unordered_map<std::string, int32_t> m_integerStats;
+    std::unordered_map<std::string, float> m_floatStats;
+    std::unordered_map<std::string, uint32_t> m_achievements;
+    std::unordered_set<std::string> m_pendingAchievements;
+};
+
+} // namespace LocalUserStats

--- a/csgo_gc/local_user_stats_tests.cpp
+++ b/csgo_gc/local_user_stats_tests.cpp
@@ -1,8 +1,8 @@
 #include "stdafx.h"
 #include "local_user_stats.h"
+#include "test_filesystem.h"
 
 #include <cstdio>
-#include <filesystem>
 
 namespace
 {
@@ -23,15 +23,14 @@ bool Check(bool condition, const char *expression, int line)
 
 void ResetStorage()
 {
-    std::error_code error;
-    std::filesystem::remove_all(TestDirectory, error);
+    TestFilesystem::RemoveFile(TestPath);
+    TestFilesystem::RemoveDirectory(TestDirectory);
+    TestFilesystem::RemoveFile(TestDirectory);
 }
 
 bool WriteBytes(std::string_view data)
 {
-    std::error_code error;
-    std::filesystem::create_directories(TestDirectory, error);
-    if (error)
+    if (!TestFilesystem::MakeDirectory(TestDirectory))
     {
         return false;
     }

--- a/csgo_gc/local_user_stats_tests.cpp
+++ b/csgo_gc/local_user_stats_tests.cpp
@@ -1,0 +1,236 @@
+#include "stdafx.h"
+#include "local_user_stats.h"
+
+#include <cstdio>
+#include <filesystem>
+
+namespace
+{
+
+constexpr const char *TestDirectory = "local_user_stats_test";
+constexpr const char *TestPath = "local_user_stats_test/user_stats.txt";
+
+bool Check(bool condition, const char *expression, int line)
+{
+    if (!condition)
+    {
+        fprintf(stderr, "Check failed at line %d: %s\n", line, expression);
+    }
+    return condition;
+}
+
+#define CHECK(expression) Check((expression), #expression, __LINE__)
+
+void ResetStorage()
+{
+    std::error_code error;
+    std::filesystem::remove_all(TestDirectory, error);
+}
+
+bool WriteBytes(std::string_view data)
+{
+    std::error_code error;
+    std::filesystem::create_directories(TestDirectory, error);
+    if (error)
+    {
+        return false;
+    }
+
+    FILE *file = fopen(TestPath, "wb");
+    if (!file)
+    {
+        return false;
+    }
+    bool success = fwrite(data.data(), 1, data.size(), file) == data.size();
+    success &= fclose(file) == 0;
+    return success;
+}
+
+bool RequiresLoadAndProvidesDefaults()
+{
+    ResetStorage();
+    LocalUserStats::Store stats{ TestPath };
+    int32_t integerValue = 42;
+    float floatValue = 42.0f;
+    bool achieved = true;
+    uint32_t unlockTime = 42;
+
+    return CHECK(!stats.GetStat("STAT", integerValue))
+        && CHECK(!stats.GetAchievement("ACHIEVEMENT", achieved, unlockTime))
+        && CHECK(stats.Load() == LocalUserStats::LoadResult::NotFound)
+        && CHECK(stats.IsLoaded())
+        && CHECK(stats.GetStat("STAT", integerValue))
+        && CHECK(integerValue == 0)
+        && CHECK(stats.GetStat("FLOAT_STAT", floatValue))
+        && CHECK(floatValue == 0.0f)
+        && CHECK(stats.GetAchievement("ACHIEVEMENT", achieved, unlockTime))
+        && CHECK(!achieved)
+        && CHECK(unlockTime == 0);
+}
+
+bool RoundTripsStatsAndAchievements()
+{
+    ResetStorage();
+    LocalUserStats::Store output{ TestPath };
+    if (!CHECK(output.Load() == LocalUserStats::LoadResult::NotFound)
+        || !CHECK(output.SetStat("TOTAL_KILLS", 1729))
+        || !CHECK(output.SetStat("AVERAGE", 1.25f))
+        || !CHECK(output.SetAchievement("WIN_BOMB_PLANT", 1234567890)))
+    {
+        return false;
+    }
+
+    std::vector<std::string> storedAchievements;
+    if (!CHECK(output.Save(storedAchievements))
+        || !CHECK(storedAchievements.size() == 1)
+        || !CHECK(storedAchievements[0] == "WIN_BOMB_PLANT"))
+    {
+        return false;
+    }
+
+    storedAchievements.emplace_back("sentinel");
+    if (!CHECK(output.Save(storedAchievements)) || !CHECK(storedAchievements.empty()))
+    {
+        return false;
+    }
+
+    LocalUserStats::Store input{ TestPath };
+    int32_t integerValue{};
+    float floatValue{};
+    bool achieved{};
+    uint32_t unlockTime{};
+    return CHECK(input.Load() == LocalUserStats::LoadResult::Success)
+        && CHECK(input.GetStat("TOTAL_KILLS", integerValue))
+        && CHECK(integerValue == 1729)
+        && CHECK(input.GetStat("AVERAGE", floatValue))
+        && CHECK(floatValue == 1.25f)
+        && CHECK(input.GetAchievement("WIN_BOMB_PLANT", achieved, unlockTime))
+        && CHECK(achieved)
+        && CHECK(unlockTime == 1234567890);
+}
+
+bool EnforcesStatTypesAndValidNames()
+{
+    ResetStorage();
+    LocalUserStats::Store stats{ TestPath };
+    if (!CHECK(stats.Load() == LocalUserStats::LoadResult::NotFound)
+        || !CHECK(stats.SetStat("INTEGER", 7))
+        || !CHECK(stats.SetStat("FLOAT", 2.5f)))
+    {
+        return false;
+    }
+
+    int32_t integerValue{};
+    float floatValue{};
+    std::string tooLong(128, 'x');
+    return CHECK(!stats.GetStat("INTEGER", floatValue))
+        && CHECK(!stats.GetStat("FLOAT", integerValue))
+        && CHECK(!stats.SetStat("", 1))
+        && CHECK(!stats.SetStat("INVALID\nNAME", 1))
+        && CHECK(!stats.SetStat("INVALID\"NAME", 1))
+        && CHECK(!stats.SetAchievement(tooLong, 1));
+}
+
+bool ClearAndResetFollowSteamSemantics()
+{
+    ResetStorage();
+    LocalUserStats::Store stats{ TestPath };
+    if (!CHECK(stats.Load() == LocalUserStats::LoadResult::NotFound)
+        || !CHECK(stats.SetStat("STAT", 9))
+        || !CHECK(stats.SetAchievement("FIRST", 100))
+        || !CHECK(stats.SetAchievement("SECOND", 200))
+        || !CHECK(stats.ClearAchievement("FIRST"))
+        || !CHECK(stats.ResetAllStats(false)))
+    {
+        return false;
+    }
+
+    int32_t value = 1;
+    bool achieved{};
+    uint32_t unlockTime{};
+    if (!CHECK(stats.GetStat("STAT", value))
+        || !CHECK(value == 0)
+        || !CHECK(stats.GetAchievement("SECOND", achieved, unlockTime))
+        || !CHECK(achieved)
+        || !CHECK(stats.ResetAllStats(true))
+        || !CHECK(stats.GetAchievement("SECOND", achieved, unlockTime))
+        || !CHECK(!achieved))
+    {
+        return false;
+    }
+
+    std::vector<std::string> storedAchievements;
+    return CHECK(stats.Save(storedAchievements))
+        && CHECK(storedAchievements.empty());
+}
+
+bool FailedSaveRetainsPendingAchievementCallbacks()
+{
+    ResetStorage();
+    LocalUserStats::Store stats{ TestPath };
+    if (!CHECK(stats.Load() == LocalUserStats::LoadResult::NotFound)
+        || !CHECK(stats.SetAchievement("RETRY_ME", 300)))
+    {
+        return false;
+    }
+
+    FILE *blockingFile = fopen(TestDirectory, "wb");
+    if (!CHECK(blockingFile != nullptr))
+    {
+        return false;
+    }
+    bool blocked = fclose(blockingFile) == 0;
+
+    std::vector<std::string> storedAchievements;
+    bool failedAsExpected = blocked && !stats.Save(storedAchievements);
+    bool failedSaveDidNotReportAchievements = storedAchievements.empty();
+    bool removedBlockingFile = remove(TestDirectory) == 0;
+    bool retrySucceeded = removedBlockingFile && stats.Save(storedAchievements);
+
+    return CHECK(blocked)
+        && CHECK(failedAsExpected)
+        && CHECK(failedSaveDidNotReportAchievements)
+        && CHECK(removedBlockingFile)
+        && CHECK(retrySucceeded)
+        && CHECK(storedAchievements.size() == 1)
+        && CHECK(storedAchievements[0] == "RETRY_ME");
+}
+
+bool MalformedFilesAreRejectedWithoutPartialState()
+{
+    ResetStorage();
+    if (!CHECK(WriteBytes(
+        "\"version\" \"1\"\n"
+        "\"integer_stats\"\n{\n"
+        "\t\"STAT\" \"not-a-number\"\n}\n")))
+    {
+        return false;
+    }
+
+    LocalUserStats::Store stats{ TestPath };
+    int32_t value{};
+    return CHECK(stats.Load() == LocalUserStats::LoadResult::InvalidFormat)
+        && CHECK(!stats.IsLoaded())
+        && CHECK(!stats.GetStat("STAT", value));
+}
+
+bool ProductionPathMatchesOtherLocalData()
+{
+    return CHECK(std::string_view{ LocalUserStats::LocalPath }
+        == "csgo_gc/achievements.txt");
+}
+
+} // namespace
+
+int main()
+{
+    bool success = RequiresLoadAndProvidesDefaults()
+        && RoundTripsStatsAndAchievements()
+        && EnforcesStatTypesAndValidNames()
+        && ClearAndResetFollowSteamSemantics()
+        && FailedSaveRetainsPendingAchievementCallbacks()
+        && MalformedFilesAreRejectedWithoutPartialState()
+        && ProductionPathMatchesOtherLocalData();
+    ResetStorage();
+    return success ? 0 : 1;
+}

--- a/csgo_gc/steam_hook.cpp
+++ b/csgo_gc/steam_hook.cpp
@@ -14,10 +14,13 @@
 #include "appid.h"
 #include "gc_client.h"
 #include "gc_server.h"
+#include "local_user_stats.h"
 #include "platform.h"
 #include "rcon_server.h"
 #include "saved_item_shuffles.h"
 #include <funchook.h>
+#include <ctime>
+#include <limits>
 
 #ifdef _WIN32
 #ifndef NOMINMAX
@@ -844,29 +847,209 @@ public:
 };
 
 static std::vector<UserStatsReceived_t> s_userStatsReceivedCallbacks;
+static std::vector<UserStatsStored_t> s_userStatsStoredCallbacks;
+static std::vector<UserAchievementStored_t> s_userAchievementStoredCallbacks;
 
-static void QueueUserStatsCallback()
+static uint64 LocalUserStatsGameId()
+{
+    return CGameID(AppId::GetOverride()).ToUint64();
+}
+
+static void QueueUserStatsReceivedCallback(uint64 steamId, EResult result)
 {
     UserStatsReceived_t callback{};
-    // m_nGameID not used
-    callback.m_eResult = k_EResultOK;
-    // m_steamIDUser not used
+    callback.m_nGameID = LocalUserStatsGameId();
+    callback.m_eResult = result;
+    callback.m_steamIDUser = CSteamID{ steamId };
     s_userStatsReceivedCallbacks.push_back(callback);
+}
+
+static void QueueUserStatsStoredCallback(EResult result)
+{
+    UserStatsStored_t callback{};
+    callback.m_nGameID = LocalUserStatsGameId();
+    callback.m_eResult = result;
+    s_userStatsStoredCallbacks.push_back(callback);
+}
+
+static void QueueUserAchievementStoredCallback(const char *name,
+    uint32 currentProgress = 0, uint32 maxProgress = 0)
+{
+    UserAchievementStored_t callback{};
+    callback.m_nGameID = LocalUserStatsGameId();
+    snprintf(callback.m_rgchAchievementName,
+        sizeof(callback.m_rgchAchievementName), "%s", name);
+    callback.m_nCurProgress = currentProgress;
+    callback.m_nMaxProgress = maxProgress;
+    s_userAchievementStoredCallbacks.push_back(callback);
 }
 
 class SteamUserStatsProxy final
 {
 public:
+    SteamUserStatsProxy(HSteamPipe pipe, HSteamUser user)
+        : m_steamId{ GetUserSteamId(pipe, user) }
+        , m_store{ LocalUserStats::LocalPath }
+    {
+    }
+
     bool RequestCurrentStats(auto original)
     {
         if (!AppId::IsOriginal())
         {
             Platform::Print("Handling RequestCurrentStats for custom appid\n");
-            QueueUserStatsCallback();
+            LocalUserStats::LoadResult result = m_store.IsLoaded()
+                ? LocalUserStats::LoadResult::Success
+                : m_store.Load();
+            bool success = result == LocalUserStats::LoadResult::Success
+                || result == LocalUserStats::LoadResult::NotFound;
+            if (!success)
+            {
+                Platform::Print("Loading local user stats failed (%d)\n",
+                    static_cast<int>(result));
+            }
+            QueueUserStatsReceivedCallback(m_steamId,
+                success ? k_EResultOK : k_EResultFail);
             return true;
         }
 
         return original();
+    }
+
+    bool GetStat(auto original, const char *name, int32 *value)
+    {
+        if (!AppId::IsOriginal())
+        {
+            return name && value && m_store.GetStat(name, *value);
+        }
+        return original(name, value);
+    }
+
+    bool GetStat(auto original, const char *name, float *value)
+    {
+        if (!AppId::IsOriginal())
+        {
+            return name && value && m_store.GetStat(name, *value);
+        }
+        return original(name, value);
+    }
+
+    bool SetStat(auto original, const char *name, int32 value)
+    {
+        if (!AppId::IsOriginal())
+        {
+            return name && m_store.SetStat(name, value);
+        }
+        return original(name, value);
+    }
+
+    bool SetStat(auto original, const char *name, float value)
+    {
+        if (!AppId::IsOriginal())
+        {
+            return name && m_store.SetStat(name, value);
+        }
+        return original(name, value);
+    }
+
+    bool GetAchievement(auto original, const char *name, bool *achieved)
+    {
+        if (!AppId::IsOriginal())
+        {
+            uint32 unlockTime{};
+            return name && achieved
+                && m_store.GetAchievement(name, *achieved, unlockTime);
+        }
+        return original(name, achieved);
+    }
+
+    bool GetAchievementAndUnlockTime(auto original, const char *name,
+        bool *achieved, uint32 *unlockTime)
+    {
+        if (!AppId::IsOriginal())
+        {
+            return name && achieved && unlockTime
+                && m_store.GetAchievement(name, *achieved, *unlockTime);
+        }
+        return original(name, achieved, unlockTime);
+    }
+
+    bool SetAchievement(auto original, const char *name)
+    {
+        if (!AppId::IsOriginal())
+        {
+            std::time_t currentTime = std::time(nullptr);
+            uint32 unlockTime = currentTime > 0
+                && static_cast<uint64_t>(currentTime) <= std::numeric_limits<uint32>::max()
+                ? static_cast<uint32>(currentTime)
+                : 0;
+            return name && m_store.SetAchievement(name, unlockTime);
+        }
+        return original(name);
+    }
+
+    bool ClearAchievement(auto original, const char *name)
+    {
+        if (!AppId::IsOriginal())
+        {
+            return name && m_store.ClearAchievement(name);
+        }
+        return original(name);
+    }
+
+    bool StoreStats(auto original)
+    {
+        if (!AppId::IsOriginal())
+        {
+            if (!m_store.IsLoaded())
+            {
+                return false;
+            }
+
+            std::vector<std::string> storedAchievements;
+            bool success = m_store.Save(storedAchievements);
+            if (!success)
+            {
+                Platform::Print("Saving local user stats to %s failed\n",
+                    LocalUserStats::LocalPath);
+            }
+            QueueUserStatsStoredCallback(success ? k_EResultOK : k_EResultFail);
+            if (success)
+            {
+                for (const std::string &name : storedAchievements)
+                {
+                    QueueUserAchievementStoredCallback(name.c_str());
+                }
+            }
+            return true;
+        }
+        return original();
+    }
+
+    bool IndicateAchievementProgress(auto original, const char *name,
+        uint32 currentProgress, uint32 maxProgress)
+    {
+        if (!AppId::IsOriginal())
+        {
+            bool achieved{};
+            uint32 unlockTime{};
+            if (!name || !m_store.GetAchievement(name, achieved, unlockTime))
+            {
+                return false;
+            }
+            QueueUserAchievementStoredCallback(name, currentProgress, maxProgress);
+            return true;
+        }
+        return original(name, currentProgress, maxProgress);
+    }
+
+    bool ResetAllStats(auto original, bool achievementsToo)
+    {
+        if (!AppId::IsOriginal())
+        {
+            return m_store.ResetAllStats(achievementsToo);
+        }
+        return original(achievementsToo);
     }
 
     SteamAPICall_t RequestUserStats(auto original, CSteamID steamIDUser)
@@ -879,6 +1062,10 @@ public:
 
         return original(steamIDUser);
     }
+
+private:
+    uint64 m_steamId;
+    LocalUserStats::Store m_store;
 };
 
 class SteamGameServerProxy final
@@ -1202,10 +1389,10 @@ public:
 
         if (VersionNameIs(version, "STEAMUSERSTATS_INTERFACE_VERSION"))
         {
-            PROXY_INTERFACE(SteamUserStats, 009);
-            PROXY_INTERFACE(SteamUserStats, 010);
-            PROXY_INTERFACE(SteamUserStats, 011);
-            PROXY_INTERFACE(SteamUserStats, 012);
+            PROXY_INTERFACE(SteamUserStats, 009, m_steamPipe, m_steamUser);
+            PROXY_INTERFACE(SteamUserStats, 010, m_steamPipe, m_steamUser);
+            PROXY_INTERFACE(SteamUserStats, 011, m_steamPipe, m_steamUser);
+            PROXY_INTERFACE(SteamUserStats, 012, m_steamPipe, m_steamUser);
             Platform::Print("Can't hook %s\n", version);
             return nullptr;
         }
@@ -1434,7 +1621,10 @@ struct CallbackHook
 
 static bool ShouldHookCallback(int id)
 {
-    if (id == UserStatsReceived_t::k_iCallback && !AppId::IsOriginal())
+    if (!AppId::IsOriginal()
+        && (id == UserStatsReceived_t::k_iCallback
+            || id == UserStatsStored_t::k_iCallback
+            || id == UserAchievementStored_t::k_iCallback))
     {
         return true;
     }
@@ -1670,16 +1860,26 @@ static void Hk_SteamAPI_RunCallbacks()
             response.m_bAuthorized = 1;
             GetCallbackHooks().RunCallback(false, MicroTxnAuthorizationResponse_t::k_iCallback, &response);
         }
+    }
 
-        if (!s_userStatsReceivedCallbacks.empty())
-        {
-            for (UserStatsReceived_t &data : s_userStatsReceivedCallbacks)
-            {
-                GetCallbackHooks().RunCallback(false, UserStatsReceived_t::k_iCallback, &data);
-            }
+    std::vector<UserStatsReceived_t> receivedCallbacks;
+    std::vector<UserStatsStored_t> storedCallbacks;
+    std::vector<UserAchievementStored_t> achievementCallbacks;
+    receivedCallbacks.swap(s_userStatsReceivedCallbacks);
+    storedCallbacks.swap(s_userStatsStoredCallbacks);
+    achievementCallbacks.swap(s_userAchievementStoredCallbacks);
 
-            s_userStatsReceivedCallbacks.clear();
-        }
+    for (UserStatsReceived_t &data : receivedCallbacks)
+    {
+        GetCallbackHooks().RunCallback(false, UserStatsReceived_t::k_iCallback, &data);
+    }
+    for (UserStatsStored_t &data : storedCallbacks)
+    {
+        GetCallbackHooks().RunCallback(false, UserStatsStored_t::k_iCallback, &data);
+    }
+    for (UserAchievementStored_t &data : achievementCallbacks)
+    {
+        GetCallbackHooks().RunCallback(false, UserAchievementStored_t::k_iCallback, &data);
     }
 }
 

--- a/csgo_gc/steam_hook.cpp
+++ b/csgo_gc/steam_hook.cpp
@@ -1047,7 +1047,20 @@ public:
     {
         if (!AppId::IsOriginal())
         {
-            return m_store.ResetAllStats(achievementsToo);
+            if (!m_store.ResetAllStats(achievementsToo))
+            {
+                return false;
+            }
+
+            std::vector<std::string> storedAchievements;
+            bool success = m_store.Save(storedAchievements);
+            if (!success)
+            {
+                Platform::Print("Saving local user stats to %s failed\n",
+                    LocalUserStats::LocalPath);
+            }
+            QueueUserStatsStoredCallback(success ? k_EResultOK : k_EResultFail);
+            return success;
         }
         return original(achievementsToo);
     }


### PR DESCRIPTION
## Summary

- add a persistent local user stats store backed by csgo_gc/achievements.txt
- route achievement and stat operations through the local store for custom app IDs
- emit Steam user stats and achievement callbacks required by the existing CS:GO achievement manager
- preserve normal Steam behavior when running under App ID 730

## Testing

- built the Windows x86 Release csgo_gc target
- ran the full configured test suite (8/8 passed)

Closes #88

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added local statistics and achievement storage for custom app IDs.
  * Added support for loading, updating, saving, resetting, and clearing local stats and achievements.
  * Added Steam-style callbacks for stored-stat and achievement changes.
  * Preserved the existing behavior for the original app ID.

* **Bug Fixes**
  * Improved handling of invalid, missing, or malformed local statistics files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->