### PR TITLE
Add "Painted Face" music kit to store offers

### DIFF
--- a/examples/price_sheet.txt
+++ b/examples/price_sheet.txt
@@ -509,6 +509,12 @@
 			"custom_format"		"coupon"
 			"w"		"0.048937"
 		}
+		"20192"
+		{
+			"custom_format"		"coupon"
+			"w"		"0.042696263641119"
+			"linked_coupon"		"20191"
+		}
 		"20075"
 		{
 			"custom_format"		"coupon"


### PR DESCRIPTION
## Summary

- Add the "Perfect World - Painted Face" music kit StatTrak offer (def index 20192) to the store banner layout.
- Preserve the linked ordinary coupon (def index 20191) and the high-confidence weight 0.042696263641119.
- Keep the existing pricing entries unchanged.

The weight and linked-coupon pairing are documented by a public CS:GO GC price-sheet candidate and match the existing store-layout semantics.

## Validation

- Windows x86 Release build: passed.
- ctest: 8/8 tests passed.

Closes #94

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new coupon-based store banner entry.
  - Linked the banner to coupon `20191` for related offer presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->