### PR TITLE
Adapt store price sheets for legacy client schemas

### DIFF
--- a/csgo_gc/gc_client.cpp
+++ b/csgo_gc/gc_client.cpp
@@ -1378,17 +1378,61 @@ constexpr uint32_t MakeAddress(uint32_t v1, uint32_t v2, uint32_t v3, uint32_t v
     return v4 | (v3 << 8) | (v2 << 16) | (v1 << 24);
 }
 
-constexpr uint32_t PriceSheetVersion = 1680057677;
+constexpr uint32_t PriceSheetVersion = 1789084800;
 constexpr int32_t StoreResultOK = 1;
 constexpr int32_t StoreResultInvalid = 2;
 constexpr uint32_t MaxStorePurchaseItems = 1024;
 
 static bool IsStoreCrate(const ItemInfo &item)
 {
-    return item.m_supplyCrateSeries || !item.m_lootListName.empty();
+    return !item.m_isCoupon
+        && (item.m_supplyCrateSeries || !item.m_lootListName.empty());
 }
 
-static void EnableOfflineStoreCrates(KeyValue &priceSheet, const ItemSchema &itemSchema)
+static bool EnsureStoreEntry(KeyValue &entries, const ItemInfo &item,
+    const KeyValue *priceTemplate)
+{
+    if (item.m_name.empty())
+    {
+        return false;
+    }
+
+    KeyValue *entry = entries.GetSubkey(item.m_name);
+    if (!entry)
+    {
+        if (!priceTemplate)
+        {
+            return false;
+        }
+
+        entry = &entries.AddSubkey(item.m_name);
+        entry->AddString("item_link", item.m_name);
+        entry->AddString("category_tags", "Misc");
+    }
+
+    entry->SetString("item_link", item.m_name);
+    KeyValue *prices = entry->GetSubkey("prices");
+    if (!prices || !prices->SubkeyCount())
+    {
+        if (!priceTemplate)
+        {
+            return false;
+        }
+
+        if (prices)
+        {
+            *prices = *priceTemplate;
+        }
+        else
+        {
+            entry->AddSubkey("prices") = *priceTemplate;
+        }
+    }
+
+    return true;
+}
+
+static void AdaptStorePriceSheet(KeyValue &priceSheet, const ItemSchema &itemSchema)
 {
     KeyValue *store = priceSheet.GetSubkey("store");
     if (!store)
@@ -1414,23 +1458,20 @@ static void EnableOfflineStoreCrates(KeyValue &priceSheet, const ItemSchema &ite
         }
     }
 
-    if (!templatePrices)
-    {
-        Platform::Print("Store price sheet has no price template for offline crates\n");
-        return;
-    }
-
     // Adding entries can reallocate the entries vector, so preserve the price
     // tree before iterating the banner layout.
-    KeyValue priceTemplate{ *templatePrices };
+    std::optional<KeyValue> priceTemplate;
+    if (templatePrices)
+    {
+        priceTemplate.emplace(*templatePrices);
+    }
+
     size_t enabledCount = 0;
+    size_t removedCount = 0;
+    size_t removedLinkedCount = 0;
+    std::vector<std::string> removeBannerEntries;
     for (KeyValue &bannerEntry : *bannerLayout)
     {
-        if (!bannerEntry.GetNumber("market_link", false))
-        {
-            continue;
-        }
-
         uint32_t defIndex{};
         if (!TryParseNumber(bannerEntry.Name(), defIndex))
         {
@@ -1438,33 +1479,65 @@ static void EnableOfflineStoreCrates(KeyValue &priceSheet, const ItemSchema &ite
         }
 
         const ItemInfo *item = itemSchema.ItemInfoByDefIndex(defIndex);
-        if (!item || !IsStoreCrate(*item))
+        if (!item || !itemSchema.CanCreateItem(defIndex))
+        {
+            removeBannerEntries.emplace_back(bannerEntry.Name());
+            continue;
+        }
+
+        bool marketLink = bannerEntry.GetNumber("market_link", false);
+        if (marketLink && IsStoreCrate(*item))
+        {
+            bannerEntry.SetString("market_link", "0");
+            marketLink = false;
+            ++enabledCount;
+        }
+
+        if (!marketLink && !EnsureStoreEntry(*entries, *item,
+                priceTemplate ? &*priceTemplate : nullptr))
+        {
+            removeBannerEntries.emplace_back(bannerEntry.Name());
+            continue;
+        }
+
+        KeyValue *linkedCoupon = bannerEntry.GetSubkey("linked_coupon");
+        if (!linkedCoupon)
         {
             continue;
         }
 
-        bannerEntry.SetString("market_link", "0");
-
-        KeyValue *entry = entries->GetSubkey(item->m_name);
-        if (!entry)
+        uint32_t linkedDefIndex{};
+        const ItemInfo *linkedItem = nullptr;
+        if (TryParseNumber(linkedCoupon->String(), linkedDefIndex))
         {
-            entry = &entries->AddSubkey(item->m_name);
-            entry->AddString("item_link", item->m_name);
-            entry->AddString("category_tags", "Misc");
+            linkedItem = itemSchema.ItemInfoByDefIndex(linkedDefIndex);
         }
 
-        if (!entry->GetSubkey("prices"))
+        if (!linkedItem || !linkedItem->m_isCoupon
+            || !itemSchema.CanCreateItem(linkedDefIndex)
+            || !EnsureStoreEntry(*entries, *linkedItem,
+                priceTemplate ? &*priceTemplate : nullptr))
         {
-            entry->AddSubkey("prices") = priceTemplate;
+            bannerEntry.RemoveSubkey("linked_coupon");
+            ++removedLinkedCount;
         }
+    }
 
-        ++enabledCount;
+    for (const std::string &name : removeBannerEntries)
+    {
+        removedCount += bannerLayout->RemoveSubkey(name);
     }
 
     if (enabledCount)
     {
         Platform::Print("Enabled %zu market crate%s for offline store purchase\n", enabledCount,
             enabledCount == 1 ? "" : "s");
+    }
+    if (removedCount || removedLinkedCount)
+    {
+        Platform::Print("Removed %zu unavailable store banner entr%s and %zu linked coupon%s\n",
+            removedCount, removedCount == 1 ? "y" : "ies",
+            removedLinkedCount, removedLinkedCount == 1 ? "" : "s");
     }
 }
 
@@ -1988,7 +2061,7 @@ void ClientGC::StoreGetUserData(GCMessageRead &messageRead)
         return;
     }
 
-    EnableOfflineStoreCrates(priceSheet, m_inventory.GetItemSchema());
+    AdaptStorePriceSheet(priceSheet, m_inventory.GetItemSchema());
 
     std::string binaryString;
     binaryString.reserve(1 << 17);
@@ -2031,7 +2104,7 @@ void ClientGC::StorePurchaseInit(GCMessageRead &messageRead)
             = item.item_def_id() == ItemSchema::ItemStatsSubscription;
         if (!item.has_item_def_id() || !item.quantity()
             || itemCount > MaxStorePurchaseItems
-            || !m_inventory.GetItemSchema().ItemInfoByDefIndex(item.item_def_id())
+            || !m_inventory.GetItemSchema().CanCreateItem(item.item_def_id())
             || (isStatsSubscription
                 && (item.quantity() != 1 || includesStatsSubscription
                     || m_inventory.HasItemDefinition(ItemSchema::ItemStatsSubscription))))

--- a/csgo_gc/gc_message_tests.cpp
+++ b/csgo_gc/gc_message_tests.cpp
@@ -1426,8 +1426,22 @@ static bool WriteStoreFixtures()
     KeyValue &crate = items.AddSubkey("8");
     crate.AddString("name", "crate_test");
     crate.AddString("loot_list_name", "crate_test");
+    KeyValue &coupon = items.AddSubkey("9");
+    coupon.AddString("name", "coupon_test");
+    coupon.AddString("item_type", "coupon");
+    coupon.AddString("loot_list_name", "coupon_test_loot");
+    KeyValue &unavailableCoupon = items.AddSubkey("10");
+    unavailableCoupon.AddString("name", "coupon_unavailable");
+    unavailableCoupon.AddString("item_type", "coupon");
+    unavailableCoupon.AddString("loot_list_name", "coupon_missing_loot");
+    KeyValue &fallbackCoupon = items.AddSubkey("11");
+    fallbackCoupon.AddString("name", "coupon_fallback");
+    fallbackCoupon.AddString("item_type", "coupon");
+    fallbackCoupon.AddString("loot_list_name", "coupon_test_loot");
     items.AddSubkey(std::to_string(ItemSchema::ItemStatsSubscription))
         .AddString("name", "subscription1");
+    KeyValue &lootLists = itemsGame.AddSubkey("client_loot_lists");
+    lootLists.AddSubkey("coupon_test_loot").AddNumber("weapon_ak47", 1);
 
     KeyValue unusualLootLists{ "unusual_loot_lists" };
     unusualLootLists.AddSubkey("empty");
@@ -1437,12 +1451,23 @@ static bool WriteStoreFixtures()
     store.AddNumber("featured_item_index", 7);
     KeyValue &bannerLayout = store.AddSubkey("store_banner_layout");
     bannerLayout.AddSubkey("8").AddNumber("market_link", 1);
+    KeyValue &couponBanner = bannerLayout.AddSubkey("9");
+    couponBanner.AddString("custom_format", "coupon");
+    couponBanner.AddNumber("linked_coupon", 10);
+    bannerLayout.AddSubkey("10").AddString("custom_format", "coupon");
+    bannerLayout.AddSubkey("11").AddString("custom_format", "coupon");
+    bannerLayout.AddSubkey("9999").AddString("custom_format", "double");
     KeyValue &entries = store.AddSubkey("entries");
     KeyValue &priceTemplate = entries.AddSubkey("offline_price_template");
     priceTemplate.AddString("item_link", "weapon_ak47");
     KeyValue &prices = priceTemplate.AddSubkey("prices");
     prices.AddNumber("USD", 99);
     prices.AddNumber("CNY", 700);
+    KeyValue &couponEntry = entries.AddSubkey("coupon_test");
+    couponEntry.AddString("item_link", "coupon_test");
+    KeyValue &couponPrices = couponEntry.AddSubkey("prices");
+    couponPrices.AddNumber("USD", 123);
+    couponPrices.AddNumber("CNY", 888);
 
     return schema.WriteToFile("csgo/scripts/items/items_game.txt")
         && unusualLootLists.WriteToFile("csgo_gc/unusual_loot_lists.txt")
@@ -1612,6 +1637,134 @@ static bool StorePurchasesFinalizeTransactionally()
         valid &= WaitForHostMessage(gc, k_EMsgGCStorePurchaseFinalizeResponse, event)
             && ParseHostProtobuf(event, finalizeResponse)
             && finalizeResponse.result() != 1;
+    }
+
+    RemoveStoreFixtures();
+    return valid;
+}
+
+static bool LegacyStorePriceSheetMatchesClientSchema()
+{
+    constexpr uint64_t SteamId = 76561197960265729ull;
+    RemoveStoreFixtures();
+    if (!WriteStoreFixtures())
+    {
+        RemoveStoreFixtures();
+        return false;
+    }
+
+    bool valid = true;
+    {
+        ClientGC gc{ SteamId };
+
+        CMsgStoreGetUserData storeData;
+        storeData.set_price_sheet_version(0);
+        SendGCProtobuf(gc, k_EMsgGCStoreGetUserData, storeData);
+
+        EventData event;
+        CMsgStoreGetUserDataResponse response;
+        constexpr std::string_view UnavailableCouponBanner{
+            "\0" "10\0" "\1" "custom_format\0" "coupon\0",
+            sizeof("\0" "10\0" "\1" "custom_format\0" "coupon\0") - 1
+        };
+        constexpr std::string_view UnknownBanner{
+            "\0" "9999\0" "\1" "custom_format\0" "double\0",
+            sizeof("\0" "9999\0" "\1" "custom_format\0" "double\0") - 1
+        };
+        constexpr std::string_view LinkedCoupon{
+            "linked_coupon\0" "10\0",
+            sizeof("linked_coupon\0" "10\0") - 1
+        };
+        constexpr std::string_view ExistingCouponPrice{
+            "\0" "coupon_test\0"
+            "\1" "item_link\0" "coupon_test\0"
+            "\0" "prices\0"
+            "\1" "USD\0" "123\0"
+            "\1" "CNY\0" "888\0",
+            sizeof("\0" "coupon_test\0"
+                "\1" "item_link\0" "coupon_test\0"
+                "\0" "prices\0"
+                "\1" "USD\0" "123\0"
+                "\1" "CNY\0" "888\0") - 1
+        };
+        constexpr std::string_view FallbackCouponPrice{
+            "\0" "coupon_fallback\0"
+            "\1" "item_link\0" "coupon_fallback\0"
+            "\1" "category_tags\0" "Misc\0"
+            "\0" "prices\0"
+            "\1" "USD\0" "99\0"
+            "\1" "CNY\0" "700\0",
+            sizeof("\0" "coupon_fallback\0"
+                "\1" "item_link\0" "coupon_fallback\0"
+                "\1" "category_tags\0" "Misc\0"
+                "\0" "prices\0"
+                "\1" "USD\0" "99\0"
+                "\1" "CNY\0" "700\0") - 1
+        };
+        valid &= WaitForHostMessage(gc, k_EMsgGCStoreGetUserDataResponse, event)
+            && ParseHostProtobuf(event, response)
+            && response.result() == 1
+            && response.price_sheet().find(UnavailableCouponBanner) == std::string::npos
+            && response.price_sheet().find(UnknownBanner) == std::string::npos
+            && response.price_sheet().find(LinkedCoupon) == std::string::npos
+            && response.price_sheet().find(ExistingCouponPrice) != std::string::npos
+            && response.price_sheet().find(FallbackCouponPrice) != std::string::npos;
+
+        CMsgGCStorePurchaseInit invalidPurchase;
+        CGCStorePurchaseInit_LineItem *lineItem = invalidPurchase.add_line_items();
+        lineItem->set_item_def_id(10);
+        lineItem->set_quantity(1);
+        SendGCProtobuf(gc, k_EMsgGCStorePurchaseInit, invalidPurchase);
+        event = {};
+        CMsgGCStorePurchaseInitResponse initResponse;
+        valid &= WaitForHostMessage(gc, k_EMsgGCStorePurchaseInitResponse, event)
+            && ParseHostProtobuf(event, initResponse)
+            && initResponse.result() != 1;
+
+        CMsgGCStorePurchaseInit purchase;
+        lineItem = purchase.add_line_items();
+        lineItem->set_item_def_id(9);
+        lineItem->set_quantity(1);
+        SendGCProtobuf(gc, k_EMsgGCStorePurchaseInit, purchase);
+        event = {};
+        initResponse.Clear();
+        valid &= WaitForHostMessage(gc, k_EMsgGCStorePurchaseInitResponse, event)
+            && ParseHostProtobuf(event, initResponse)
+            && initResponse.result() == 1
+            && initResponse.txn_id() != 0;
+
+        CMsgGCStorePurchaseFinalize finalize;
+        finalize.set_txn_id(initResponse.txn_id());
+        SendGCProtobuf(gc, k_EMsgGCStorePurchaseFinalize, finalize);
+
+        std::vector<EventData> finalizeEvents;
+        CMsgGCStorePurchaseFinalizeResponse finalizeResponse;
+        CMsgSOSingleObject create;
+        CSOEconItem purchasedItem;
+        bool foundFinalize = false;
+        bool foundCreate = false;
+        valid &= WaitForHostMessagesUntil(gc,
+            k_EMsgGCStorePurchaseFinalizeResponse, finalizeEvents);
+        for (const EventData &finalizeEvent : finalizeEvents)
+        {
+            uint32_t type = static_cast<uint32_t>(finalizeEvent.id) & ~ProtobufMask;
+            if (type == k_ESOMsg_Create)
+            {
+                foundCreate = ParseHostProtobuf(finalizeEvent, create)
+                    && ParseItemObject(create, purchasedItem);
+            }
+            else if (type == k_EMsgGCStorePurchaseFinalizeResponse)
+            {
+                foundFinalize = ParseHostProtobuf(finalizeEvent, finalizeResponse);
+            }
+        }
+
+        valid &= foundFinalize
+            && foundCreate
+            && finalizeResponse.result() == 1
+            && finalizeResponse.item_ids_size() == 1
+            && purchasedItem.id() == finalizeResponse.item_ids(0)
+            && purchasedItem.def_index() == 7;
     }
 
     RemoveStoreFixtures();
@@ -3019,6 +3172,8 @@ int main()
         { "StatTrakSwapToolTwoPackCreatesTwoTools", StatTrakSwapToolTwoPackCreatesTwoTools },
         { "UnusualStatTrakKnivesCanSwapCounters", UnusualStatTrakKnivesCanSwapCounters },
         { "StorePurchasesFinalizeTransactionally", StorePurchasesFinalizeTransactionally },
+        { "LegacyStorePriceSheetMatchesClientSchema",
+            LegacyStorePriceSheetMatchesClientSchema },
         { "StatsSubscriptionPurchasesRejectDuplicates",
             StatsSubscriptionPurchasesRejectDuplicates },
         { "ServiceMedalsFollowBuildYearAndPersistPrestige",

--- a/csgo_gc/inventory.cpp
+++ b/csgo_gc/inventory.cpp
@@ -2677,9 +2677,9 @@ Inventory::CounterSwapResult Inventory::PerformCounterSwap(uint64_t toolId, uint
 
 uint64_t Inventory::PurchaseItem(uint32_t defIndex, std::vector<CMsgSOSingleObject> &update)
 {
-    if (!m_itemSchema.ItemInfoByDefIndex(defIndex))
+    if (!m_itemSchema.CanCreateItem(defIndex))
     {
-        Platform::Print("PurchaseItem: unknown def_index %u\n", defIndex);
+        Platform::Print("PurchaseItem: unavailable def_index %u\n", defIndex);
         return 0;
     }
 

--- a/csgo_gc/item_schema.cpp
+++ b/csgo_gc/item_schema.cpp
@@ -674,12 +674,18 @@ bool ItemSchema::CanCreateItem(uint32_t defIndex) const
     }
 
     const LootList &lootList = lootListSearch->second;
-    return lootList.subLists.empty()
-        && lootList.items.size() == 1
-        && lootList.items.front().itemInfo
-        && !lootList.items.front().itemInfo->m_isCoupon
-        && !lootList.willProduceStatTrak
-        && !lootList.isUnusual;
+    if (!lootList.subLists.empty() || lootList.items.size() != 1
+        || lootList.willProduceStatTrak || lootList.isUnusual)
+    {
+        return false;
+    }
+
+    const LootListItem &lootListItem = lootList.items.front();
+    return lootListItem.itemInfo
+        && !lootListItem.itemInfo->m_isCoupon
+        && (!itemInfo.m_willProduceStatTrak
+            || lootListItem.type == LootListItemMusicKit
+            || lootListItem.type == LootListItemPaintable);
 }
 
 bool ItemSchema::CreateItem(uint32_t defIndex, ItemOrigin origin, UnacknowledgedType unacknowledgedType, CSOEconItem &econItem) const

--- a/csgo_gc/item_schema.cpp
+++ b/csgo_gc/item_schema.cpp
@@ -653,6 +653,35 @@ bool ItemSchema::CreateItemFromLootListItem(Random &random,
     return true;
 }
 
+bool ItemSchema::CanCreateItem(uint32_t defIndex) const
+{
+    auto itemSearch = m_itemInfo.find(defIndex);
+    if (itemSearch == m_itemInfo.end())
+    {
+        return false;
+    }
+
+    const ItemInfo &itemInfo = itemSearch->second;
+    if (!itemInfo.m_isCoupon)
+    {
+        return true;
+    }
+
+    auto lootListSearch = m_lootLists.find(itemInfo.m_lootListName);
+    if (lootListSearch == m_lootLists.end())
+    {
+        return false;
+    }
+
+    const LootList &lootList = lootListSearch->second;
+    return lootList.subLists.empty()
+        && lootList.items.size() == 1
+        && lootList.items.front().itemInfo
+        && !lootList.items.front().itemInfo->m_isCoupon
+        && !lootList.willProduceStatTrak
+        && !lootList.isUnusual;
+}
+
 bool ItemSchema::CreateItem(uint32_t defIndex, ItemOrigin origin, UnacknowledgedType unacknowledgedType, CSOEconItem &econItem) const
 {
     auto itemSearch = m_itemInfo.find(defIndex);
@@ -667,17 +696,14 @@ bool ItemSchema::CreateItem(uint32_t defIndex, ItemOrigin origin, Unacknowledged
     // urgh wtf is this crap
     if (itemInfo.m_isCoupon)
     {
-        assert(itemInfo.m_lootListName.size());
-        auto lootListSearch = m_lootLists.find(itemInfo.m_lootListName);
-        if (lootListSearch == m_lootLists.end())
+        if (!CanCreateItem(defIndex))
         {
             assert(false);
             return false;
         }
 
+        auto lootListSearch = m_lootLists.find(itemInfo.m_lootListName);
         const LootList &lootList = lootListSearch->second;
-        assert(lootList.subLists.size() == 0 && lootList.items.size() == 1);
-        assert(lootList.willProduceStatTrak == false && lootList.isUnusual == false);
 
         Random random;
 

--- a/csgo_gc/item_schema.h
+++ b/csgo_gc/item_schema.h
@@ -200,6 +200,7 @@ public:
         CSOEconItem &item) const;
 
     // item creation: id and account id not set, needs to be done by the caller
+    bool CanCreateItem(uint32_t defIndex) const;
     bool CreateItem(uint32_t defIndex, ItemOrigin origin, UnacknowledgedType unacknowledgedType, CSOEconItem &econItem) const;
 
     // trade-up helpers

--- a/csgo_gc/item_schema_tests.cpp
+++ b/csgo_gc/item_schema_tests.cpp
@@ -289,6 +289,80 @@ public:
             && schema.m_missionCardsBySeason.find(12) == schema.m_missionCardsBySeason.end();
     }
 
+    bool ValidateCouponStatTrakTargets()
+    {
+        auto addUint32Attribute = [&](uint32_t defIndex)
+        {
+            KeyValue attribute{ std::to_string(defIndex) };
+            attribute.AddString("attribute_type", "uint32");
+            schema.m_attributeInfo.emplace(defIndex, AttributeInfo{ attribute });
+        };
+        addUint32Attribute(ItemSchema::AttributeTexturePrefab);
+        addUint32Attribute(ItemSchema::AttributeTextureSeed);
+        addUint32Attribute(ItemSchema::AttributeTextureWear);
+        addUint32Attribute(ItemSchema::AttributeKillEater);
+        addUint32Attribute(ItemSchema::AttributeKillEaterScoreType);
+
+        ItemInfo &target = schema.m_itemInfo.try_emplace(100, 100).first->second;
+        target.m_name = "weapon_test";
+
+        ItemInfo &validCoupon = schema.m_itemInfo.try_emplace(200, 200).first->second;
+        validCoupon.m_name = "coupon_stattrak_valid";
+        validCoupon.m_isCoupon = true;
+        validCoupon.m_lootListName = "stattrak_valid";
+        validCoupon.m_willProduceStatTrak = true;
+
+        ItemInfo &invalidCoupon = schema.m_itemInfo.try_emplace(201, 201).first->second;
+        invalidCoupon.m_name = "coupon_stattrak_invalid";
+        invalidCoupon.m_isCoupon = true;
+        invalidCoupon.m_lootListName = "stattrak_invalid";
+        invalidCoupon.m_willProduceStatTrak = true;
+
+        KeyValue paintKitKey{ "1" };
+        paintKitKey.AddString("name", "paint_test");
+        auto paintKit = schema.m_paintKitInfo.emplace("paint_test",
+            PaintKitInfo{ paintKitKey, 0.0f, 1.0f });
+
+        const ItemInfo *targetInfo = schema.ItemInfoByDefIndex(100);
+        LootListItem validLootItem;
+        validLootItem.itemInfo = targetInfo;
+        validLootItem.type = LootListItemPaintable;
+        validLootItem.paintKitInfo = &paintKit.first->second;
+        validLootItem.rarity = ItemSchema::RarityCommon;
+        validLootItem.quality = ItemSchema::QualityUnique;
+        schema.m_lootLists["stattrak_valid"].items.push_back(validLootItem);
+
+        LootListItem invalidLootItem;
+        invalidLootItem.itemInfo = targetInfo;
+        invalidLootItem.type = LootListItemNoAttribute;
+        invalidLootItem.rarity = ItemSchema::RarityCommon;
+        invalidLootItem.quality = ItemSchema::QualityUnique;
+        schema.m_lootLists["stattrak_invalid"].items.push_back(invalidLootItem);
+
+        if (!schema.CanCreateItem(200) || schema.CanCreateItem(201))
+        {
+            return false;
+        }
+
+        CSOEconItem created;
+        if (!schema.CreateItem(200, ItemOriginPurchased, UnacknowledgedPurchased, created)
+            || created.quality() != ItemSchema::QualityStrange)
+        {
+            return false;
+        }
+
+        bool hasKillEater = false;
+        bool hasWeaponScoreType = false;
+        for (const CSOEconItemAttribute &attribute : created.attribute())
+        {
+            hasKillEater |= attribute.def_index() == ItemSchema::AttributeKillEater;
+            hasWeaponScoreType |= attribute.def_index() == ItemSchema::AttributeKillEaterScoreType
+                && schema.AttributeUint32(&attribute) == 0;
+        }
+
+        return hasKillEater && hasWeaponScoreType;
+    }
+
     ItemSchema schema;
 };
 
@@ -350,6 +424,12 @@ static bool SeasonalOperationUsesSchemaPassCoinAndMissionCards()
     return fixture.ParseSeasonalOperationData();
 }
 
+static bool CouponStatTrakValidationMatchesTargetType()
+{
+    ItemSchemaTestFixture fixture;
+    return fixture.ValidateCouponStatTrakTargets();
+}
+
 int main()
 {
     if (!TournamentStickerCapsuleIsNotSouvenir())
@@ -385,6 +465,11 @@ int main()
     if (!SeasonalOperationUsesSchemaPassCoinAndMissionCards())
     {
         return 7;
+    }
+
+    if (!CouponStatTrakValidationMatchesTargetType())
+    {
+        return 8;
     }
 
     return 0;

--- a/csgo_gc/keyvalue.cpp
+++ b/csgo_gc/keyvalue.cpp
@@ -495,6 +495,19 @@ KeyValue &KeyValue::AddSubkey(std::string_view name)
     return m_subkeys.emplace_back(name);
 }
 
+bool KeyValue::RemoveSubkey(std::string_view name)
+{
+    auto it = std::find_if(m_subkeys.begin(), m_subkeys.end(),
+        [name](const KeyValue &subkey) { return subkey.m_name == name; });
+    if (it == m_subkeys.end())
+    {
+        return false;
+    }
+
+    m_subkeys.erase(it);
+    return true;
+}
+
 void KeyValue::AddString(std::string_view name, std::string_view value)
 {
     KeyValue &subkey = AddSubkey(name);

--- a/csgo_gc/keyvalue.h
+++ b/csgo_gc/keyvalue.h
@@ -70,6 +70,7 @@ public:
 
     // writing helpers
     KeyValue &AddSubkey(std::string_view name);
+    bool RemoveSubkey(std::string_view name);
     void AddString(std::string_view name, std::string_view value);
     void SetString(std::string_view name, std::string_view value);
 

--- a/csgo_gc/keyvalue_tests.cpp
+++ b/csgo_gc/keyvalue_tests.cpp
@@ -94,6 +94,19 @@ bool ExistingFileIsAtomicallyReplaced()
         && input.GetNumber<int>("value") == 1729;
 }
 
+bool SubkeysCanBeRemoved()
+{
+    KeyValue key{ "test" };
+    key.AddNumber("first", 1);
+    key.AddNumber("second", 2);
+
+    return key.RemoveSubkey("first")
+        && !key.RemoveSubkey("missing")
+        && key.SubkeyCount() == 1
+        && !key.GetSubkey("first")
+        && key.GetNumber<int>("second") == 2;
+}
+
 } // namespace
 
 int main()
@@ -102,7 +115,8 @@ int main()
 
     bool success = DetailedFileResultsAreReported()
         && Utf8BomIsAccepted()
-        && ExistingFileIsAtomicallyReplaced();
+        && ExistingFileIsAtomicallyReplaced()
+        && SubkeysCanBeRemoved();
 
     RemoveTestFiles();
     return success ? 0 : 1;


### PR DESCRIPTION
Fix #92

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved offline store price-sheet handling for unavailable items, coupons, and invalid linked-coupon entries.
  * Prevented purchases and item creation for unavailable or unsupported coupon items.
  * Preserved valid fallback pricing when store entries lack complete price data.
  * Improved validation for coupons that produce StatTrak-compatible items.

* **Tests**
  * Added coverage for legacy price-sheet compatibility, coupon visibility, purchase validation, StatTrak coupon outputs, and subkey removal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->